### PR TITLE
Add Servicer Context

### DIFF
--- a/asserter/block.go
+++ b/asserter/block.go
@@ -199,11 +199,11 @@ func PartialBlockIdentifier(blockIdentifier *types.PartialBlockIdentifier) error
 		return errors.New("PartialBlockIdentifier is nil")
 	}
 
-	if blockIdentifier.Hash != nil && *blockIdentifier.Hash == "" {
+	if blockIdentifier.Hash != nil && *blockIdentifier.Hash != "" {
 		return nil
 	}
 
-	if blockIdentifier.Index != nil && *blockIdentifier.Index > 0 {
+	if blockIdentifier.Index != nil && *blockIdentifier.Index >= 0 {
 		return nil
 	}
 

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -33,6 +33,7 @@ var (
 		Address: "acct1",
 	}
 
+	genesisBlockIndex           = int64(0)
 	validBlockIndex             = int64(1000)
 	validPartialBlockIdentifier = &types.PartialBlockIdentifier{
 		Index: &validBlockIndex,
@@ -111,6 +112,15 @@ func TestBlockRequest(t *testing.T) {
 			request: &types.BlockRequest{
 				NetworkIdentifier: validNetworkIdentifier,
 				BlockIdentifier:   validPartialBlockIdentifier,
+			},
+			err: nil,
+		},
+		"valid request for block 0": {
+			request: &types.BlockRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				BlockIdentifier: &types.PartialBlockIdentifier{
+					Index: &genesisBlockIndex,
+				},
 			},
 			err: nil,
 		},

--- a/examples/fetcher/main.go
+++ b/examples/fetcher/main.go
@@ -113,6 +113,9 @@ func main() {
 		networkStatus.GenesisBlockIdentifier.Index,
 		networkStatus.GenesisBlockIdentifier.Index+10,
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Step 7: Print the block range
 	prettyBlockRange, err := json.MarshalIndent(

--- a/examples/fetcher/main.go
+++ b/examples/fetcher/main.go
@@ -105,4 +105,23 @@ func main() {
 		log.Fatal(err)
 	}
 	log.Printf("Current Block: %s\n", string(prettyBlock))
+
+	// Step 6: Get a range of blocks
+	blockMap, err := newFetcher.BlockRange(
+		ctx,
+		primaryNetwork,
+		networkStatus.GenesisBlockIdentifier.Index,
+		networkStatus.GenesisBlockIdentifier.Index+10,
+	)
+
+	// Step 7: Print the block range
+	prettyBlockRange, err := json.MarshalIndent(
+		blockMap,
+		"",
+		" ",
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Block Range: %s\n", string(prettyBlockRange))
 }

--- a/examples/server/services/block_service.go
+++ b/examples/server/services/block_service.go
@@ -15,6 +15,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -36,6 +37,7 @@ func NewBlockAPIService(network *types.NetworkIdentifier) server.BlockAPIService
 
 // Block implements the /block endpoint.
 func (s *BlockAPIService) Block(
+	ctx context.Context,
 	request *types.BlockRequest,
 ) (*types.BlockResponse, *types.Error) {
 	if *request.BlockIdentifier.Index != 1000 {
@@ -130,6 +132,7 @@ func (s *BlockAPIService) Block(
 
 // BlockTransaction implements the /block/transaction endpoint.
 func (s *BlockAPIService) BlockTransaction(
+	ctx context.Context,
 	request *types.BlockTransactionRequest,
 ) (*types.BlockTransactionResponse, *types.Error) {
 	return &types.BlockTransactionResponse{

--- a/examples/server/services/block_service.go
+++ b/examples/server/services/block_service.go
@@ -15,6 +15,9 @@
 package services
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -35,6 +38,28 @@ func NewBlockAPIService(network *types.NetworkIdentifier) server.BlockAPIService
 func (s *BlockAPIService) Block(
 	request *types.BlockRequest,
 ) (*types.BlockResponse, *types.Error) {
+	if *request.BlockIdentifier.Index != 1000 {
+		previousBlockIndex := *request.BlockIdentifier.Index - 1
+		if previousBlockIndex < 0 {
+			previousBlockIndex = 0
+		}
+
+		return &types.BlockResponse{
+			Block: &types.Block{
+				BlockIdentifier: &types.BlockIdentifier{
+					Index: *request.BlockIdentifier.Index,
+					Hash:  fmt.Sprintf("block %d", *request.BlockIdentifier.Index),
+				},
+				ParentBlockIdentifier: &types.BlockIdentifier{
+					Index: previousBlockIndex,
+					Hash:  fmt.Sprintf("block %d", previousBlockIndex),
+				},
+				Timestamp:    time.Now().UnixNano() / 1000000,
+				Transactions: []*types.Transaction{},
+			},
+		}, nil
+	}
+
 	return &types.BlockResponse{
 		Block: &types.Block{
 			BlockIdentifier: &types.BlockIdentifier{

--- a/examples/server/services/network_service.go
+++ b/examples/server/services/network_service.go
@@ -15,6 +15,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -33,7 +35,8 @@ func NewNetworkAPIService(network *types.NetworkIdentifier) server.NetworkAPISer
 
 // NetworkList implements the /network/list endpoint
 func (s *NetworkAPIService) NetworkList(
-	*types.MetadataRequest,
+	ctx context.Context,
+	request *types.MetadataRequest,
 ) (*types.NetworkListResponse, *types.Error) {
 	return &types.NetworkListResponse{
 		NetworkIdentifiers: []*types.NetworkIdentifier{
@@ -44,7 +47,8 @@ func (s *NetworkAPIService) NetworkList(
 
 // NetworkStatus implements the /network/status endpoint.
 func (s *NetworkAPIService) NetworkStatus(
-	*types.NetworkRequest,
+	ctx context.Context,
+	request *types.NetworkRequest,
 ) (*types.NetworkStatusResponse, *types.Error) {
 	return &types.NetworkStatusResponse{
 		CurrentBlockIdentifier: &types.BlockIdentifier{
@@ -66,7 +70,8 @@ func (s *NetworkAPIService) NetworkStatus(
 
 // NetworkOptions implements the /network/options endpoint.
 func (s *NetworkAPIService) NetworkOptions(
-	*types.NetworkRequest,
+	ctx context.Context,
+	request *types.NetworkRequest,
 ) (*types.NetworkOptionsResponse, *types.Error) {
 	return &types.NetworkOptionsResponse{
 		Version: &types.Version{

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/server/api.go
+++ b/server/api.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -78,7 +79,10 @@ type NetworkAPIRouter interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type AccountAPIServicer interface {
-	AccountBalance(*types.AccountBalanceRequest) (*types.AccountBalanceResponse, *types.Error)
+	AccountBalance(
+		context.Context,
+		*types.AccountBalanceRequest,
+	) (*types.AccountBalanceResponse, *types.Error)
 }
 
 // BlockAPIServicer defines the api actions for the BlockAPI service
@@ -86,8 +90,11 @@ type AccountAPIServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type BlockAPIServicer interface {
-	Block(*types.BlockRequest) (*types.BlockResponse, *types.Error)
-	BlockTransaction(*types.BlockTransactionRequest) (*types.BlockTransactionResponse, *types.Error)
+	Block(context.Context, *types.BlockRequest) (*types.BlockResponse, *types.Error)
+	BlockTransaction(
+		context.Context,
+		*types.BlockTransactionRequest,
+	) (*types.BlockTransactionResponse, *types.Error)
 }
 
 // ConstructionAPIServicer defines the api actions for the ConstructionAPI service
@@ -96,9 +103,11 @@ type BlockAPIServicer interface {
 // and updated with the logic required for the API.
 type ConstructionAPIServicer interface {
 	ConstructionMetadata(
+		context.Context,
 		*types.ConstructionMetadataRequest,
 	) (*types.ConstructionMetadataResponse, *types.Error)
 	ConstructionSubmit(
+		context.Context,
 		*types.ConstructionSubmitRequest,
 	) (*types.ConstructionSubmitResponse, *types.Error)
 }
@@ -108,8 +117,9 @@ type ConstructionAPIServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type MempoolAPIServicer interface {
-	Mempool(*types.MempoolRequest) (*types.MempoolResponse, *types.Error)
+	Mempool(context.Context, *types.MempoolRequest) (*types.MempoolResponse, *types.Error)
 	MempoolTransaction(
+		context.Context,
 		*types.MempoolTransactionRequest,
 	) (*types.MempoolTransactionResponse, *types.Error)
 }
@@ -119,7 +129,13 @@ type MempoolAPIServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type NetworkAPIServicer interface {
-	NetworkList(*types.MetadataRequest) (*types.NetworkListResponse, *types.Error)
-	NetworkOptions(*types.NetworkRequest) (*types.NetworkOptionsResponse, *types.Error)
-	NetworkStatus(*types.NetworkRequest) (*types.NetworkStatusResponse, *types.Error)
+	NetworkList(context.Context, *types.MetadataRequest) (*types.NetworkListResponse, *types.Error)
+	NetworkOptions(
+		context.Context,
+		*types.NetworkRequest,
+	) (*types.NetworkOptionsResponse, *types.Error)
+	NetworkStatus(
+		context.Context,
+		*types.NetworkRequest,
+	) (*types.NetworkStatusResponse, *types.Error)
 }

--- a/server/api_account.go
+++ b/server/api_account.go
@@ -68,7 +68,7 @@ func (c *AccountAPIController) AccountBalance(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, serviceErr := c.service.AccountBalance(accountBalanceRequest)
+	result, serviceErr := c.service.AccountBalance(r.Context(), accountBalanceRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_block.go
+++ b/server/api_block.go
@@ -74,7 +74,7 @@ func (c *BlockAPIController) Block(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, serviceErr := c.service.Block(blockRequest)
+	result, serviceErr := c.service.Block(r.Context(), blockRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -104,7 +104,7 @@ func (c *BlockAPIController) BlockTransaction(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, serviceErr := c.service.BlockTransaction(blockTransactionRequest)
+	result, serviceErr := c.service.BlockTransaction(r.Context(), blockTransactionRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -74,7 +74,7 @@ func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, 
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionMetadata(constructionMetadataRequest)
+	result, serviceErr := c.service.ConstructionMetadata(r.Context(), constructionMetadataRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -104,7 +104,7 @@ func (c *ConstructionAPIController) ConstructionSubmit(w http.ResponseWriter, r 
 		return
 	}
 
-	result, serviceErr := c.service.ConstructionSubmit(constructionSubmitRequest)
+	result, serviceErr := c.service.ConstructionSubmit(r.Context(), constructionSubmitRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -74,7 +74,7 @@ func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, serviceErr := c.service.Mempool(mempoolRequest)
+	result, serviceErr := c.service.Mempool(r.Context(), mempoolRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -104,7 +104,7 @@ func (c *MempoolAPIController) MempoolTransaction(w http.ResponseWriter, r *http
 		return
 	}
 
-	result, serviceErr := c.service.MempoolTransaction(mempoolTransactionRequest)
+	result, serviceErr := c.service.MempoolTransaction(r.Context(), mempoolTransactionRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_network.go
+++ b/server/api_network.go
@@ -80,7 +80,7 @@ func (c *NetworkAPIController) NetworkList(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	result, serviceErr := c.service.NetworkList(metadataRequest)
+	result, serviceErr := c.service.NetworkList(r.Context(), metadataRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -110,7 +110,7 @@ func (c *NetworkAPIController) NetworkOptions(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, serviceErr := c.service.NetworkOptions(networkRequest)
+	result, serviceErr := c.service.NetworkOptions(r.Context(), networkRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 
@@ -140,7 +140,7 @@ func (c *NetworkAPIController) NetworkStatus(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	result, serviceErr := c.service.NetworkStatus(networkRequest)
+	result, serviceErr := c.service.NetworkStatus(r.Context(), networkRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/templates/server/api.mustache
+++ b/templates/server/api.mustache
@@ -2,7 +2,8 @@
 package {{packageName}}
 
 import (
-	"net/http"
+  "context"
+  "net/http"
 
   "github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -21,5 +22,5 @@ type {{classname}}Router interface { {{#operations}}{{#operation}}
 // while the service implementation can ignored with the .openapi-generator-ignore file 
 // and updated with the logic required for the API.
 type {{classname}}Servicer interface { {{#operations}}{{#operation}}
-	{{operationId}}({{#allParams}}*types.{{dataType}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) (*types.{{returnType}}, *types.Error){{/operation}}{{/operations}}
+	{{operationId}}(context.Context, {{#allParams}}*types.{{dataType}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) (*types.{{returnType}}, *types.Error){{/operation}}{{/operations}}
 }{{/apis}}{{/apiInfo}}

--- a/templates/server/controller-api.mustache
+++ b/templates/server/controller-api.mustache
@@ -54,7 +54,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
   }
 
 	{{/isBodyParam}}{{/allParams}}
-	result, serviceErr := c.service.{{nickname}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
+	result, serviceErr := c.service.{{nickname}}(r.Context(), {{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 	if serviceErr != nil {
     EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 


### PR DESCRIPTION
### Motivation
The autogenerated servicer interface methods did not include the request context as a parameter.

### Solution
Each servicer method now includes context as a parameter.