### PR TITLE
1.3.1 Release

### DIFF
--- a/asserter/account.go
+++ b/asserter/account.go
@@ -21,24 +21,6 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-// containsAccountIdentifier returns a boolean indicating if a
-// *types.AccountIdentifier is contained within a slice of
-// *types.AccountIdentifier. The check for equality takes
-// into account everything within the types.AccountIdentifier
-// struct (including the SubAccountIdentifier).
-func containsAccountIdentifier(
-	identifiers []*types.AccountIdentifier,
-	identifier *types.AccountIdentifier,
-) bool {
-	for _, ident := range identifiers {
-		if reflect.DeepEqual(ident, identifier) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // containsCurrency returns a boolean indicating if a
 // *types.Currency is contained within a slice of
 // *types.Currency. The check for equality takes
@@ -83,31 +65,11 @@ func assertBalanceAmounts(amounts []*types.Amount) error {
 // or if a types.Balance is considered invalid.
 func AccountBalance(
 	block *types.BlockIdentifier,
-	balances []*types.Balance,
+	balances []*types.Amount,
 ) error {
 	if err := BlockIdentifier(block); err != nil {
 		return err
 	}
 
-	accounts := make([]*types.AccountIdentifier, 0)
-	for _, balance := range balances {
-		if err := AccountIdentifier(balance.AccountIdentifier); err != nil {
-			return err
-		}
-
-		// Ensure an account identifier is used at most once in a balance response
-		if containsAccountIdentifier(accounts, balance.AccountIdentifier) {
-			return fmt.Errorf(
-				"account identifier %+v used in balance multiple times",
-				balance.AccountIdentifier,
-			)
-		}
-		accounts = append(accounts, balance.AccountIdentifier)
-
-		if err := assertBalanceAmounts(balance.Amounts); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return assertBalanceAmounts(balances)
 }

--- a/asserter/account_test.go
+++ b/asserter/account_test.go
@@ -125,120 +125,6 @@ func TestContainsCurrency(t *testing.T) {
 	}
 }
 
-func TestContainsAccountIdentifier(t *testing.T) {
-	var tests = map[string]struct {
-		identifiers []*types.AccountIdentifier
-		identifier  *types.AccountIdentifier
-		contains    bool
-	}{
-		"simple contains": {
-			identifiers: []*types.AccountIdentifier{
-				{
-					Address: "acct1",
-				},
-			},
-			identifier: &types.AccountIdentifier{
-				Address: "acct1",
-			},
-			contains: true,
-		},
-		"complex contains": {
-			identifiers: []*types.AccountIdentifier{
-				{
-					Address: "acct1",
-					SubAccount: &types.SubAccountIdentifier{
-						Address: "subacct1",
-						Metadata: &map[string]interface{}{
-							"blah": "hello",
-						},
-					},
-				},
-			},
-			identifier: &types.AccountIdentifier{
-				Address: "acct1",
-				SubAccount: &types.SubAccountIdentifier{
-					Address: "subacct1",
-					Metadata: &map[string]interface{}{
-						"blah": "hello",
-					},
-				},
-			},
-			contains: true,
-		},
-		"simple mismatch": {
-			identifiers: []*types.AccountIdentifier{
-				{
-					Address: "acct1",
-				},
-			},
-			identifier: &types.AccountIdentifier{
-				Address: "acct2",
-			},
-			contains: false,
-		},
-		"empty": {
-			identifiers: []*types.AccountIdentifier{},
-			identifier: &types.AccountIdentifier{
-				Address: "acct2",
-			},
-			contains: false,
-		},
-		"subaccount mismatch": {
-			identifiers: []*types.AccountIdentifier{
-				{
-					Address: "acct1",
-					SubAccount: &types.SubAccountIdentifier{
-						Address: "subacct2",
-						Metadata: &map[string]interface{}{
-							"blah": "hello",
-						},
-					},
-				},
-			},
-			identifier: &types.AccountIdentifier{
-				Address: "acct1",
-				SubAccount: &types.SubAccountIdentifier{
-					Address: "subacct1",
-					Metadata: &map[string]interface{}{
-						"blah": "hello",
-					},
-				},
-			},
-			contains: false,
-		},
-		"metadata mismatch": {
-			identifiers: []*types.AccountIdentifier{
-				{
-					Address: "acct1",
-					SubAccount: &types.SubAccountIdentifier{
-						Address: "subacct1",
-						Metadata: &map[string]interface{}{
-							"blah": "hello",
-						},
-					},
-				},
-			},
-			identifier: &types.AccountIdentifier{
-				Address: "acct1",
-				SubAccount: &types.SubAccountIdentifier{
-					Address: "subacct1",
-					Metadata: &map[string]interface{}{
-						"blah": "bye",
-					},
-				},
-			},
-			contains: false,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			exists := containsAccountIdentifier(test.identifiers, test.identifier)
-			assert.Equal(t, test.contains, exists)
-		})
-	}
-}
-
 func TestAccoutBalance(t *testing.T) {
 	validBlock := &types.BlockIdentifier{
 		Index: 1000,
@@ -248,14 +134,6 @@ func TestAccoutBalance(t *testing.T) {
 	invalidBlock := &types.BlockIdentifier{
 		Index: 1,
 		Hash:  "",
-	}
-
-	validIdentifier := &types.AccountIdentifier{
-		Address: "acct1",
-	}
-
-	invalidIdentifier := &types.AccountIdentifier{
-		Address: "",
 	}
 
 	validAmount := &types.Amount{
@@ -268,75 +146,30 @@ func TestAccoutBalance(t *testing.T) {
 
 	var tests = map[string]struct {
 		block    *types.BlockIdentifier
-		balances []*types.Balance
+		balances []*types.Amount
 		err      error
 	}{
 		"simple balance": {
 			block: validBlock,
-			balances: []*types.Balance{
-				{
-					AccountIdentifier: validIdentifier,
-					Amounts: []*types.Amount{
-						validAmount,
-					},
-				},
+			balances: []*types.Amount{
+				validAmount,
 			},
 			err: nil,
 		},
 		"invalid block": {
 			block: invalidBlock,
-			balances: []*types.Balance{
-				{
-					AccountIdentifier: validIdentifier,
-					Amounts: []*types.Amount{
-						validAmount,
-					},
-				},
+			balances: []*types.Amount{
+				validAmount,
 			},
 			err: errors.New("BlockIdentifier.Hash is missing"),
 		},
-		"invalid account identifier": {
-			block: validBlock,
-			balances: []*types.Balance{
-				{
-					AccountIdentifier: invalidIdentifier,
-					Amounts: []*types.Amount{
-						validAmount,
-					},
-				},
-			},
-			err: errors.New("Account.Address is missing"),
-		},
 		"duplicate currency": {
 			block: validBlock,
-			balances: []*types.Balance{
-				{
-					AccountIdentifier: validIdentifier,
-					Amounts: []*types.Amount{
-						validAmount,
-						validAmount,
-					},
-				},
+			balances: []*types.Amount{
+				validAmount,
+				validAmount,
 			},
 			err: fmt.Errorf("currency %+v used in balance multiple times", validAmount.Currency),
-		},
-		"duplicate identifier": {
-			block: validBlock,
-			balances: []*types.Balance{
-				{
-					AccountIdentifier: validIdentifier,
-					Amounts: []*types.Amount{
-						validAmount,
-					},
-				},
-				{
-					AccountIdentifier: validIdentifier,
-					Amounts: []*types.Amount{
-						validAmount,
-					},
-				},
-			},
-			err: fmt.Errorf("account identifier %+v used in balance multiple times", validIdentifier),
 		},
 	}
 

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -29,13 +29,15 @@ type Asserter struct {
 	genesisIndex       int64
 }
 
-// New constructs a new Asserter.
-func New(
+// NewWithResponses constructs a new Asserter
+// from a NetworkStatusResponse and
+// NetworkOptionsResponse.
+func NewWithResponses(
 	ctx context.Context,
 	networkStatus *types.NetworkStatusResponse,
 	networkOptions *types.NetworkOptionsResponse,
 ) (*Asserter, error) {
-	return NewOptions(
+	return NewWithOptions(
 		ctx,
 		networkStatus.GenesisBlockIdentifier,
 		networkOptions.Allow.OperationTypes,
@@ -44,9 +46,10 @@ func New(
 	), nil
 }
 
-// NewOptions constructs a new Asserter using the provided
-// arguments instead of using a types.NetworkStatusResponse.
-func NewOptions(
+// NewWithOptions constructs a new Asserter using the provided
+// arguments instead of using a NetworkStatusResponse and a
+// NetworkOptionsResponse.
+func NewWithOptions(
 	ctx context.Context,
 	genesisBlockIdentifier *types.BlockIdentifier,
 	operationTypes []string,

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -16,7 +16,6 @@ package asserter
 
 import (
 	"context"
-	"errors"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -33,20 +32,15 @@ type Asserter struct {
 // New constructs a new Asserter.
 func New(
 	ctx context.Context,
-	networkResponse *types.NetworkStatusResponse,
+	networkStatus *types.NetworkStatusResponse,
+	networkOptions *types.NetworkOptionsResponse,
 ) (*Asserter, error) {
-	if len(networkResponse.NetworkStatus) == 0 {
-		return nil, errors.New("no available networks in network response")
-	}
-
-	primaryNetwork := networkResponse.NetworkStatus[0]
-
 	return NewOptions(
 		ctx,
-		primaryNetwork.NetworkInformation.GenesisBlockIdentifier,
-		networkResponse.Options.OperationTypes,
-		networkResponse.Options.OperationStatuses,
-		networkResponse.Options.Errors,
+		networkStatus.GenesisBlockIdentifier,
+		networkOptions.Allow.OperationTypes,
+		networkOptions.Allow.OperationStatuses,
+		networkOptions.Allow.Errors,
 	), nil
 }
 

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -383,7 +383,7 @@ func TestOperation(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		asserter, err := New(
+		asserter, err := NewWithResponses(
 			context.Background(),
 			&types.NetworkStatusResponse{
 				GenesisBlockIdentifier: &types.BlockIdentifier{
@@ -537,7 +537,7 @@ func TestBlock(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			asserter, err := New(
+			asserter, err := NewWithResponses(
 				context.Background(),
 				&types.NetworkStatusResponse{
 					GenesisBlockIdentifier: &types.BlockIdentifier{

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -386,16 +386,12 @@ func TestOperation(t *testing.T) {
 		asserter, err := New(
 			context.Background(),
 			&types.NetworkStatusResponse{
-				NetworkStatus: []*types.NetworkStatus{
-					{
-						NetworkInformation: &types.NetworkInformation{
-							GenesisBlockIdentifier: &types.BlockIdentifier{
-								Index: 0,
-							},
-						},
-					},
+				GenesisBlockIdentifier: &types.BlockIdentifier{
+					Index: 0,
 				},
-				Options: &types.Options{
+			},
+			&types.NetworkOptionsResponse{
+				Allow: &types.Allow{
 					OperationStatuses: []*types.OperationStatus{
 						{
 							Status:     "SUCCESS",
@@ -544,16 +540,12 @@ func TestBlock(t *testing.T) {
 			asserter, err := New(
 				context.Background(),
 				&types.NetworkStatusResponse{
-					NetworkStatus: []*types.NetworkStatus{
-						{
-							NetworkInformation: &types.NetworkInformation{
-								GenesisBlockIdentifier: &types.BlockIdentifier{
-									Index: test.genesisIndex,
-								},
-							},
-						},
+					GenesisBlockIdentifier: &types.BlockIdentifier{
+						Index: test.genesisIndex,
 					},
-					Options: &types.Options{
+				},
+				&types.NetworkOptionsResponse{
+					Allow: &types.Allow{
 						OperationStatuses: []*types.OperationStatus{},
 						OperationTypes:    []string{},
 					},

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -15,23 +15,29 @@
 package asserter
 
 import (
+	"errors"
+
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-// TransactionConstruction returns an error if
+// ConstructionMetadata returns an error if
 // the NetworkFee is not a valid types.Amount.
-func TransactionConstruction(
-	response *types.TransactionConstructionResponse,
+func ConstructionMetadata(
+	response *types.ConstructionMetadataResponse,
 ) error {
-	return Amount(response.NetworkFee)
+	if response.Metadata == nil {
+		return errors.New("Metadata is nil")
+	}
+
+	return nil
 }
 
-// TransactionSubmit returns an error if
+// ConstructionSubmit returns an error if
 // the types.TransactionIdentifier in the response is not
 // valid or if the Submission.Status is not contained
 // within the provided validStatuses slice.
-func (a *Asserter) TransactionSubmit(
-	response *types.TransactionSubmitResponse,
+func (a *Asserter) ConstructionSubmit(
+	response *types.ConstructionSubmitResponse,
 ) error {
 	if err := TransactionIdentifier(response.TransactionIdentifier); err != nil {
 		return err

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -24,65 +24,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTransactionConstruction(t *testing.T) {
-	validAmount := &types.Amount{
-		Value: "1",
-		Currency: &types.Currency{
-			Symbol:   "BTC",
-			Decimals: 8,
-		},
-	}
-
-	invalidAmount := &types.Amount{
-		Value: "",
-		Currency: &types.Currency{
-			Symbol:   "BTC",
-			Decimals: 8,
-		},
-	}
-
+func TestConstructionMetadata(t *testing.T) {
 	var tests = map[string]struct {
-		response *types.TransactionConstructionResponse
+		response *types.ConstructionMetadataResponse
 		err      error
 	}{
 		"valid response": {
-			response: &types.TransactionConstructionResponse{
-				NetworkFee: validAmount,
+			response: &types.ConstructionMetadataResponse{
+				Metadata: &map[string]interface{}{},
 			},
 			err: nil,
 		},
-		"valid response with metadata": {
-			response: &types.TransactionConstructionResponse{
-				NetworkFee: validAmount,
-				Metadata: &map[string]interface{}{
-					"blah": "hello",
-				},
-			},
-			err: nil,
-		},
-		"invalid amount": {
-			response: &types.TransactionConstructionResponse{
-				NetworkFee: invalidAmount,
-			},
-			err: errors.New("Amount.Value is missing"),
+		"invalid metadata": {
+			response: &types.ConstructionMetadataResponse{},
+			err:      errors.New("Metadata is nil"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := TransactionConstruction(test.response)
+			err := ConstructionMetadata(test.response)
 			assert.Equal(t, test.err, err)
 		})
 	}
 }
 
-func TestTransactionSubmit(t *testing.T) {
+func TestConstructionSubmit(t *testing.T) {
 	var tests = map[string]struct {
-		response *types.TransactionSubmitResponse
+		response *types.ConstructionSubmitResponse
 		err      error
 	}{
 		"valid response": {
-			response: &types.TransactionSubmitResponse{
+			response: &types.ConstructionSubmitResponse{
 				TransactionIdentifier: &types.TransactionIdentifier{
 					Hash: "tx1",
 				},
@@ -90,7 +63,7 @@ func TestTransactionSubmit(t *testing.T) {
 			err: nil,
 		},
 		"invalid transaction identifier": {
-			response: &types.TransactionSubmitResponse{},
+			response: &types.ConstructionSubmitResponse{},
 			err:      errors.New("TransactionIdentifier is nil"),
 		},
 	}
@@ -99,16 +72,12 @@ func TestTransactionSubmit(t *testing.T) {
 		asserter, err := New(
 			context.Background(),
 			&types.NetworkStatusResponse{
-				NetworkStatus: []*types.NetworkStatus{
-					{
-						NetworkInformation: &types.NetworkInformation{
-							GenesisBlockIdentifier: &types.BlockIdentifier{
-								Index: 0,
-							},
-						},
-					},
+				GenesisBlockIdentifier: &types.BlockIdentifier{
+					Index: 0,
 				},
-				Options: &types.Options{
+			},
+			&types.NetworkOptionsResponse{
+				Allow: &types.Allow{
 					OperationStatuses: []*types.OperationStatus{
 						{
 							Status:     "SUCCESS",
@@ -127,7 +96,7 @@ func TestTransactionSubmit(t *testing.T) {
 		)
 		assert.NoError(t, err)
 		t.Run(name, func(t *testing.T) {
-			err := asserter.TransactionSubmit(test.response)
+			err := asserter.ConstructionSubmit(test.response)
 			assert.Equal(t, test.err, err)
 		})
 	}

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -69,7 +69,7 @@ func TestConstructionSubmit(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		asserter, err := New(
+		asserter, err := NewWithResponses(
 			context.Background(),
 			&types.NetworkStatusResponse{
 				GenesisBlockIdentifier: &types.BlockIdentifier{

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -43,7 +43,7 @@ func NetworkIdentifier(network *types.NetworkIdentifier) error {
 	}
 
 	if network.Blockchain == "" {
-		return errors.New("NetworkIdentifier is nil")
+		return errors.New("NetworkIdentifier.Blockchain is missing")
 	}
 
 	if network.Network == "" {
@@ -247,6 +247,10 @@ func NetworkListResponse(response *types.NetworkListResponse) error {
 
 	seen := make([]*types.NetworkIdentifier, 0)
 	for _, network := range response.NetworkIdentifiers {
+		if err := NetworkIdentifier(network); err != nil {
+			return err
+		}
+
 		if containsNetworkIdentifier(seen, network) {
 			return errors.New("NetworkListResponse.Networks contains duplicates")
 		}

--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -44,7 +44,7 @@ func TestNetworkIdentifier(t *testing.T) {
 				Blockchain: "",
 				Network:    "mainnet",
 			},
-			err: errors.New("NetworkIdentifier is nil"),
+			err: errors.New("NetworkIdentifier.Blockchain is missing"),
 		},
 		"invalid network": {
 			network: &types.NetworkIdentifier{
@@ -278,6 +278,72 @@ func TestErrors(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, test.err, Errors(test.rosettaErrors))
+		})
+	}
+}
+
+func TestNetworkListResponse(t *testing.T) {
+	var (
+		network1 = &types.NetworkIdentifier{
+			Blockchain: "blockchain 1",
+			Network:    "network 1",
+		}
+		network1Sub = &types.NetworkIdentifier{
+			Blockchain: "blockchain 1",
+			Network:    "network 1",
+			SubNetworkIdentifier: &types.SubNetworkIdentifier{
+				Network: "subnetwork",
+			},
+		}
+		network2 = &types.NetworkIdentifier{
+			Blockchain: "blockchain 2",
+			Network:    "network 2",
+		}
+		network3 = &types.NetworkIdentifier{
+			Network: "network 2",
+		}
+	)
+
+	var tests = map[string]struct {
+		networkListResponse *types.NetworkListResponse
+		err                 error
+	}{
+		"valid network list": {
+			networkListResponse: &types.NetworkListResponse{
+				NetworkIdentifiers: []*types.NetworkIdentifier{
+					network1,
+					network1Sub,
+					network2,
+				},
+			},
+			err: nil,
+		},
+		"nil network list": {
+			networkListResponse: nil,
+			err:                 errors.New("NetworkListResponse is nil"),
+		},
+		"network list duplicate": {
+			networkListResponse: &types.NetworkListResponse{
+				NetworkIdentifiers: []*types.NetworkIdentifier{
+					network1Sub,
+					network1Sub,
+				},
+			},
+			err: errors.New("NetworkListResponse.Networks contains duplicates"),
+		},
+		"invalid network": {
+			networkListResponse: &types.NetworkListResponse{
+				NetworkIdentifiers: []*types.NetworkIdentifier{
+					network3,
+				},
+			},
+			err: errors.New("NetworkIdentifier.Blockchain is missing"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.err, NetworkListResponse(test.networkListResponse))
 		})
 	}
 }

--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -142,7 +142,7 @@ func TestVersion(t *testing.T) {
 	}
 }
 
-func TestNetworkOptions(t *testing.T) {
+func TestAllow(t *testing.T) {
 	var (
 		operationStatuses = []*types.OperationStatus{
 			{
@@ -161,45 +161,45 @@ func TestNetworkOptions(t *testing.T) {
 	)
 
 	var tests = map[string]struct {
-		networkOptions *types.Options
-		err            error
+		allow *types.Allow
+		err   error
 	}{
-		"valid options": {
-			networkOptions: &types.Options{
+		"valid Allow": {
+			allow: &types.Allow{
 				OperationStatuses: operationStatuses,
 				OperationTypes:    operationTypes,
 			},
 		},
-		"nil options": {
-			networkOptions: nil,
-			err:            errors.New("options is nil"),
+		"nil Allow": {
+			allow: nil,
+			err:   errors.New("Allow is nil"),
 		},
 		"no OperationStatuses": {
-			networkOptions: &types.Options{
+			allow: &types.Allow{
 				OperationTypes: operationTypes,
 			},
-			err: errors.New("no Options.OperationStatuses found"),
+			err: errors.New("no Allow.OperationStatuses found"),
 		},
 		"no successful OperationStatuses": {
-			networkOptions: &types.Options{
+			allow: &types.Allow{
 				OperationStatuses: []*types.OperationStatus{
 					operationStatuses[1],
 				},
 				OperationTypes: operationTypes,
 			},
-			err: errors.New("no successful Options.OperationStatuses found"),
+			err: errors.New("no successful Allow.OperationStatuses found"),
 		},
 		"no OperationTypes": {
-			networkOptions: &types.Options{
+			allow: &types.Allow{
 				OperationStatuses: operationStatuses,
 			},
-			err: errors.New("no Options.OperationTypes found"),
+			err: errors.New("no Allow.OperationTypes found"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.err, NetworkOptions(test.networkOptions))
+			assert.Equal(t, test.err, Allow(test.allow))
 		})
 	}
 }

--- a/asserter/request.go
+++ b/asserter/request.go
@@ -74,37 +74,33 @@ func BlockTransactionRequest(request *types.BlockTransactionRequest) error {
 	return TransactionIdentifier(request.TransactionIdentifier)
 }
 
-// TransactionConstructionRequest ensures that a types.TransactionConstructionRequest
+// ConstructionMetadataRequest ensures that a types.ConstructionMetadataRequest
 // is well-formatted.
-func TransactionConstructionRequest(request *types.TransactionConstructionRequest) error {
+func ConstructionMetadataRequest(request *types.ConstructionMetadataRequest) error {
 	if request == nil {
-		return errors.New("TransactionConstructionRequest is nil")
+		return errors.New("ConstructionMetadataRequest is nil")
 	}
 
 	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
-	if err := AccountIdentifier(request.AccountIdentifier); err != nil {
-		return err
-	}
-
-	if request.Method != nil && *request.Method == "" {
-		return errors.New("TransactionConstructionRequest.Method is empty")
+	if request.Options == nil {
+		return errors.New("ConstructionMetadataRequest.Options is nil")
 	}
 
 	return nil
 }
 
-// TransactionSubmitRequest ensures that a types.TransactionSubmitRequest
+// ConstructionSubmitRequest ensures that a types.ConstructionSubmitRequest
 // is well-formatted.
-func TransactionSubmitRequest(request *types.TransactionSubmitRequest) error {
+func ConstructionSubmitRequest(request *types.ConstructionSubmitRequest) error {
 	if request == nil {
-		return errors.New("TransactionSubmitRequest is nil")
+		return errors.New("ConstructionSubmitRequest is nil")
 	}
 
 	if request.SignedTransaction == "" {
-		return errors.New("TransactionSubmitRequest.SignedTransaction is empty")
+		return errors.New("ConstructionSubmitRequest.SignedTransaction is empty")
 	}
 
 	return nil
@@ -134,12 +130,22 @@ func MempoolTransactionRequest(request *types.MempoolTransactionRequest) error {
 	return TransactionIdentifier(request.TransactionIdentifier)
 }
 
-// NetworkStatusRequest ensures that a types.NetworkStatusRequest
+// MetadataRequest ensures that a types.MetadataRequest
 // is well-formatted.
-func NetworkStatusRequest(request *types.NetworkStatusRequest) error {
+func MetadataRequest(request *types.MetadataRequest) error {
 	if request == nil {
-		return errors.New("NetworkStatusRequest is nil")
+		return errors.New("MetadataRequest is nil")
 	}
 
 	return nil
+}
+
+// NetworkRequest ensures that a types.NetworkRequest
+// is well-formatted.
+func NetworkRequest(request *types.NetworkRequest) error {
+	if request == nil {
+		return errors.New("NetworkRequest is nil")
+	}
+
+	return NetworkIdentifier(request.NetworkIdentifier)
 }

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -46,8 +46,6 @@ var (
 	validTransactionIdentifier = &types.TransactionIdentifier{
 		Hash: "tx1",
 	}
-
-	validMethod = "transfer"
 )
 
 func TestAccountBalanceRequest(t *testing.T) {

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -197,76 +197,68 @@ func TestBlockTransactionRequest(t *testing.T) {
 	}
 }
 
-func TestTransactionConstructionRequest(t *testing.T) {
+func TestConstructionMetadataRequest(t *testing.T) {
 	var tests = map[string]struct {
-		request *types.TransactionConstructionRequest
+		request *types.ConstructionMetadataRequest
 		err     error
 	}{
 		"valid request": {
-			request: &types.TransactionConstructionRequest{
+			request: &types.ConstructionMetadataRequest{
 				NetworkIdentifier: validNetworkIdentifier,
-				AccountIdentifier: validAccountIdentifier,
-			},
-			err: nil,
-		},
-		"valid request with method": {
-			request: &types.TransactionConstructionRequest{
-				NetworkIdentifier: validNetworkIdentifier,
-				AccountIdentifier: validAccountIdentifier,
-				Method:            &validMethod,
+				Options:           &map[string]interface{}{},
 			},
 			err: nil,
 		},
 		"nil request": {
 			request: nil,
-			err:     errors.New("TransactionConstructionRequest is nil"),
+			err:     errors.New("ConstructionMetadataRequest is nil"),
 		},
 		"missing network": {
-			request: &types.TransactionConstructionRequest{
-				AccountIdentifier: validAccountIdentifier,
+			request: &types.ConstructionMetadataRequest{
+				Options: &map[string]interface{}{},
 			},
 			err: errors.New("NetworkIdentifier is nil"),
 		},
-		"missing account identifier": {
-			request: &types.TransactionConstructionRequest{
+		"missing options": {
+			request: &types.ConstructionMetadataRequest{
 				NetworkIdentifier: validNetworkIdentifier,
 			},
-			err: errors.New("Account is nil"),
+			err: errors.New("ConstructionMetadataRequest.Options is nil"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := TransactionConstructionRequest(test.request)
+			err := ConstructionMetadataRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
 }
 
-func TestTransactionSubmitRequest(t *testing.T) {
+func TestConstructionSubmitRequest(t *testing.T) {
 	var tests = map[string]struct {
-		request *types.TransactionSubmitRequest
+		request *types.ConstructionSubmitRequest
 		err     error
 	}{
 		"valid request": {
-			request: &types.TransactionSubmitRequest{
+			request: &types.ConstructionSubmitRequest{
 				SignedTransaction: "tx",
 			},
 			err: nil,
 		},
 		"nil request": {
 			request: nil,
-			err:     errors.New("TransactionSubmitRequest is nil"),
+			err:     errors.New("ConstructionSubmitRequest is nil"),
 		},
 		"empty tx": {
-			request: &types.TransactionSubmitRequest{},
-			err:     errors.New("TransactionSubmitRequest.SignedTransaction is empty"),
+			request: &types.ConstructionSubmitRequest{},
+			err:     errors.New("ConstructionSubmitRequest.SignedTransaction is empty"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := TransactionSubmitRequest(test.request)
+			err := ConstructionSubmitRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -340,24 +332,53 @@ func TestMempoolTransactionRequest(t *testing.T) {
 	}
 }
 
-func TestNetworkStatusRequest(t *testing.T) {
+func TestMetadataRequest(t *testing.T) {
 	var tests = map[string]struct {
-		request *types.NetworkStatusRequest
+		request *types.MetadataRequest
 		err     error
 	}{
 		"valid request": {
-			request: &types.NetworkStatusRequest{},
+			request: &types.MetadataRequest{},
 			err:     nil,
 		},
 		"nil request": {
 			request: nil,
-			err:     errors.New("NetworkStatusRequest is nil"),
+			err:     errors.New("MetadataRequest is nil"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := NetworkStatusRequest(test.request)
+			err := MetadataRequest(test.request)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}
+
+func TestNetworkRequest(t *testing.T) {
+	var tests = map[string]struct {
+		request *types.NetworkRequest
+		err     error
+	}{
+		"valid request": {
+			request: &types.NetworkRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+			},
+			err: nil,
+		},
+		"nil request": {
+			request: nil,
+			err:     errors.New("NetworkRequest is nil"),
+		},
+		"missing network": {
+			request: &types.NetworkRequest{},
+			err:     errors.New("NetworkIdentifier is nil"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := NetworkRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}

--- a/client/api_block.go
+++ b/client/api_block.go
@@ -104,11 +104,11 @@ func (a *BlockAPIService) Block(
 	return &v, nil, nil
 }
 
-// BlockTransaction Get a transaction in a block by its Transaction Identifier. This method should
+// BlockTransaction Get a transaction in a block by its Transaction Identifier. This endpoint should
 // only be used when querying a node for a block does not return all transactions contained within
-// it.  All transactions returned by this method must be appended to any transactions returned by
+// it.  All transactions returned by this endpoint must be appended to any transactions returned by
 // the /block method by consumers of this data. Fetching a transaction by hash is considered an
-// Explorer Method (which is classified under the Future Work section).  Calling this method
+// Explorer Method (which is classified under the Future Work section).  Calling this endpoint
 // requires reference to a BlockIdentifier because transaction parsing can change depending on which
 // block contains the transaction. For example, in Bitcoin it is necessary to know which block
 // contains a transaction to determine the destination of fee payments. Without specifying a block

--- a/client/api_construction.go
+++ b/client/api_construction.go
@@ -33,16 +33,20 @@ var (
 // ConstructionAPIService ConstructionAPI service
 type ConstructionAPIService service
 
-// TransactionConstruction Get any information required to construct a transaction for a specific
-// account. Metadata returned here could be a recent hash to use or an account sequence number.  It
-// is important to clarify that this endpoint should not pre-construct any transactions for the
-// client. All account-specific metadata must be returned as a key-value mapping so that transaction
-// construction can be audited and performed entirely offline. Any account-agnostic metadata does
-// not need to be broken out into a key-value mapping and can be returned as a blob.
-func (a *ConstructionAPIService) TransactionConstruction(
+// ConstructionMetadata Get any information required to construct a transaction for a specific
+// network. Metadata returned here could be a recent hash to use, an account sequence number, or
+// even arbitrary chain state. It is up to the client to correctly populate the options object with
+// any network-specific details to ensure the correct metadata is retrieved.  It is important to
+// clarify that this endpoint should not pre-construct any transactions for the client (this should
+// happen in the SDK). This endpoint is left purposely unstructured because of the wide scope of
+// metadata that could be required.  In a future version of the spec, we plan to pass an array of
+// Rosetta Operations to specify which metadata should be received and to create a transaction in an
+// accompanying SDK. This will help to insulate the client from chain-specific details that are
+// currently required here.
+func (a *ConstructionAPIService) ConstructionMetadata(
 	ctx _context.Context,
-	transactionConstructionRequest *types.TransactionConstructionRequest,
-) (*types.TransactionConstructionResponse, *types.Error, error) {
+	constructionMetadataRequest *types.ConstructionMetadataRequest,
+) (*types.ConstructionMetadataResponse, *types.Error, error) {
 	var (
 		localVarPostBody interface{}
 	)
@@ -69,7 +73,7 @@ func (a *ConstructionAPIService) TransactionConstruction(
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = transactionConstructionRequest
+	localVarPostBody = constructionMetadataRequest
 
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
 	if err != nil {
@@ -97,7 +101,7 @@ func (a *ConstructionAPIService) TransactionConstruction(
 		return nil, &v, fmt.Errorf("%+v", v)
 	}
 
-	var v types.TransactionConstructionResponse
+	var v types.ConstructionMetadataResponse
 	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		return nil, nil, err
@@ -106,15 +110,15 @@ func (a *ConstructionAPIService) TransactionConstruction(
 	return &v, nil, nil
 }
 
-// TransactionSubmit Submit a pre-signed transaction to the node. This call should not block on the
+// ConstructionSubmit Submit a pre-signed transaction to the node. This call should not block on the
 // transaction being included in a block. Rather, it should return immediately with an indication of
 // whether or not the transaction was included in the mempool.  The transaction submission response
 // should only return a 200 status if the submitted transaction could be included in the mempool.
 // Otherwise, it should return an error.
-func (a *ConstructionAPIService) TransactionSubmit(
+func (a *ConstructionAPIService) ConstructionSubmit(
 	ctx _context.Context,
-	transactionSubmitRequest *types.TransactionSubmitRequest,
-) (*types.TransactionSubmitResponse, *types.Error, error) {
+	constructionSubmitRequest *types.ConstructionSubmitRequest,
+) (*types.ConstructionSubmitResponse, *types.Error, error) {
 	var (
 		localVarPostBody interface{}
 	)
@@ -141,7 +145,7 @@ func (a *ConstructionAPIService) TransactionSubmit(
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = transactionSubmitRequest
+	localVarPostBody = constructionSubmitRequest
 
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
 	if err != nil {
@@ -169,7 +173,7 @@ func (a *ConstructionAPIService) TransactionSubmit(
 		return nil, &v, fmt.Errorf("%+v", v)
 	}
 
-	var v types.TransactionSubmitResponse
+	var v types.ConstructionSubmitResponse
 	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		return nil, nil, err

--- a/client/api_network.go
+++ b/client/api_network.go
@@ -33,11 +33,151 @@ var (
 // NetworkAPIService NetworkAPI service
 type NetworkAPIService service
 
-// NetworkStatus This method returns the current status of the network the node knows about. This
-// method also returns the methods, operation types, and operation statuses the node supports.
+// NetworkList This endpoint returns a list of NetworkIdentifiers that the Rosetta server can
+// handle.
+func (a *NetworkAPIService) NetworkList(
+	ctx _context.Context,
+	metadataRequest *types.MetadataRequest,
+) (*types.NetworkListResponse, *types.Error, error) {
+	var (
+		localVarPostBody interface{}
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/network/list"
+	localVarHeaderParams := make(map[string]string)
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = metadataRequest
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(ctx, r)
+	if err != nil || localVarHTTPResponse == nil {
+		return nil, nil, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	defer localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, &v, fmt.Errorf("%+v", v)
+	}
+
+	var v types.NetworkListResponse
+	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &v, nil, nil
+}
+
+// NetworkOptions This endpoint returns the version information and allowed network-specific types
+// for a NetworkIdentifier. Any NetworkIdentifier returned by /network/list should be accessible
+// here.  Because options are retrievable in the context of a NetworkIdentifier, it is possible to
+// define unique options for each network.
+func (a *NetworkAPIService) NetworkOptions(
+	ctx _context.Context,
+	networkRequest *types.NetworkRequest,
+) (*types.NetworkOptionsResponse, *types.Error, error) {
+	var (
+		localVarPostBody interface{}
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/network/options"
+	localVarHeaderParams := make(map[string]string)
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = networkRequest
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(ctx, r)
+	if err != nil || localVarHTTPResponse == nil {
+		return nil, nil, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	defer localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, &v, fmt.Errorf("%+v", v)
+	}
+
+	var v types.NetworkOptionsResponse
+	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &v, nil, nil
+}
+
+// NetworkStatus This endpoint returns the current status of the network requested. Any
+// NetworkIdentifier returned by /network/list should be accessible here.
 func (a *NetworkAPIService) NetworkStatus(
 	ctx _context.Context,
-	networkStatusRequest *types.NetworkStatusRequest,
+	networkRequest *types.NetworkRequest,
 ) (*types.NetworkStatusResponse, *types.Error, error) {
 	var (
 		localVarPostBody interface{}
@@ -65,7 +205,7 @@ func (a *NetworkAPIService) NetworkStatus(
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = networkStatusRequest
+	localVarPostBody = networkRequest
 
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ var (
 	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
 )
 
-// APIClient manages communication with the Rosetta API v1.3.0
+// APIClient manages communication with the Rosetta API v1.3.1
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -115,11 +115,6 @@ sed "${SED_IFLAG[@]}" 's/<\/code>//g' client/* server/*;
 # Fix slice containing pointers
 sed "${SED_IFLAG[@]}" 's/\*\[\]/\[\]\*/g' client/* server/*;
 
-# Fix misspellings
-sed "${SED_IFLAG[@]}" 's/occured/occurred/g' client/* server/*;
-sed "${SED_IFLAG[@]}" 's/cannonical/canonical/g' client/* server/*;
-sed "${SED_IFLAG[@]}" 's/Cannonical/Canonical/g' client/* server/*;
-
 # Move model files to types/
 mv client/model_*.go types/;
 for file in types/model_*.go; do

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	client := client.NewAPIClient(clientCfg)
 
-	// Step 2: Get all avaliable networks
+	// Step 2: Get all available networks
 	networkList, rosettaErr, err := client.NetworkAPI.NetworkList(
 		ctx,
 		&types.MetadataRequest{},

--- a/examples/fetcher/main.go
+++ b/examples/fetcher/main.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"log"
-	"net/http"
-	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -28,31 +26,6 @@ import (
 const (
 	// serverURL is the URL of a Rosetta Server.
 	serverURL = "http://localhost:8080"
-
-	// agent is the user-agent on requests to the
-	// Rosetta Server.
-	agent = "rosetta-sdk-go"
-
-	// defaultTimeout is the default timeout for
-	// HTTP requests.
-	defaultTimeout = 5 * time.Second
-
-	// blockConcurrency is the number of blocks to
-	// fetch concurrently in a call to fetcher.SyncBlockRange.
-	blockConcurrency = 4
-
-	// transactionConcurrency is the number of transactions to
-	// fetch concurrently (if BlockResponse.OtherTransactions
-	// is populated) in a call to fetcher.SyncBlockRange.
-	transactionConcurrency = 4
-
-	// maxElapsedTime is the maximum amount of time we will
-	// spend retrying failed requests.
-	maxElapsedTime = 1 * time.Minute
-
-	// maxRetries is the maximum number of times we will
-	// retry a failed request.
-	maxRetries = 10
 )
 
 func main() {
@@ -62,12 +35,6 @@ func main() {
 	newFetcher := fetcher.New(
 		ctx,
 		serverURL,
-		agent,
-		&http.Client{
-			Timeout: defaultTimeout,
-		},
-		blockConcurrency,
-		transactionConcurrency,
 	)
 
 	// Step 2: Initialize the fetcher's asserter
@@ -75,21 +42,21 @@ func main() {
 	// Behind the scenes this makes a call to get the
 	// network status and uses the response to inform
 	// the asserter what are valid responses.
-	networkStatusResponse, err := newFetcher.InitializeAsserter(ctx)
+	primaryNetwork, networkStatus, err := newFetcher.InitializeAsserter(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Step 3: Print the network status response
-	prettyNetworkStatusResponse, err := json.MarshalIndent(
-		networkStatusResponse,
+	prettyNetworkStatus, err := json.MarshalIndent(
+		networkStatus,
 		"",
 		" ",
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("Network Status Response: %s\n", string(prettyNetworkStatusResponse))
+	log.Printf("Network Status: %s\n", string(prettyNetworkStatus))
 
 	// Step 4: Fetch the current block with retries (automatically
 	// asserted for correctness)
@@ -107,15 +74,12 @@ func main() {
 	// the client directly, you will need to implement a mechanism
 	// to fully populate the block by fetching all these
 	// transactions.
-	primaryNetwork := networkStatusResponse.NetworkStatus[0]
 	block, err := newFetcher.BlockRetry(
 		ctx,
-		primaryNetwork.NetworkIdentifier,
+		primaryNetwork,
 		types.ConstructPartialBlockIdentifier(
-			primaryNetwork.NetworkInformation.CurrentBlockIdentifier,
+			networkStatus.CurrentBlockIdentifier,
 		),
-		maxElapsedTime,
-		maxRetries,
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/examples/fetcher/main.go
+++ b/examples/fetcher/main.go
@@ -47,7 +47,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Step 3: Print the network status response
+	// Step 3: Print the primary network and network status
+	prettyPrimaryNetwork, err := json.MarshalIndent(
+		primaryNetwork,
+		"",
+		" ",
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Primary Network: %s\n", string(prettyPrimaryNetwork))
+
 	prettyNetworkStatus, err := json.MarshalIndent(
 		networkStatus,
 		"",

--- a/examples/server/services/network_service.go
+++ b/examples/server/services/network_service.go
@@ -31,37 +31,49 @@ func NewNetworkAPIService(network *types.NetworkIdentifier) server.NetworkAPISer
 	}
 }
 
+// NetworkList implements the /network/list endpoint
+func (s *NetworkAPIService) NetworkList(
+	*types.MetadataRequest,
+) (*types.NetworkListResponse, *types.Error) {
+	return &types.NetworkListResponse{
+		NetworkIdentifiers: []*types.NetworkIdentifier{
+			s.network,
+		},
+	}, nil
+}
+
 // NetworkStatus implements the /network/status endpoint.
 func (s *NetworkAPIService) NetworkStatus(
-	*types.NetworkStatusRequest,
+	*types.NetworkRequest,
 ) (*types.NetworkStatusResponse, *types.Error) {
 	return &types.NetworkStatusResponse{
-		NetworkStatus: []*types.NetworkStatus{
+		CurrentBlockIdentifier: &types.BlockIdentifier{
+			Index: 1000,
+			Hash:  "block 1000",
+		},
+		CurrentBlockTimestamp: int64(1586483189000),
+		GenesisBlockIdentifier: &types.BlockIdentifier{
+			Index: 0,
+			Hash:  "block 0",
+		},
+		Peers: []*types.Peer{
 			{
-				NetworkIdentifier: s.network,
-				NetworkInformation: &types.NetworkInformation{
-					CurrentBlockIdentifier: &types.BlockIdentifier{
-						Index: 1000,
-						Hash:  "block 1000",
-					},
-					CurrentBlockTimestamp: int64(1586483189000),
-					GenesisBlockIdentifier: &types.BlockIdentifier{
-						Index: 0,
-						Hash:  "block 0",
-					},
-					Peers: []*types.Peer{
-						{
-							PeerID: "peer 1",
-						},
-					},
-				},
+				PeerID: "peer 1",
 			},
 		},
+	}, nil
+}
+
+// NetworkOptions implements the /network/options endpoint.
+func (s *NetworkAPIService) NetworkOptions(
+	*types.NetworkRequest,
+) (*types.NetworkOptionsResponse, *types.Error) {
+	return &types.NetworkOptionsResponse{
 		Version: &types.Version{
 			RosettaVersion: "1.3.0",
 			NodeVersion:    "0.0.1",
 		},
-		Options: &types.Options{
+		Allow: &types.Allow{
 			OperationStatuses: []*types.OperationStatus{
 				{
 					Status:     "Success",
@@ -78,8 +90,9 @@ func (s *NetworkAPIService) NetworkStatus(
 			},
 			Errors: []*types.Error{
 				{
-					Code:    1,
-					Message: "not implemented",
+					Code:      1,
+					Message:   "not implemented",
+					Retriable: false,
 				},
 			},
 		},

--- a/fetcher/README.md
+++ b/fetcher/README.md
@@ -3,7 +3,8 @@
 [![GoDoc](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=shield)](https://pkg.go.dev/github.com/coinbase/rosetta-sdk-go/fetcher?tab=doc)
 
 The Fetcher package provides a simplified client interface to communicate
-with a Rosetta server.
+with a Rosetta server. It also provides automatic retries and concurrent block
+fetches.
 
 If you want a lower-level interface to communicate with a Rosetta server,
 check out the [Client](/client).
@@ -14,6 +15,20 @@ check out the [Client](/client).
 go get github.com/coinbase/rosetta-sdk-go/fetcher
 ```
 
-## Examples
+## Create a Fetcher
+Creating a basic Fetcher is as easy as providing a context and Rosetta server URL:
+```go
+fetcher := fetcher.New(ctx, serverURL)
+```
+
+It is also possible to provide a series of optional arguments that override
+default behavior. For example, it is possible to override the concurrency
+for making block requests:
+```go
+fetcher := fetcher.New(ctx, serverURL, fetcher.WithBlockConcurrency(10))
+```
+
+## More Examples
 Check out the [examples](/examples) to see how easy
 it is to connect to a Rosetta server.
+

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -18,21 +18,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-// UnsafeAccountBalance returns the unvalidated response
+// AccountBalance returns the validated response
 // from the AccountBalance method.
-func (f *Fetcher) UnsafeAccountBalance(
+func (f *Fetcher) AccountBalance(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	account *types.AccountIdentifier,
 ) (*types.BlockIdentifier, []*types.Amount, error) {
-	balance, _, err := f.rosettaClient.AccountAPI.AccountBalance(ctx,
+	response, _, err := f.rosettaClient.AccountAPI.AccountBalance(ctx,
 		&types.AccountBalanceRequest{
 			NetworkIdentifier: network,
 			AccountIdentifier: account,
@@ -42,21 +41,8 @@ func (f *Fetcher) UnsafeAccountBalance(
 		return nil, nil, err
 	}
 
-	return balance.BlockIdentifier, balance.Balances, nil
-}
-
-// AccountBalance returns the validated response
-// from the AccountBalance method.
-func (f *Fetcher) AccountBalance(
-	ctx context.Context,
-	network *types.NetworkIdentifier,
-	account *types.AccountIdentifier,
-) (*types.BlockIdentifier, []*types.Amount, error) {
-	block, balances, err := f.UnsafeAccountBalance(ctx, network, account)
-	if err != nil {
-		return nil, nil, err
-	}
-
+	block := response.BlockIdentifier
+	balances := response.Balances
 	if err := asserter.AccountBalance(block, balances); err != nil {
 		return nil, nil, err
 	}
@@ -70,10 +56,11 @@ func (f *Fetcher) AccountBalanceRetry(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	account *types.AccountIdentifier,
-	maxElapsedTime time.Duration,
-	maxRetries uint64,
 ) (*types.BlockIdentifier, []*types.Amount, error) {
-	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
+	backoffRetries := backoffRetries(
+		f.retryElapsedTime,
+		f.maxRetries,
+	)
 
 	for ctx.Err() == nil {
 		block, balances, err := f.AccountBalance(

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -31,7 +31,7 @@ func (f *Fetcher) UnsafeAccountBalance(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	account *types.AccountIdentifier,
-) (*types.BlockIdentifier, []*types.Balance, error) {
+) (*types.BlockIdentifier, []*types.Amount, error) {
 	balance, _, err := f.rosettaClient.AccountAPI.AccountBalance(ctx,
 		&types.AccountBalanceRequest{
 			NetworkIdentifier: network,
@@ -51,7 +51,7 @@ func (f *Fetcher) AccountBalance(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	account *types.AccountIdentifier,
-) (*types.BlockIdentifier, []*types.Balance, error) {
+) (*types.BlockIdentifier, []*types.Amount, error) {
 	block, balances, err := f.UnsafeAccountBalance(ctx, network, account)
 	if err != nil {
 		return nil, nil, err
@@ -72,7 +72,7 @@ func (f *Fetcher) AccountBalanceRetry(
 	account *types.AccountIdentifier,
 	maxElapsedTime time.Duration,
 	maxRetries uint64,
-) (*types.BlockIdentifier, []*types.Balance, error) {
+) (*types.BlockIdentifier, []*types.Amount, error) {
 	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
 
 	for ctx.Err() == nil {

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -196,8 +196,6 @@ func (f *Fetcher) BlockRetry(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	blockIdentifier *types.PartialBlockIdentifier,
-	maxElapsedTime time.Duration,
-	maxRetries uint64,
 ) (*types.Block, error) {
 	if f.Asserter == nil {
 		return nil, errors.New("asserter not initialized")
@@ -207,7 +205,10 @@ func (f *Fetcher) BlockRetry(
 		return nil, err
 	}
 
-	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
+	backoffRetries := backoffRetries(
+		f.retryElapsedTime,
+		f.maxRetries,
+	)
 
 	for ctx.Err() == nil {
 		block, err := f.Block(
@@ -280,8 +281,6 @@ func (f *Fetcher) fetchChannelBlocks(
 			&types.PartialBlockIdentifier{
 				Index: &b,
 			},
-			DefaultElapsedTime,
-			DefaultRetries,
 		)
 		if err != nil {
 			return err

--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -1,0 +1,59 @@
+package fetcher
+
+import (
+	"time"
+
+	"github.com/coinbase/rosetta-sdk-go/asserter"
+	"github.com/coinbase/rosetta-sdk-go/client"
+)
+
+// Option is used to overwrite default values in
+// Fetcher construction. Any Option not provided
+// falls back to the default value.
+type Option func(f *Fetcher)
+
+// WithClient overrides the default client.APIClient.
+func WithClient(client *client.APIClient) Option {
+	return func(f *Fetcher) {
+		f.rosettaClient = client
+	}
+}
+
+// WithBlockConcurrency overrides the default block concurrency.
+func WithBlockConcurrency(concurrency uint64) Option {
+	return func(f *Fetcher) {
+		f.blockConcurrency = concurrency
+	}
+}
+
+// WithTransactionConcurrency overrides the default transaction
+// concurrency.
+func WithTransactionConcurrency(concurrency uint64) Option {
+	return func(f *Fetcher) {
+		f.transactionConcurrency = concurrency
+	}
+}
+
+// WithMaxRetries overrides the default number of retries on
+// a request.
+func WithMaxRetries(maxRetries uint64) Option {
+	return func(f *Fetcher) {
+		f.maxRetries = maxRetries
+	}
+}
+
+// WithRetryElapsedTime overrides the default max elapsed time
+// to retry a request.
+func WithRetryElapsedTime(retryElapsedTime time.Duration) Option {
+	return func(f *Fetcher) {
+		f.retryElapsedTime = retryElapsedTime
+	}
+}
+
+// WithAsserter sets the asserter.Asserter on construction
+// so it does not need to be initialized.
+func WithAsserter(asserter *asserter.Asserter) Option {
+	return func(f *Fetcher) {
+		f.Asserter = asserter
+	}
+}

--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fetcher
 
 import (

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -28,25 +28,23 @@ import (
 func (f *Fetcher) ConstructionMetadata(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
-	account *types.AccountIdentifier,
-	method *string,
-) (*types.Amount, *map[string]interface{}, error) {
-	metadata, _, err := f.rosettaClient.ConstructionAPI.TransactionConstruction(ctx,
-		&types.TransactionConstructionRequest{
+	options *map[string]interface{},
+) (*map[string]interface{}, error) {
+	metadata, _, err := f.rosettaClient.ConstructionAPI.ConstructionMetadata(ctx,
+		&types.ConstructionMetadataRequest{
 			NetworkIdentifier: network,
-			AccountIdentifier: account,
-			Method:            method,
+			Options:           options,
 		},
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if err := asserter.TransactionConstruction(metadata); err != nil {
-		return nil, nil, err
+	if err := asserter.ConstructionMetadata(metadata); err != nil {
+		return nil, err
 	}
 
-	return metadata.NetworkFee, metadata.Metadata, nil
+	return metadata.Metadata, nil
 }
 
 // ConstructionSubmit returns the validated response
@@ -59,9 +57,9 @@ func (f *Fetcher) ConstructionSubmit(
 		return nil, nil, errors.New("asserter not initialized")
 	}
 
-	submitResponse, _, err := f.rosettaClient.ConstructionAPI.TransactionSubmit(
+	submitResponse, _, err := f.rosettaClient.ConstructionAPI.ConstructionSubmit(
 		ctx,
-		&types.TransactionSubmitRequest{
+		&types.ConstructionSubmitRequest{
 			SignedTransaction: signedTransaction,
 		},
 	)
@@ -69,7 +67,7 @@ func (f *Fetcher) ConstructionSubmit(
 		return nil, nil, err
 	}
 
-	if err := f.Asserter.TransactionSubmit(submitResponse); err != nil {
+	if err := f.Asserter.ConstructionSubmit(submitResponse); err != nil {
 		return nil, nil, err
 	}
 

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -24,32 +24,20 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-// UnsafeNetworkStatus returns the unvalidated response
-// from the NetworkStatus method.
-func (f *Fetcher) UnsafeNetworkStatus(
-	ctx context.Context,
-	metadata *map[string]interface{},
-) (*types.NetworkStatusResponse, error) {
-	networkStatus, _, err := f.rosettaClient.NetworkAPI.NetworkStatus(
-		ctx,
-		&types.NetworkStatusRequest{
-			Metadata: metadata,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return networkStatus, nil
-}
-
 // NetworkStatus returns the validated response
 // from the NetworkStatus method.
 func (f *Fetcher) NetworkStatus(
 	ctx context.Context,
+	network *types.NetworkIdentifier,
 	metadata *map[string]interface{},
 ) (*types.NetworkStatusResponse, error) {
-	networkStatus, err := f.UnsafeNetworkStatus(ctx, metadata)
+	networkStatus, _, err := f.rosettaClient.NetworkAPI.NetworkStatus(
+		ctx,
+		&types.NetworkRequest{
+			NetworkIdentifier: network,
+			Metadata:          metadata,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -65,6 +53,7 @@ func (f *Fetcher) NetworkStatus(
 // with a specified number of retries and max elapsed time.
 func (f *Fetcher) NetworkStatusRetry(
 	ctx context.Context,
+	network *types.NetworkIdentifier,
 	metadata *map[string]interface{},
 	maxElapsedTime time.Duration,
 	maxRetries uint64,
@@ -72,15 +61,123 @@ func (f *Fetcher) NetworkStatusRetry(
 	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
 
 	for ctx.Err() == nil {
-		networkStatus, err := f.NetworkStatus(ctx, metadata)
+		networkStatus, err := f.NetworkStatus(
+			ctx,
+			network,
+			metadata,
+		)
 		if err == nil {
 			return networkStatus, nil
 		}
 
-		if !tryAgain("network", backoffRetries, err) {
+		if !tryAgain("NetworkStatus", backoffRetries, err) {
 			break
 		}
 	}
 
-	return nil, errors.New("exhausted retries for network")
+	return nil, errors.New("exhausted retries for NetworkStatus")
+}
+
+// NetworkList returns the validated response
+// from the NetworList method.
+func (f *Fetcher) NetworkList(
+	ctx context.Context,
+	metadata *map[string]interface{},
+) (*types.NetworkListResponse, error) {
+	networkList, _, err := f.rosettaClient.NetworkAPI.NetworkList(
+		ctx,
+		&types.MetadataRequest{
+			Metadata: metadata,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := asserter.NetworkListResponse(networkList); err != nil {
+		return nil, err
+	}
+
+	return networkList, nil
+}
+
+// NetworkListRetry retrieves the validated NetworkList
+// with a specified number of retries and max elapsed time.
+func (f *Fetcher) NetworkListRetry(
+	ctx context.Context,
+	metadata *map[string]interface{},
+	maxElapsedTime time.Duration,
+	maxRetries uint64,
+) (*types.NetworkListResponse, error) {
+	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
+
+	for ctx.Err() == nil {
+		networkList, err := f.NetworkList(
+			ctx,
+			metadata,
+		)
+		if err == nil {
+			return networkList, nil
+		}
+
+		if !tryAgain("NetworkList", backoffRetries, err) {
+			break
+		}
+	}
+
+	return nil, errors.New("exhausted retries for NetworkList")
+}
+
+// NetworkOptions returns the validated response
+// from the NetworList method.
+func (f *Fetcher) NetworkOptions(
+	ctx context.Context,
+	network *types.NetworkIdentifier,
+	metadata *map[string]interface{},
+) (*types.NetworkOptionsResponse, error) {
+	NetworkOptions, _, err := f.rosettaClient.NetworkAPI.NetworkOptions(
+		ctx,
+		&types.NetworkRequest{
+			NetworkIdentifier: network,
+			Metadata:          metadata,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := asserter.NetworkOptionsResponse(NetworkOptions); err != nil {
+		return nil, err
+	}
+
+	return NetworkOptions, nil
+}
+
+// NetworkOptionsRetry retrieves the validated NetworkOptions
+// with a specified number of retries and max elapsed time.
+func (f *Fetcher) NetworkOptionsRetry(
+	ctx context.Context,
+	network *types.NetworkIdentifier,
+	metadata *map[string]interface{},
+	maxElapsedTime time.Duration,
+	maxRetries uint64,
+) (*types.NetworkOptionsResponse, error) {
+	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
+
+	for ctx.Err() == nil {
+		networkOptions, err := f.NetworkOptions(
+			ctx,
+			network,
+			metadata,
+		)
+		if err == nil {
+			return networkOptions, nil
+		}
+
+		if !tryAgain("NetworkOptions", backoffRetries, err) {
+			break
+		}
+	}
+
+	return nil, errors.New("exhausted retries for NetworkOptions")
 }

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -17,7 +17,6 @@ package fetcher
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 
@@ -55,10 +54,11 @@ func (f *Fetcher) NetworkStatusRetry(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	metadata *map[string]interface{},
-	maxElapsedTime time.Duration,
-	maxRetries uint64,
 ) (*types.NetworkStatusResponse, error) {
-	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
+	backoffRetries := backoffRetries(
+		f.retryElapsedTime,
+		f.maxRetries,
+	)
 
 	for ctx.Err() == nil {
 		networkStatus, err := f.NetworkStatus(
@@ -106,10 +106,11 @@ func (f *Fetcher) NetworkList(
 func (f *Fetcher) NetworkListRetry(
 	ctx context.Context,
 	metadata *map[string]interface{},
-	maxElapsedTime time.Duration,
-	maxRetries uint64,
 ) (*types.NetworkListResponse, error) {
-	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
+	backoffRetries := backoffRetries(
+		f.retryElapsedTime,
+		f.maxRetries,
+	)
 
 	for ctx.Err() == nil {
 		networkList, err := f.NetworkList(
@@ -159,10 +160,11 @@ func (f *Fetcher) NetworkOptionsRetry(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	metadata *map[string]interface{},
-	maxElapsedTime time.Duration,
-	maxRetries uint64,
 ) (*types.NetworkOptionsResponse, error) {
-	backoffRetries := backoffRetries(maxElapsedTime, maxRetries)
+	backoffRetries := backoffRetries(
+		f.retryElapsedTime,
+		f.maxRetries,
+	)
 
 	for ctx.Err() == nil {
 		networkOptions, err := f.NetworkOptions(

--- a/server/api.go
+++ b/server/api.go
@@ -48,8 +48,8 @@ type BlockAPIRouter interface {
 // pass the data to a ConstructionAPIServicer to perform the required actions, then write the
 // service results to the http response.
 type ConstructionAPIRouter interface {
-	TransactionConstruction(http.ResponseWriter, *http.Request)
-	TransactionSubmit(http.ResponseWriter, *http.Request)
+	ConstructionMetadata(http.ResponseWriter, *http.Request)
+	ConstructionSubmit(http.ResponseWriter, *http.Request)
 }
 
 // MempoolAPIRouter defines the required methods for binding the api requests to a responses for the
@@ -68,6 +68,8 @@ type MempoolAPIRouter interface {
 // pass the data to a NetworkAPIServicer to perform the required actions, then write the service
 // results to the http response.
 type NetworkAPIRouter interface {
+	NetworkList(http.ResponseWriter, *http.Request)
+	NetworkOptions(http.ResponseWriter, *http.Request)
 	NetworkStatus(http.ResponseWriter, *http.Request)
 }
 
@@ -93,12 +95,12 @@ type BlockAPIServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type ConstructionAPIServicer interface {
-	TransactionConstruction(
-		*types.TransactionConstructionRequest,
-	) (*types.TransactionConstructionResponse, *types.Error)
-	TransactionSubmit(
-		*types.TransactionSubmitRequest,
-	) (*types.TransactionSubmitResponse, *types.Error)
+	ConstructionMetadata(
+		*types.ConstructionMetadataRequest,
+	) (*types.ConstructionMetadataResponse, *types.Error)
+	ConstructionSubmit(
+		*types.ConstructionSubmitRequest,
+	) (*types.ConstructionSubmitResponse, *types.Error)
 }
 
 // MempoolAPIServicer defines the api actions for the MempoolAPI service
@@ -117,5 +119,7 @@ type MempoolAPIServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type NetworkAPIServicer interface {
-	NetworkStatus(*types.NetworkStatusRequest) (*types.NetworkStatusResponse, *types.Error)
+	NetworkList(*types.MetadataRequest) (*types.NetworkListResponse, *types.Error)
+	NetworkOptions(*types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error)
+	NetworkStatus(*types.NetworkRequest) (*types.NetworkStatusResponse, *types.Error)
 }

--- a/server/api_account.go
+++ b/server/api_account.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"strings"
 
@@ -53,39 +52,28 @@ func (c *AccountAPIController) Routes() Routes {
 func (c *AccountAPIController) AccountBalance(w http.ResponseWriter, r *http.Request) {
 	accountBalanceRequest := &types.AccountBalanceRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&accountBalanceRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that AccountBalanceRequest is correct
 	if err := asserter.AccountBalanceRequest(accountBalanceRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.AccountBalance(accountBalanceRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }

--- a/server/api_block.go
+++ b/server/api_block.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"strings"
 
@@ -59,80 +58,58 @@ func (c *BlockAPIController) Routes() Routes {
 func (c *BlockAPIController) Block(w http.ResponseWriter, r *http.Request) {
 	blockRequest := &types.BlockRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&blockRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that BlockRequest is correct
 	if err := asserter.BlockRequest(blockRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.Block(blockRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
 // BlockTransaction - Get a Block Transaction
 func (c *BlockAPIController) BlockTransaction(w http.ResponseWriter, r *http.Request) {
 	blockTransactionRequest := &types.BlockTransactionRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&blockTransactionRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that BlockTransactionRequest is correct
 	if err := asserter.BlockTransactionRequest(blockTransactionRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.BlockTransaction(blockTransactionRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"strings"
 
@@ -59,80 +58,58 @@ func (c *ConstructionAPIController) Routes() Routes {
 func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, r *http.Request) {
 	constructionMetadataRequest := &types.ConstructionMetadataRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&constructionMetadataRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that ConstructionMetadataRequest is correct
 	if err := asserter.ConstructionMetadataRequest(constructionMetadataRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.ConstructionMetadata(constructionMetadataRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
 // ConstructionSubmit - Submit a Signed Transaction
 func (c *ConstructionAPIController) ConstructionSubmit(w http.ResponseWriter, r *http.Request) {
 	constructionSubmitRequest := &types.ConstructionSubmitRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&constructionSubmitRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that ConstructionSubmitRequest is correct
 	if err := asserter.ConstructionSubmitRequest(constructionSubmitRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.ConstructionSubmit(constructionSubmitRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -41,27 +41,24 @@ func NewConstructionAPIController(s ConstructionAPIServicer) Router {
 func (c *ConstructionAPIController) Routes() Routes {
 	return Routes{
 		{
-			"TransactionConstruction",
+			"ConstructionMetadata",
 			strings.ToUpper("Post"),
 			"/construction/metadata",
-			c.TransactionConstruction,
+			c.ConstructionMetadata,
 		},
 		{
-			"TransactionSubmit",
+			"ConstructionSubmit",
 			strings.ToUpper("Post"),
 			"/construction/submit",
-			c.TransactionSubmit,
+			c.ConstructionSubmit,
 		},
 	}
 }
 
-// TransactionConstruction - Get Transaction Construction Metadata
-func (c *ConstructionAPIController) TransactionConstruction(
-	w http.ResponseWriter,
-	r *http.Request,
-) {
-	transactionConstructionRequest := &types.TransactionConstructionRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&transactionConstructionRequest); err != nil {
+// ConstructionMetadata - Get Transaction Construction Metadata
+func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, r *http.Request) {
+	constructionMetadataRequest := &types.ConstructionMetadataRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&constructionMetadataRequest); err != nil {
 		err = EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -72,8 +69,8 @@ func (c *ConstructionAPIController) TransactionConstruction(
 		return
 	}
 
-	// Assert that TransactionConstructionRequest is correct
-	if err := asserter.TransactionConstructionRequest(transactionConstructionRequest); err != nil {
+	// Assert that ConstructionMetadataRequest is correct
+	if err := asserter.ConstructionMetadataRequest(constructionMetadataRequest); err != nil {
 		err = EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -84,7 +81,7 @@ func (c *ConstructionAPIController) TransactionConstruction(
 		return
 	}
 
-	result, serviceErr := c.service.TransactionConstruction(transactionConstructionRequest)
+	result, serviceErr := c.service.ConstructionMetadata(constructionMetadataRequest)
 	if serviceErr != nil {
 		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 		if err != nil {
@@ -99,10 +96,10 @@ func (c *ConstructionAPIController) TransactionConstruction(
 	}
 }
 
-// TransactionSubmit - Submit a Signed Transaction
-func (c *ConstructionAPIController) TransactionSubmit(w http.ResponseWriter, r *http.Request) {
-	transactionSubmitRequest := &types.TransactionSubmitRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&transactionSubmitRequest); err != nil {
+// ConstructionSubmit - Submit a Signed Transaction
+func (c *ConstructionAPIController) ConstructionSubmit(w http.ResponseWriter, r *http.Request) {
+	constructionSubmitRequest := &types.ConstructionSubmitRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&constructionSubmitRequest); err != nil {
 		err = EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -113,8 +110,8 @@ func (c *ConstructionAPIController) TransactionSubmit(w http.ResponseWriter, r *
 		return
 	}
 
-	// Assert that TransactionSubmitRequest is correct
-	if err := asserter.TransactionSubmitRequest(transactionSubmitRequest); err != nil {
+	// Assert that ConstructionSubmitRequest is correct
+	if err := asserter.ConstructionSubmitRequest(constructionSubmitRequest); err != nil {
 		err = EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -125,7 +122,7 @@ func (c *ConstructionAPIController) TransactionSubmit(w http.ResponseWriter, r *
 		return
 	}
 
-	result, serviceErr := c.service.TransactionSubmit(transactionSubmitRequest)
+	result, serviceErr := c.service.ConstructionSubmit(constructionSubmitRequest)
 	if serviceErr != nil {
 		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 		if err != nil {

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"strings"
 
@@ -59,80 +58,58 @@ func (c *MempoolAPIController) Routes() Routes {
 func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
 	mempoolRequest := &types.MempoolRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&mempoolRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that MempoolRequest is correct
 	if err := asserter.MempoolRequest(mempoolRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.Mempool(mempoolRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
 // MempoolTransaction - Get a Mempool Transaction
 func (c *MempoolAPIController) MempoolTransaction(w http.ResponseWriter, r *http.Request) {
 	mempoolTransactionRequest := &types.MempoolTransactionRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&mempoolTransactionRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that MempoolTransactionRequest is correct
 	if err := asserter.MempoolTransactionRequest(mempoolTransactionRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.MempoolTransaction(mempoolTransactionRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }

--- a/server/api_network.go
+++ b/server/api_network.go
@@ -41,6 +41,18 @@ func NewNetworkAPIController(s NetworkAPIServicer) Router {
 func (c *NetworkAPIController) Routes() Routes {
 	return Routes{
 		{
+			"NetworkList",
+			strings.ToUpper("Post"),
+			"/network/list",
+			c.NetworkList,
+		},
+		{
+			"NetworkOptions",
+			strings.ToUpper("Post"),
+			"/network/options",
+			c.NetworkOptions,
+		},
+		{
 			"NetworkStatus",
 			strings.ToUpper("Post"),
 			"/network/status",
@@ -49,10 +61,92 @@ func (c *NetworkAPIController) Routes() Routes {
 	}
 }
 
+// NetworkList - Get List of Available Networks
+func (c *NetworkAPIController) NetworkList(w http.ResponseWriter, r *http.Request) {
+	metadataRequest := &types.MetadataRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&metadataRequest); err != nil {
+		err = EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return
+	}
+
+	// Assert that MetadataRequest is correct
+	if err := asserter.MetadataRequest(metadataRequest); err != nil {
+		err = EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return
+	}
+
+	result, serviceErr := c.service.NetworkList(metadataRequest)
+	if serviceErr != nil {
+		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return
+	}
+
+	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// NetworkOptions - Get Network Options
+func (c *NetworkAPIController) NetworkOptions(w http.ResponseWriter, r *http.Request) {
+	networkRequest := &types.NetworkRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&networkRequest); err != nil {
+		err = EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return
+	}
+
+	// Assert that NetworkRequest is correct
+	if err := asserter.NetworkRequest(networkRequest); err != nil {
+		err = EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return
+	}
+
+	result, serviceErr := c.service.NetworkOptions(networkRequest)
+	if serviceErr != nil {
+		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return
+	}
+
+	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
+		log.Fatal(err)
+	}
+}
+
 // NetworkStatus - Get Network Status
 func (c *NetworkAPIController) NetworkStatus(w http.ResponseWriter, r *http.Request) {
-	networkStatusRequest := &types.NetworkStatusRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&networkStatusRequest); err != nil {
+	networkRequest := &types.NetworkRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&networkRequest); err != nil {
 		err = EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -63,8 +157,8 @@ func (c *NetworkAPIController) NetworkStatus(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Assert that NetworkStatusRequest is correct
-	if err := asserter.NetworkStatusRequest(networkStatusRequest); err != nil {
+	// Assert that NetworkRequest is correct
+	if err := asserter.NetworkRequest(networkRequest); err != nil {
 		err = EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -75,7 +169,7 @@ func (c *NetworkAPIController) NetworkStatus(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	result, serviceErr := c.service.NetworkStatus(networkStatusRequest)
+	result, serviceErr := c.service.NetworkStatus(networkRequest)
 	if serviceErr != nil {
 		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 		if err != nil {

--- a/server/api_network.go
+++ b/server/api_network.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"strings"
 
@@ -65,121 +64,88 @@ func (c *NetworkAPIController) Routes() Routes {
 func (c *NetworkAPIController) NetworkList(w http.ResponseWriter, r *http.Request) {
 	metadataRequest := &types.MetadataRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&metadataRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that MetadataRequest is correct
 	if err := asserter.MetadataRequest(metadataRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.NetworkList(metadataRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
 // NetworkOptions - Get Network Options
 func (c *NetworkAPIController) NetworkOptions(w http.ResponseWriter, r *http.Request) {
 	networkRequest := &types.NetworkRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&networkRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that NetworkRequest is correct
 	if err := asserter.NetworkRequest(networkRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.NetworkOptions(networkRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }
 
 // NetworkStatus - Get Network Status
 func (c *NetworkAPIController) NetworkStatus(w http.ResponseWriter, r *http.Request) {
 	networkRequest := &types.NetworkRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&networkRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	// Assert that NetworkRequest is correct
 	if err := asserter.NetworkRequest(networkRequest); err != nil {
-		err = EncodeJSONResponse(&types.Error{
+		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
 
 		return
 	}
 
 	result, serviceErr := c.service.NetworkStatus(networkRequest)
 	if serviceErr != nil {
-		err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-		if err != nil {
-			log.Fatal(err)
-		}
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-		log.Fatal(err)
-	}
+	EncodeJSONResponse(result, http.StatusOK, w)
 }

--- a/server/logger.go
+++ b/server/logger.go
@@ -22,6 +22,7 @@ import (
 	"time"
 )
 
+// Logger prints all server requests to stdout.
 func Logger(inner http.Handler, name string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/server/routers.go
+++ b/server/routers.go
@@ -80,9 +80,11 @@ func NewRouter(routers ...Router) http.Handler {
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an
 // optional status code
-func EncodeJSONResponse(i interface{}, status int, w http.ResponseWriter) error {
+func EncodeJSONResponse(i interface{}, status int, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(status)
 
-	return json.NewEncoder(w).Encode(i)
+	if err := json.NewEncoder(w).Encode(i); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }

--- a/templates/server/controller-api.mustache
+++ b/templates/server/controller-api.mustache
@@ -3,7 +3,6 @@ package {{packageName}}
 
 import (
 	"encoding/json"
-  "log"
 	"net/http"
 	"strings"
 
@@ -38,24 +37,18 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{paramName}} := r.Header.Get("{{paramName}}"){{/isHeaderParam}}{{#isBodyParam}}
 	{{paramName}} := &types.{{dataType}}{}
 	if err := json.NewDecoder(r.Body).Decode(&{{paramName}}); err != nil {
-    err = EncodeJSONResponse(&types.Error{
+    EncodeJSONResponse(&types.Error{
       Message: err.Error(),
     }, http.StatusInternalServerError, w)
-    if err != nil {
-      log.Fatal(err)
-    }
 
     return
 	}
 
   // Assert that {{dataType}} is correct
   if err := asserter.{{dataType}}({{paramName}}); err != nil {
-    err = EncodeJSONResponse(&types.Error{
+    EncodeJSONResponse(&types.Error{
       Message: err.Error(),
     }, http.StatusInternalServerError, w)
-    if err != nil {
-      log.Fatal(err)
-    }
 
     return
   }
@@ -63,15 +56,10 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isBodyParam}}{{/allParams}}
 	result, serviceErr := c.service.{{nickname}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 	if serviceErr != nil {
-    err := EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
-    if err != nil {
-      log.Fatal(err)
-    }
+    EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
 		return
 	}
 	
-	if err := EncodeJSONResponse(result, http.StatusOK, w); err != nil {
-    log.Fatal(err)
-  }
+	EncodeJSONResponse(result, http.StatusOK, w)
 }{{/operation}}{{/operations}}

--- a/templates/server/logger.mustache
+++ b/templates/server/logger.mustache
@@ -7,6 +7,7 @@ import (
 	"time"
 )
 
+// Logger prints all server requests to stdout.
 func Logger(inner http.Handler, name string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/templates/server/routers.mustache
+++ b/templates/server/routers.mustache
@@ -61,9 +61,11 @@ func NewRouter(routers ...Router) http.Handler {
 }
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
-func EncodeJSONResponse(i interface{}, status int, w http.ResponseWriter) error {
+func EncodeJSONResponse(i interface{}, status int, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
   w.WriteHeader(status)
 
-	return json.NewEncoder(w).Encode(i)
+	if err := json.NewEncoder(w).Encode(i); err != nil {
+    http.Error(w, err.Error(), http.StatusInternalServerError)
+  }
 }

--- a/templates/spec.json
+++ b/templates/spec.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.3.0",
+   "version":"1.3.1",
    "title":"Rosetta",
    "description":"A Standard for Blockchain Interaction",
    "license": {
@@ -10,21 +10,62 @@
     }
   },
  "paths": {
+   "/network/list": {
+     "post": {
+       "summary":"Get List of Available Networks",
+       "description":"This endpoint returns a list of NetworkIdentifiers that the Rosetta server can handle.",
+       "operationId":"networkList",
+       "tags": [
+         "Network"
+        ],
+       "requestBody": {
+         "required": true,
+         "content": {
+           "application/json": {
+             "schema": {
+               "$ref":"#/components/schemas/MetadataRequest"
+              }
+            }
+          }
+        },
+       "responses": {
+         "200": {
+           "description":"Expected response to a valid request",
+           "content": {
+             "application/json": {
+               "schema": {
+                 "$ref":"#/components/schemas/NetworkListResponse"
+                }
+              }
+            }
+          },
+         "default": {
+           "description":"unexpected error",
+           "content": {
+             "application/json": {
+               "schema": {
+                 "$ref":"#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
    "/network/status": {
      "post": {
        "summary":"Get Network Status",
-       "description":"This method returns the current status of the network the node knows about. This method also returns the methods, operation types, and operation statuses the node supports.",
+       "description":"This endpoint returns the current status of the network requested. Any NetworkIdentifier returned by /network/list should be accessible here.",
        "operationId":"networkStatus",
        "tags": [
          "Network"
         ],
        "requestBody": {
-         "description":"There are not any required fields in this request, yet. It is still specified as a POST request to ensure required fields can be added without requiring clients to change from a GET(which is currently more ideal) to a POST request.",
          "required": true,
          "content": {
            "application/json": {
              "schema": {
-               "$ref":"#/components/schemas/NetworkStatusRequest"
+               "$ref":"#/components/schemas/NetworkRequest"
               }
             }
           }
@@ -36,6 +77,48 @@
              "application/json": {
                "schema": {
                  "$ref":"#/components/schemas/NetworkStatusResponse"
+                }
+              }
+            }
+          },
+         "default": {
+           "description":"unexpected error",
+           "content": {
+             "application/json": {
+               "schema": {
+                 "$ref":"#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+   "/network/options": {
+     "post": {
+       "summary":"Get Network Options",
+       "description":"This endpoint returns the version information and allowed network-specific types for a NetworkIdentifier. Any NetworkIdentifier returned by /network/list should be accessible here.  Because options are retrievable in the context of a NetworkIdentifier, it is possible to define unique options for each network.",
+       "operationId":"networkOptions",
+       "tags": [
+         "Network"
+        ],
+       "requestBody": {
+         "required": true,
+         "content": {
+           "application/json": {
+             "schema": {
+               "$ref":"#/components/schemas/NetworkRequest"
+              }
+            }
+          }
+        },
+       "responses": {
+         "200": {
+           "description":"Expected response to a valid request",
+           "content": {
+             "application/json": {
+               "schema": {
+                 "$ref":"#/components/schemas/NetworkOptionsResponse"
                 }
               }
             }
@@ -98,7 +181,7 @@
    "/block/transaction": {
      "post": {
        "summary":"Get a Block Transaction",
-       "description":"Get a transaction in a block by its Transaction Identifier. This method should only be used when querying a node for a block does not return all transactions contained within it.  All transactions returned by this method must be appended to any transactions returned by the /block method by consumers of this data. Fetching a transaction by hash is considered an Explorer Method (which is classified under the Future Work section).  Calling this method requires reference to a BlockIdentifier because transaction parsing can change depending on which block contains the transaction. For example, in Bitcoin it is necessary to know which block contains a transaction to determine the destination of fee payments. Without specifying a block identifier, the node would have to infer which block to use (which could change during a re-org).  Implementations that require fetching previous transactions to populate the response (ex: Previous UTXOs in Bitcoin) may find it useful to run a cache within the Rosetta server in the /data directory (on a path that does not conflict with the node).",
+       "description":"Get a transaction in a block by its Transaction Identifier. This endpoint should only be used when querying a node for a block does not return all transactions contained within it.  All transactions returned by this endpoint must be appended to any transactions returned by the /block method by consumers of this data. Fetching a transaction by hash is considered an Explorer Method (which is classified under the Future Work section).  Calling this endpoint requires reference to a BlockIdentifier because transaction parsing can change depending on which block contains the transaction. For example, in Bitcoin it is necessary to know which block contains a transaction to determine the destination of fee payments. Without specifying a block identifier, the node would have to infer which block to use (which could change during a re-org).  Implementations that require fetching previous transactions to populate the response (ex: Previous UTXOs in Bitcoin) may find it useful to run a cache within the Rosetta server in the /data directory (on a path that does not conflict with the node).",
        "operationId":"blockTransaction",
        "tags": [
          "Block"
@@ -266,8 +349,8 @@
    "/construction/metadata": {
      "post": {
        "summary":"Get Transaction Construction Metadata",
-       "description":"Get any information required to construct a transaction for a specific account. Metadata returned here could be a recent hash to use or an account sequence number.  It is important to clarify that this endpoint should not pre-construct any transactions for the client. All account-specific metadata must be returned as a key-value mapping so that transaction construction can be audited and performed entirely offline. Any account-agnostic metadata does not need to be broken out into a key-value mapping and can be returned as a blob.",
-       "operationId":"transactionConstruction",
+       "description":"Get any information required to construct a transaction for a specific network. Metadata returned here could be a recent hash to use, an account sequence number, or even arbitrary chain state. It is up to the client to correctly populate the options object with any network-specific details to ensure the correct metadata is retrieved.  It is important to clarify that this endpoint should not pre-construct any transactions for the client (this should happen in the SDK). This endpoint is left purposely unstructured because of the wide scope of metadata that could be required.  In a future version of the spec, we plan to pass an array of Rosetta Operations to specify which metadata should be received and to create a transaction in an accompanying SDK. This will help to insulate the client from chain-specific details that are currently required here.",
+       "operationId":"constructionMetadata",
        "tags": [
          "Construction"
         ],
@@ -276,7 +359,7 @@
          "content": {
            "application/json": {
              "schema": {
-               "$ref":"#/components/schemas/TransactionConstructionRequest"
+               "$ref":"#/components/schemas/ConstructionMetadataRequest"
               }
             }
           }
@@ -287,7 +370,7 @@
            "content": {
              "application/json": {
                "schema": {
-                 "$ref":"#/components/schemas/TransactionConstructionResponse"
+                 "$ref":"#/components/schemas/ConstructionMetadataResponse"
                 }
               }
             }
@@ -309,7 +392,7 @@
      "post": {
        "summary":"Submit a Signed Transaction",
        "description":"Submit a pre-signed transaction to the node. This call should not block on the transaction being included in a block. Rather, it should return immediately with an indication of whether or not the transaction was included in the mempool.  The transaction submission response should only return a 200 status if the submitted transaction could be included in the mempool. Otherwise, it should return an error.",
-       "operationId":"transactionSubmit",
+       "operationId":"constructionSubmit",
        "tags": [
          "Construction"
         ],
@@ -318,7 +401,7 @@
          "content": {
            "application/json": {
              "schema": {
-               "$ref":"#/components/schemas/TransactionSubmitRequest"
+               "$ref":"#/components/schemas/ConstructionSubmitRequest"
               }
             }
           }
@@ -329,7 +412,7 @@
            "content": {
              "application/json": {
                "schema": {
-                 "$ref":"#/components/schemas/TransactionSubmitResponse"
+                 "$ref":"#/components/schemas/ConstructionSubmitResponse"
                 }
               }
             }
@@ -503,7 +586,7 @@
         }
       },
      "Block": {
-       "description":"Blocks contain an array of Transactions that occured at a particular BlockIdentifier.",
+       "description":"Blocks contain an array of Transactions that occurred at a particular BlockIdentifier.",
        "type":"object",
        "required": [
          "block_identifier",
@@ -637,7 +720,7 @@
         }
       },
      "Currency": {
-       "description":"Currency is composed of a cannonical Symbol and Decimals. This Decimals value is used to convert an Amount.Value from atomic units (Satoshis) to standard units (Bitcoins).",
+       "description":"Currency is composed of a canonical Symbol and Decimals. This Decimals value is used to convert an Amount.Value from atomic units (Satoshis) to standard units (Bitcoins).",
        "type":"object",
        "required": [
          "symbol",
@@ -645,7 +728,7 @@
         ],
        "properties": {
          "symbol": {
-           "description":"Cannonical symbol associated with a currency.",
+           "description":"Canonical symbol associated with a currency.",
            "type":"string",
            "example":"BTC"
           },
@@ -661,33 +744,6 @@
            "type":"object",
            "example": {
              "Issuer":"Satoshi"
-            }
-          }
-        }
-      },
-     "Balance": {
-       "description":"Balance is the array of Amount controlled by an AccountIdentifier. An underspecified AccountIdentifier may result in many amounts (ex: all ERC-20 balances for a single address).",
-       "type":"object",
-       "required": [
-         "account_identifier",
-         "amounts"
-        ],
-       "properties": {
-         "account_identifier": {
-           "$ref":"#/components/schemas/AccountIdentifier"
-          },
-         "amounts": {
-           "description":"A single account may have a balance in multiple currencies.",
-           "type":"array",
-           "items": {
-             "$ref":"#/components/schemas/Amount"
-            }
-          },
-         "metadata": {
-           "description":"Account-based blockchains that utilize a nonce or sequence number should include that number in the metadata. This number could be unique to the identifier or global across the account address.",
-           "type":"object",
-           "example": {
-             "sequence_number": 23
             }
           }
         }
@@ -722,7 +778,7 @@
            "example":"1.2.5"
           },
          "node_version": {
-           "description":"The node_version is the cannonical version of the node runtime. This can help clients manage deployments.",
+           "description":"The node_version is the canonical version of the node runtime. This can help clients manage deployments.",
            "type":"string",
            "example":"1.0.2"
           },
@@ -737,51 +793,8 @@
           }
         }
       },
-     "NetworkInformation": {
-       "description":"NetworkInformation contains basic information about a node's view of a blockchain network.",
-       "type":"object",
-       "required": [
-         "current_block_identifier",
-         "current_block_timestamp",
-         "genesis_block_identifier",
-         "peers"
-        ],
-       "properties": {
-         "current_block_identifier": {
-           "$ref":"#/components/schemas/BlockIdentifier"
-          },
-         "current_block_timestamp": {
-           "$ref":"#/components/schemas/Timestamp"
-          },
-         "genesis_block_identifier": {
-           "$ref":"#/components/schemas/BlockIdentifier"
-          },
-         "peers": {
-           "type":"array",
-           "items": {
-             "$ref":"#/components/schemas/Peer"
-            }
-          }
-        }
-      },
-     "NetworkStatus": {
-       "description":"A NetworkStatus object contains the network_information pertaining to a network specified by the network_identifier.",
-       "type":"object",
-       "required": [
-         "network_identifier",
-         "network_information"
-        ],
-       "properties": {
-         "network_identifier": {
-           "$ref":"#/components/schemas/NetworkIdentifier"
-          },
-         "network_information": {
-           "$ref":"#/components/schemas/NetworkInformation"
-          }
-        }
-      },
-     "Options": {
-       "description":"Options specify supported Operation status, Operation types, and all possible error statuses. This Options object is used by clients to validate the correctness of a Rosetta Server implementation. It is expected that these clients will error if they receive some response that contains any of the above information that is not specified here.",
+     "Allow": {
+       "description":"Allow specifies supported Operation status, Operation types, and all possible error statuses. This Allow object is used by clients to validate the correctness of a Rosetta Server implementation. It is expected that these clients will error if they receive some response that contains any of the above information that is not specified here.",
        "type":"object",
        "required": [
          "operation_statuses",
@@ -862,7 +875,7 @@
         }
       },
      "AccountBalanceResponse": {
-       "description":"An AccountBalanceResponse is returned on the /account/balance endpoint.",
+       "description":"An AccountBalanceResponse is returned on the /account/balance endpoint. If an account has a balance for each AccountIdentifier describing it (ex: an ERC-20 token balance on a few smart contracts), an account balance request must be made with each AccountIdentifier.",
        "type":"object",
        "required": [
          "block_identifier",
@@ -873,10 +886,17 @@
            "$ref":"#/components/schemas/BlockIdentifier"
           },
          "balances": {
-           "description":"An AccountBalanceResponse may include multiple uniquely-identified balances. For example, the balance of an account on each shard could be returned or the balance of an account on each ERC-20 contract.",
            "type":"array",
+           "description":"A single account may have a balance in multiple currencies.",
            "items": {
-             "$ref":"#/components/schemas/Balance"
+             "$ref":"#/components/schemas/Amount"
+            }
+          },
+         "metadata": {
+           "description":"Account-based blockchains that utilize a nonce or sequence number should include that number in the metadata. This number could be unique to the identifier or global across the account address.",
+           "type":"object",
+           "example": {
+             "sequence_number": 23
             }
           }
         }
@@ -1010,8 +1030,8 @@
           }
         }
       },
-     "NetworkStatusRequest": {
-       "description":"A NetworkStatusRequest is utilized to retrieve the status of the network. It currently contains only optional metadata.",
+     "MetadataRequest": {
+       "description":"A MetadataRequest is utilized in any request where the only argument is optional metadata.",
        "type":"object",
        "properties": {
          "metadata": {
@@ -1019,66 +1039,103 @@
           }
         }
       },
-     "NetworkStatusResponse": {
-       "description":"A NetworkStatusResponse contains all information required to make reliable requests to the Rosetta Server implementation.",
+     "NetworkListResponse": {
+       "description":"A NetworkListResponse contains all NetworkIdentifiers that the node can serve information for.",
        "type":"object",
        "required": [
-         "network_status",
-         "version",
-         "options"
+         "network_identifiers"
         ],
        "properties": {
-         "network_status": {
-           "description":"The network_status array contains the status of all networks available to query. This includes all sub-networks that are also accessible (ex: shards).  If a node supports multiple networks, the first status returned should be the root chain or beacon chain (if applicable).",
+         "network_identifiers": {
            "type":"array",
            "items": {
-             "$ref":"#/components/schemas/NetworkStatus"
-            }
-          },
-         "version": {
-           "$ref":"#/components/schemas/Version"
-          },
-         "options": {
-           "$ref":"#/components/schemas/Options"
-          },
-         "metadata": {
-           "type":"object",
-           "example": {
-             "peer_id":"0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"
+             "$ref":"#/components/schemas/NetworkIdentifier"
             }
           }
         }
       },
-     "TransactionConstructionRequest": {
-       "description":"A TransactionConstructionRequest is utilized to get information required to construct a transaction. Optionally, the client can provide a method to reduce the amount of information that may need to be returned to the client to construct any transaction.",
+     "NetworkRequest": {
+       "description":"A NetworkRequest is utilized to retrieve some data specific exclusively to a NetworkIdentifier.",
        "type":"object",
        "required": [
-         "network_identifier",
-         "account_identifier"
+         "network_identifier"
         ],
        "properties": {
          "network_identifier": {
            "$ref":"#/components/schemas/NetworkIdentifier"
           },
-         "account_identifier": {
-           "$ref":"#/components/schemas/AccountIdentifier"
-          },
-         "method": {
-           "description":"Some blockchains require different metadata for different types of transaction construction (ex: delegation versus a transfer).  Instead of requiring a blockchain node to return all possible types of metadata for construction (which may require multiple node fetches), the client can specify a method to limit the metadata returned to only the subset required.",
-           "type":"string"
+         "metadata": {
+           "type":"object"
           }
         }
       },
-     "TransactionConstructionResponse": {
-       "description":"The transaction construction response should return the network fee to use in transaction construction. This network fee should be the gas price or cost per byte not some calculate value based on the method in the transaction construction request. Any calculations (like the one previously described) should be included in the metadata.",
+     "NetworkStatusResponse": {
+       "description":"NetworkStatusResponse contains basic information about the node's view of a blockchain network.",
        "type":"object",
        "required": [
-         "network_fee"
+         "current_block_identifier",
+         "current_block_timestamp",
+         "genesis_block_identifier",
+         "peers"
         ],
        "properties": {
-         "network_fee": {
-           "$ref":"#/components/schemas/Amount"
+         "current_block_identifier": {
+           "$ref":"#/components/schemas/BlockIdentifier"
           },
+         "current_block_timestamp": {
+           "$ref":"#/components/schemas/Timestamp"
+          },
+         "genesis_block_identifier": {
+           "$ref":"#/components/schemas/BlockIdentifier"
+          },
+         "peers": {
+           "type":"array",
+           "items": {
+             "$ref":"#/components/schemas/Peer"
+            }
+          }
+        }
+      },
+     "NetworkOptionsResponse": {
+       "description":"NetworkOptionsResponse contains information about the versioning of the node and the allowed operation statuses, operation types, and errors.",
+       "type":"object",
+       "required": [
+         "version",
+         "allow"
+        ],
+       "properties": {
+         "version": {
+           "$ref":"#/components/schemas/Version"
+          },
+         "allow": {
+           "$ref":"#/components/schemas/Allow"
+          }
+        }
+      },
+     "ConstructionMetadataRequest": {
+       "description":"A ConstructionMetadataRequest is utilized to get information required to construct a transaction. The Options object used to specify which metadata to return is left purposely unstructured to allow flexibility for implementers.",
+       "type":"object",
+       "required": [
+         "network_identifier",
+         "options"
+        ],
+       "properties": {
+         "network_identifier": {
+           "$ref":"#/components/schemas/NetworkIdentifier"
+          },
+         "options": {
+           "description":"Some blockchains require different metadata for different types of transaction construction (ex: delegation versus a transfer). Instead of requiring a blockchain node to return all possible types of metadata for construction (which may require multiple node fetches), the client can populate an options object to limit the metadata returned to only the subset required.",
+           "type":"object"
+          }
+        }
+      },
+     "ConstructionMetadataResponse": {
+       "description":"The ConstructionMetadataResponse returns network-specific metadata used for transaction construction. It is likely that the client will not inspect this metadata before passing it to a client SDK that uses it for construction.",
+       "type":"object",
+       "required": [
+         "metadata"
+        ],
+       "properties": {
          "metadata": {
            "type":"object",
            "example": {
@@ -1088,19 +1145,23 @@
           }
         }
       },
-     "TransactionSubmitRequest": {
+     "ConstructionSubmitRequest": {
        "description":"The transaction submission request includes a signed transaction.",
        "type":"object",
        "required": [
+         "network_identifier",
          "signed_transaction"
         ],
        "properties": {
+         "network_identifier": {
+           "$ref":"#/components/schemas/NetworkIdentifier"
+          },
          "signed_transaction": {
            "type":"string"
           }
         }
       },
-     "TransactionSubmitResponse": {
+     "ConstructionSubmitResponse": {
        "description":"A TransactionSubmitResponse contains the transaction_identifier of a submitted transaction that was accepted into the mempool.",
        "type":"object",
        "required": [
@@ -1120,7 +1181,8 @@
        "type":"object",
        "required": [
          "code",
-         "message"
+         "message",
+         "retriable"
         ],
        "properties": {
          "code": {
@@ -1132,6 +1194,10 @@
          "message": {
            "description":"Message is a network-specific error message.",
            "type":"string"
+          },
+         "retriable": {
+           "description":"An error is retriable if the same request may succeed if submitted again.",
+           "type":"boolean"
           }
         }
       }

--- a/types/account_balance_response.go
+++ b/types/account_balance_response.go
@@ -16,11 +16,15 @@
 
 package types
 
-// AccountBalanceResponse An AccountBalanceResponse is returned on the /account/balance endpoint.
+// AccountBalanceResponse An AccountBalanceResponse is returned on the /account/balance endpoint. If
+// an account has a balance for each AccountIdentifier describing it (ex: an ERC-20 token balance on
+// a few smart contracts), an account balance request must be made with each AccountIdentifier.
 type AccountBalanceResponse struct {
 	BlockIdentifier *BlockIdentifier `json:"block_identifier"`
-	// An AccountBalanceResponse may include multiple uniquely-identified balances. For example, the
-	// balance of an account on each shard could be returned or the balance of an account on each
-	// ERC-20 contract.
-	Balances []*Balance `json:"balances"`
+	// A single account may have a balance in multiple currencies.
+	Balances []*Amount `json:"balances"`
+	// Account-based blockchains that utilize a nonce or sequence number should include that number
+	// in the metadata. This number could be unique to the identifier or global across the account
+	// address.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/allow.go
+++ b/types/allow.go
@@ -16,11 +16,11 @@
 
 package types
 
-// Options Options specify supported Operation status, Operation types, and all possible error
-// statuses. This Options object is used by clients to validate the correctness of a Rosetta Server
+// Allow Allow specifies supported Operation status, Operation types, and all possible error
+// statuses. This Allow object is used by clients to validate the correctness of a Rosetta Server
 // implementation. It is expected that these clients will error if they receive some response that
 // contains any of the above information that is not specified here.
-type Options struct {
+type Allow struct {
 	// All Operation.Status this implementation supports. Any status that is returned during parsing
 	// that is not listed here will cause client validation to error.
 	OperationStatuses []*OperationStatus `json:"operation_statuses"`

--- a/types/construction_metadata_request.go
+++ b/types/construction_metadata_request.go
@@ -16,15 +16,15 @@
 
 package types
 
-// TransactionConstructionRequest A TransactionConstructionRequest is utilized to get information
-// required to construct a transaction. Optionally, the client can provide a method to reduce the
-// amount of information that may need to be returned to the client to construct any transaction.
-type TransactionConstructionRequest struct {
+// ConstructionMetadataRequest A ConstructionMetadataRequest is utilized to get information required
+// to construct a transaction. The Options object used to specify which metadata to return is left
+// purposely unstructured to allow flexibility for implementers.
+type ConstructionMetadataRequest struct {
 	NetworkIdentifier *NetworkIdentifier `json:"network_identifier"`
-	AccountIdentifier *AccountIdentifier `json:"account_identifier"`
 	// Some blockchains require different metadata for different types of transaction construction
-	// (ex: delegation versus a transfer).  Instead of requiring a blockchain node to return all
+	// (ex: delegation versus a transfer). Instead of requiring a blockchain node to return all
 	// possible types of metadata for construction (which may require multiple node fetches), the
-	// client can specify a method to limit the metadata returned to only the subset required.
-	Method *string `json:"method,omitempty"`
+	// client can populate an options object to limit the metadata returned to only the subset
+	// required.
+	Options *map[string]interface{} `json:"options"`
 }

--- a/types/construction_metadata_response.go
+++ b/types/construction_metadata_response.go
@@ -16,14 +16,9 @@
 
 package types
 
-// Balance Balance is the array of Amount controlled by an AccountIdentifier. An underspecified
-// AccountIdentifier may result in many amounts (ex: all ERC-20 balances for a single address).
-type Balance struct {
-	AccountIdentifier *AccountIdentifier `json:"account_identifier"`
-	// A single account may have a balance in multiple currencies.
-	Amounts []*Amount `json:"amounts"`
-	// Account-based blockchains that utilize a nonce or sequence number should include that number
-	// in the metadata. This number could be unique to the identifier or global across the account
-	// address.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionMetadataResponse The ConstructionMetadataResponse returns network-specific metadata
+// used for transaction construction. It is likely that the client will not inspect this metadata
+// before passing it to a client SDK that uses it for construction.
+type ConstructionMetadataResponse struct {
+	Metadata *map[string]interface{} `json:"metadata"`
 }

--- a/types/construction_submit_request.go
+++ b/types/construction_submit_request.go
@@ -16,9 +16,8 @@
 
 package types
 
-// NetworkStatus A NetworkStatus object contains the network_information pertaining to a network
-// specified by the network_identifier.
-type NetworkStatus struct {
-	NetworkIdentifier  *NetworkIdentifier  `json:"network_identifier"`
-	NetworkInformation *NetworkInformation `json:"network_information"`
+// ConstructionSubmitRequest The transaction submission request includes a signed transaction.
+type ConstructionSubmitRequest struct {
+	NetworkIdentifier *NetworkIdentifier `json:"network_identifier"`
+	SignedTransaction string             `json:"signed_transaction"`
 }

--- a/types/construction_submit_response.go
+++ b/types/construction_submit_response.go
@@ -16,8 +16,9 @@
 
 package types
 
-// NetworkStatusRequest A NetworkStatusRequest is utilized to retrieve the status of the network. It
-// currently contains only optional metadata.
-type NetworkStatusRequest struct {
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionSubmitResponse A TransactionSubmitResponse contains the transaction_identifier of a
+// submitted transaction that was accepted into the mempool.
+type ConstructionSubmitResponse struct {
+	TransactionIdentifier *TransactionIdentifier  `json:"transaction_identifier"`
+	Metadata              *map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/error.go
+++ b/types/error.go
@@ -24,4 +24,6 @@ type Error struct {
 	Code int32 `json:"code"`
 	// Message is a network-specific error message.
 	Message string `json:"message"`
+	// An error is retriable if the same request may succeed if submitted again.
+	Retriable bool `json:"retriable"`
 }

--- a/types/metadata_request.go
+++ b/types/metadata_request.go
@@ -16,7 +16,8 @@
 
 package types
 
-// TransactionSubmitRequest The transaction submission request includes a signed transaction.
-type TransactionSubmitRequest struct {
-	SignedTransaction string `json:"signed_transaction"`
+// MetadataRequest A MetadataRequest is utilized in any request where the only argument is optional
+// metadata.
+type MetadataRequest struct {
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/network_list_response.go
+++ b/types/network_list_response.go
@@ -16,11 +16,8 @@
 
 package types
 
-// TransactionConstructionResponse The transaction construction response should return the network
-// fee to use in transaction construction. This network fee should be the gas price or cost per byte
-// not some calculate value based on the method in the transaction construction request. Any
-// calculations (like the one previously described) should be included in the metadata.
-type TransactionConstructionResponse struct {
-	NetworkFee *Amount                 `json:"network_fee"`
-	Metadata   *map[string]interface{} `json:"metadata,omitempty"`
+// NetworkListResponse A NetworkListResponse contains all NetworkIdentifiers that the node can serve
+// information for.
+type NetworkListResponse struct {
+	NetworkIdentifiers []*NetworkIdentifier `json:"network_identifiers"`
 }

--- a/types/network_options_response.go
+++ b/types/network_options_response.go
@@ -16,13 +16,9 @@
 
 package types
 
-// NetworkInformation NetworkInformation contains basic information about a node's view of a
-// blockchain network.
-type NetworkInformation struct {
-	CurrentBlockIdentifier *BlockIdentifier `json:"current_block_identifier"`
-	// The timestamp of the block in milliseconds since the Unix Epoch. The timestamp is stored in
-	// milliseconds because some blockchains produce blocks more often than once a second.
-	CurrentBlockTimestamp  int64            `json:"current_block_timestamp"`
-	GenesisBlockIdentifier *BlockIdentifier `json:"genesis_block_identifier"`
-	Peers                  []*Peer          `json:"peers"`
+// NetworkOptionsResponse NetworkOptionsResponse contains information about the versioning of the
+// node and the allowed operation statuses, operation types, and errors.
+type NetworkOptionsResponse struct {
+	Version *Version `json:"version"`
+	Allow   *Allow   `json:"allow"`
 }

--- a/types/network_request.go
+++ b/types/network_request.go
@@ -16,9 +16,9 @@
 
 package types
 
-// TransactionSubmitResponse A TransactionSubmitResponse contains the transaction_identifier of a
-// submitted transaction that was accepted into the mempool.
-type TransactionSubmitResponse struct {
-	TransactionIdentifier *TransactionIdentifier  `json:"transaction_identifier"`
-	Metadata              *map[string]interface{} `json:"metadata,omitempty"`
+// NetworkRequest A NetworkRequest is utilized to retrieve some data specific exclusively to a
+// NetworkIdentifier.
+type NetworkRequest struct {
+	NetworkIdentifier *NetworkIdentifier      `json:"network_identifier"`
+	Metadata          *map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/network_status_response.go
+++ b/types/network_status_response.go
@@ -16,14 +16,13 @@
 
 package types
 
-// NetworkStatusResponse A NetworkStatusResponse contains all information required to make reliable
-// requests to the Rosetta Server implementation.
+// NetworkStatusResponse NetworkStatusResponse contains basic information about the node's view of a
+// blockchain network.
 type NetworkStatusResponse struct {
-	// The network_status array contains the status of all networks available to query. This
-	// includes all sub-networks that are also accessible (ex: shards).  If a node supports multiple
-	// networks, the first status returned should be the root chain or beacon chain (if applicable).
-	NetworkStatus []*NetworkStatus        `json:"network_status"`
-	Version       *Version                `json:"version"`
-	Options       *Options                `json:"options"`
-	Metadata      *map[string]interface{} `json:"metadata,omitempty"`
+	CurrentBlockIdentifier *BlockIdentifier `json:"current_block_identifier"`
+	// The timestamp of the block in milliseconds since the Unix Epoch. The timestamp is stored in
+	// milliseconds because some blockchains produce blocks more often than once a second.
+	CurrentBlockTimestamp  int64            `json:"current_block_timestamp"`
+	GenesisBlockIdentifier *BlockIdentifier `json:"genesis_block_identifier"`
+	Peers                  []*Peer          `json:"peers"`
 }


### PR DESCRIPTION
* Run codegen using the 1.3.1 Rosetta specification
* Cleanup `fetcher` construction and `fetcher` retry methods
* Remove `log.Fatal` calls from server package (if there is an error encoding a response just use http.error)
