### PR TITLE
Add /network/status to allowedMethods

### DIFF
--- a/asserter/network.go
+++ b/asserter/network.go
@@ -132,14 +132,15 @@ func SupportedMethods(methods []string) error {
 	}
 
 	allowedMethods := []string{
-		"/block",
-		"/block/transaction",
-		"/mempool",
-		"/mempool/transaction",
 		"/account/balance",
 		"/account/transactions",
+		"/block",
+		"/block/transaction",
 		"/construction/metadata",
 		"/construction/submit",
+		"/mempool",
+		"/mempool/transaction",
+		"/network/status",
 	}
 
 	for _, method := range methods {

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -21,6 +21,22 @@ import (
 	rosetta "github.com/coinbase/rosetta-sdk-go/gen"
 )
 
+var (
+	// AllowedMethods are all the methods that are considered
+	// valid in a Options.Methods array.
+	AllowedMethods = []string{
+		"/account/balance",
+		"/account/transactions",
+		"/block",
+		"/block/transaction",
+		"/construction/metadata",
+		"/construction/submit",
+		"/mempool",
+		"/mempool/transaction",
+		"/network/status",
+	}
+)
+
 // SubNetworkIdentifier asserts a rosetta.SubNetworkIdentifer is valid (if not nil).
 func SubNetworkIdentifier(subNetworkIdentifier *rosetta.SubNetworkIdentifier) error {
 	if subNetworkIdentifier == nil {
@@ -131,20 +147,8 @@ func SupportedMethods(methods []string) error {
 		return errors.New("no Options.Methods found")
 	}
 
-	allowedMethods := []string{
-		"/account/balance",
-		"/account/transactions",
-		"/block",
-		"/block/transaction",
-		"/construction/metadata",
-		"/construction/submit",
-		"/mempool",
-		"/mempool/transaction",
-		"/network/status",
-	}
-
 	for _, method := range methods {
-		if !contains(allowedMethods, method) {
+		if !contains(AllowedMethods, method) {
 			return fmt.Errorf("%s is not a valid method", method)
 		}
 	}

--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -172,8 +172,9 @@ func TestVersion(t *testing.T) {
 func TestNetworkOptions(t *testing.T) {
 	var (
 		methods = []string{
-			"/block",
 			"/account/balance",
+			"/block",
+			"/network/status",
 		}
 
 		operationStatuses = []*rosetta.OperationStatus{


### PR DESCRIPTION
### Motivation
Currently, `asserter/network.go` will raise an error if `/network/status` is returned as a method in the `Options.Methods` array. This was originally done because listing `/network/status` on a call to `/network/status` seemed redundant. However, the Rosetta documentation provides no indication that `/network/status` should not be returned.

### Solution
Instead of updating documentation not to include `/network/status` (which would cause unnecessary friction in development), it has been added to `AllowedMethods`.

### Other
* Export `AllowedMethods`
* Alphabetize `AllowedMethods`