### PR TITLE
Change link to docs page

### DIFF
--- a/asserter/README.md
+++ b/asserter/README.md
@@ -1,6 +1,6 @@
 # Asserter
 
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/asserter?tab=overview)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/asserter?tab=doc)
 
 The Asserter package is used to validate the correctness of Rosetta models. It is
 important to note that this validation only ensures that required fields are

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,6 @@
 # Client
 
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/client?tab=overview)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/client?tab=doc)
 
 The Client package reduces the work required to communicate with a Rosetta server.
 

--- a/fetcher/README.md
+++ b/fetcher/README.md
@@ -1,6 +1,6 @@
 # Fetcher
 
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/fetcher?tab=overview)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/fetcher?tab=doc)
 
 The Fetcher package provides a simplified client interface to communicate
 with a Rosetta server.

--- a/models/README.md
+++ b/models/README.md
@@ -1,6 +1,6 @@
 # Models
 
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/models?tab=overview)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/models?tab=doc)
 
 Models contains a collection of auto-generated Rosetta models. Using this
 package ensures that you don't need to automatically generate code on your

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Server
 
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/server?tab=overview)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/server?tab=doc)
 
 The Server package reduces the work required to write your own Rosetta server.
 In short, this package takes care of the basics (boilerplate server code

--- a/templates/docs/client.md
+++ b/templates/docs/client.md
@@ -1,6 +1,6 @@
 # Client
 
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/client?tab=overview)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/client?tab=doc)
 
 The Client package reduces the work required to communicate with a Rosetta server.
 

--- a/templates/docs/models.md
+++ b/templates/docs/models.md
@@ -1,6 +1,6 @@
 # Models
 
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/models?tab=overview)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/models?tab=doc)
 
 Models contains a collection of auto-generated Rosetta models. Using this
 package ensures that you don't need to automatically generate code on your

--- a/templates/docs/server.md
+++ b/templates/docs/server.md
@@ -1,6 +1,6 @@
 # Server
 
-[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/server?tab=overview)
+[![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/server?tab=doc)
 
 The Server package reduces the work required to write your own Rosetta server.
 In short, this package takes care of the basics (boilerplate server code


### PR DESCRIPTION
### Motivation
Current godocs links direct to overview page instead of docs page.

### Solution
Change links to point to docs page.

