### PR TITLE
Create Asserter from File

### DIFF
--- a/asserter/account_test.go
+++ b/asserter/account_test.go
@@ -48,7 +48,7 @@ func TestContainsCurrency(t *testing.T) {
 				{
 					Symbol:   "BTC",
 					Decimals: 8,
-					Metadata: &map[string]interface{}{
+					Metadata: map[string]interface{}{
 						"blah": "hello",
 					},
 				},
@@ -56,7 +56,7 @@ func TestContainsCurrency(t *testing.T) {
 			currency: &types.Currency{
 				Symbol:   "BTC",
 				Decimals: 8,
-				Metadata: &map[string]interface{}{
+				Metadata: map[string]interface{}{
 					"blah": "hello",
 				},
 			},
@@ -101,7 +101,7 @@ func TestContainsCurrency(t *testing.T) {
 				{
 					Symbol:   "BTC",
 					Decimals: 8,
-					Metadata: &map[string]interface{}{
+					Metadata: map[string]interface{}{
 						"blah": "hello",
 					},
 				},
@@ -109,7 +109,7 @@ func TestContainsCurrency(t *testing.T) {
 			currency: &types.Currency{
 				Symbol:   "BTC",
 				Decimals: 8,
-				Metadata: &map[string]interface{}{
+				Metadata: map[string]interface{}{
 					"blah": "bye",
 				},
 			},

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"path"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -85,7 +86,7 @@ type FileConfiguration struct {
 func NewWithFile(
 	filePath string,
 ) (*Asserter, error) {
-	content, err := ioutil.ReadFile(filePath)
+	content, err := ioutil.ReadFile(path.Clean(filePath))
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +153,14 @@ func NewWithOptions(
 
 // Configuration returns all variables currently set in an Asserter.
 // This function will error if it is called on an uninitialized asserter.
-func (a *Asserter) Configuration() (*types.NetworkIdentifier, *types.BlockIdentifier, []string, []*types.OperationStatus, []*types.Error, error) {
+func (a *Asserter) Configuration() (
+	*types.NetworkIdentifier,
+	*types.BlockIdentifier,
+	[]string,
+	[]*types.OperationStatus,
+	[]*types.Error,
+	error,
+) {
 	if a == nil {
 		return nil, nil, nil, nil, nil, ErrAsserterNotInitialized
 	}

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -15,7 +15,6 @@
 package asserter
 
 import (
-	"context"
 	"errors"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -40,7 +39,6 @@ type Asserter struct {
 // from a NetworkStatusResponse and
 // NetworkOptionsResponse.
 func NewWithResponses(
-	ctx context.Context,
 	networkStatus *types.NetworkStatusResponse,
 	networkOptions *types.NetworkOptionsResponse,
 ) (*Asserter, error) {
@@ -53,7 +51,6 @@ func NewWithResponses(
 	}
 
 	return NewWithOptions(
-		ctx,
 		networkStatus.GenesisBlockIdentifier,
 		networkOptions.Allow.OperationTypes,
 		networkOptions.Allow.OperationStatuses,
@@ -61,11 +58,26 @@ func NewWithResponses(
 	), nil
 }
 
+// NewWithFile constructs a new Asserter using a specification
+// file instead of responses. This can be useful for running reliable
+// systems that error when updates to the server (more error types,
+// more operations, etc.) significantly change how to parse the chain.
+func NewWithFile(
+	filePath string,
+) (*Asserter, error) {
+	// load file
+
+	// parse items
+
+	// run NewWithOptions
+
+	return nil, errors.New("not implemented")
+}
+
 // NewWithOptions constructs a new Asserter using the provided
 // arguments instead of using a NetworkStatusResponse and a
 // NetworkOptionsResponse.
 func NewWithOptions(
-	ctx context.Context,
 	genesisBlockIdentifier *types.BlockIdentifier,
 	operationTypes []string,
 	operationStatuses []*types.OperationStatus,

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -33,11 +33,29 @@ var (
 // Asserter contains all logic to perform static
 // validation on Rosetta Server responses.
 type Asserter struct {
+	// These variables are used for response assertion.
 	network            *types.NetworkIdentifier
 	operationTypes     []string
 	operationStatusMap map[string]bool
 	errorTypeMap       map[int32]*types.Error
 	genesisBlock       *types.BlockIdentifier
+
+	// These variables are used for request assertion.
+	supportedNetworks []*types.NetworkIdentifier
+}
+
+// NewServer constructs a new Asserter for use in the
+// server package.
+func NewServer(
+	supportedNetworks []*types.NetworkIdentifier,
+) (*Asserter, error) {
+	if err := SupportedNetworks(supportedNetworks); err != nil {
+		return nil, err
+	}
+
+	return &Asserter{
+		supportedNetworks: supportedNetworks,
+	}, nil
 }
 
 // NewWithResponses constructs a new Asserter

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -58,10 +58,10 @@ func NewServer(
 	}, nil
 }
 
-// NewWithResponses constructs a new Asserter
+// NewClientWithResponses constructs a new Asserter
 // from a NetworkStatusResponse and
 // NetworkOptionsResponse.
-func NewWithResponses(
+func NewClientWithResponses(
 	network *types.NetworkIdentifier,
 	networkStatus *types.NetworkStatusResponse,
 	networkOptions *types.NetworkOptionsResponse,
@@ -78,7 +78,7 @@ func NewWithResponses(
 		return nil, err
 	}
 
-	return NewWithOptions(
+	return NewClientWithOptions(
 		network,
 		networkStatus.GenesisBlockIdentifier,
 		networkOptions.Allow.OperationTypes,
@@ -96,12 +96,12 @@ type FileConfiguration struct {
 	AllowedErrors            []*types.Error           `json:"allowed_errors"`
 }
 
-// NewWithFile constructs a new Asserter using a specification
+// NewClientWithFile constructs a new Asserter using a specification
 // file instead of responses. This can be useful for running reliable
 // systems that error when updates to the server (more error types,
 // more operations, etc.) significantly change how to parse the chain.
 // The filePath provided is parsed relative to the current directory.
-func NewWithFile(
+func NewClientWithFile(
 	filePath string,
 ) (*Asserter, error) {
 	content, err := ioutil.ReadFile(path.Clean(filePath))
@@ -114,7 +114,7 @@ func NewWithFile(
 		return nil, err
 	}
 
-	return NewWithOptions(
+	return NewClientWithOptions(
 		config.NetworkIdentifier,
 		config.GenesisBlockIdentifier,
 		config.AllowedOperationTypes,
@@ -123,11 +123,10 @@ func NewWithFile(
 	)
 }
 
-// NewWithOptions constructs a new Asserter using the provided
+// NewClientWithOptions constructs a new Asserter using the provided
 // arguments instead of using a NetworkStatusResponse and a
-// NetworkOptionsResponse. NewWithOptions does not check the
-// correctness of inputs.
-func NewWithOptions(
+// NetworkOptionsResponse.
+func NewClientWithOptions(
 	network *types.NetworkIdentifier,
 	genesisBlockIdentifier *types.BlockIdentifier,
 	operationTypes []string,
@@ -169,9 +168,9 @@ func NewWithOptions(
 	return asserter, nil
 }
 
-// Configuration returns all variables currently set in an Asserter.
+// ClientConfiguration returns all variables currently set in an Asserter.
 // This function will error if it is called on an uninitialized asserter.
-func (a *Asserter) Configuration() (
+func (a *Asserter) ClientConfiguration() (
 	*types.NetworkIdentifier,
 	*types.BlockIdentifier,
 	[]string,

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -210,7 +210,7 @@ func TestNew(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(fmt.Sprintf("%s with responses", name), func(t *testing.T) {
-			asserter, err := NewWithResponses(
+			asserter, err := NewClientWithResponses(
 				test.network,
 				test.networkStatus,
 				test.networkOptions,
@@ -223,7 +223,7 @@ func TestNew(t *testing.T) {
 			}
 
 			assert.NotNil(t, asserter)
-			network, genesis, opTypes, opStatuses, errors, err := asserter.Configuration()
+			network, genesis, opTypes, opStatuses, errors, err := asserter.ClientConfiguration()
 			assert.NoError(t, err)
 			assert.Equal(t, test.network, network)
 			assert.Equal(t, test.networkStatus.GenesisBlockIdentifier, genesis)
@@ -251,7 +251,7 @@ func TestNew(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NoError(t, tmpfile.Close())
 
-			asserter, err := NewWithFile(
+			asserter, err := NewClientWithFile(
 				tmpfile.Name(),
 			)
 
@@ -262,7 +262,7 @@ func TestNew(t *testing.T) {
 			}
 
 			assert.NotNil(t, asserter)
-			network, genesis, opTypes, opStatuses, errors, err := asserter.Configuration()
+			network, genesis, opTypes, opStatuses, errors, err := asserter.ClientConfiguration()
 			assert.NoError(t, err)
 			assert.Equal(t, test.network, network)
 			assert.Equal(t, test.networkStatus.GenesisBlockIdentifier, genesis)

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -131,6 +131,10 @@ func TestNewWithResponses(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			asserter, err := NewWithResponses(
+				&types.NetworkIdentifier{
+					Blockchain: "hello",
+					Network:    "world",
+				},
 				test.networkStatus,
 				test.networkOptions,
 			)

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -271,4 +271,29 @@ func TestNew(t *testing.T) {
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, errors)
 		})
 	}
+
+	t.Run("non-existent file", func(t *testing.T) {
+		asserter, err := NewClientWithFile(
+			"blah",
+		)
+		assert.Error(t, err)
+		assert.Nil(t, asserter)
+	})
+
+	t.Run("file not formatted correctly", func(t *testing.T) {
+		tmpfile, err := ioutil.TempFile("", "test.json")
+		assert.NoError(t, err)
+		defer os.Remove(tmpfile.Name())
+
+		_, err = tmpfile.Write([]byte("blah"))
+		assert.NoError(t, err)
+		assert.NoError(t, tmpfile.Close())
+
+		asserter, err := NewClientWithFile(
+			tmpfile.Name(),
+		)
+
+		assert.Nil(t, asserter)
+		assert.Error(t, err)
+	})
 }

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -15,7 +15,6 @@
 package asserter
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -132,7 +131,6 @@ func TestNewWithResponses(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			asserter, err := NewWithResponses(
-				context.Background(),
 				test.networkStatus,
 				test.networkOptions,
 			)

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -43,7 +43,7 @@ func TestNew(t *testing.T) {
 				Index: 100,
 				Hash:  "block 100",
 			},
-			CurrentBlockTimestamp: 100,
+			CurrentBlockTimestamp: MinUnixEpoch + 1,
 			Peers: []*types.Peer{
 				{
 					PeerID: "peer 1",
@@ -56,7 +56,7 @@ func TestNew(t *testing.T) {
 				Index: 100,
 				Hash:  "block 100",
 			},
-			CurrentBlockTimestamp: 100,
+			CurrentBlockTimestamp: MinUnixEpoch + 1,
 			Peers: []*types.Peer{
 				{
 					PeerID: "peer 1",

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -25,11 +25,11 @@ import (
 const (
 	// MinUnixEpoch is the unix epoch time in milliseconds of
 	// 01/01/2000 at 12:00:00 AM.
-	MinUnixEpoch = int64(946713600000)
+	MinUnixEpoch = 946713600000
 
 	// MaxUnixEpoch is the unix epoch time in milliseconds of
 	// 01/01/2040 at 12:00:00 AM.
-	MaxUnixEpoch = int64(2209017600000)
+	MaxUnixEpoch = 2209017600000
 )
 
 // Amount ensures a types.Amount has an
@@ -262,11 +262,12 @@ func (a *Asserter) Transaction(
 // Timestamp returns an error if the timestamp
 // on a block is less than or equal to 0.
 func Timestamp(timestamp int64) error {
-	if timestamp < MinUnixEpoch {
+	switch {
+	case timestamp < MinUnixEpoch:
 		return fmt.Errorf("Timestamp %d is before 01/01/2000", timestamp)
-	} else if timestamp > MaxUnixEpoch {
+	case timestamp > MaxUnixEpoch:
 		return fmt.Errorf("Timestamp %d is after 01/01/2040", timestamp)
-	} else {
+	default:
 		return nil
 	}
 }

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -285,7 +285,7 @@ func (a *Asserter) Block(
 
 	// Only apply some assertions if the block index is not the
 	// genesis index.
-	if a.genesisIndex != block.BlockIdentifier.Index {
+	if a.genesisBlock.Index != block.BlockIdentifier.Index {
 		if block.BlockIdentifier.Hash == block.ParentBlockIdentifier.Hash {
 			return errors.New("BlockIdentifier.Hash == ParentBlockIdentifier.Hash")
 		}

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -384,6 +384,10 @@ func TestOperation(t *testing.T) {
 
 	for name, test := range tests {
 		asserter, err := NewWithResponses(
+			&types.NetworkIdentifier{
+				Blockchain: "hello",
+				Network:    "world",
+			},
 			&types.NetworkStatusResponse{
 				GenesisBlockIdentifier: &types.BlockIdentifier{
 					Index: 0,
@@ -554,6 +558,10 @@ func TestBlock(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			asserter, err := NewWithResponses(
+				&types.NetworkIdentifier{
+					Blockchain: "hello",
+					Network:    "world",
+				},
 				&types.NetworkStatusResponse{
 					GenesisBlockIdentifier: &types.BlockIdentifier{
 						Index: test.genesisIndex,

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -15,7 +15,6 @@
 package asserter
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -385,7 +384,6 @@ func TestOperation(t *testing.T) {
 
 	for name, test := range tests {
 		asserter, err := NewWithResponses(
-			context.Background(),
 			&types.NetworkStatusResponse{
 				GenesisBlockIdentifier: &types.BlockIdentifier{
 					Index: 0,
@@ -556,7 +554,6 @@ func TestBlock(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			asserter, err := NewWithResponses(
-				context.Background(),
 				&types.NetworkStatusResponse{
 					GenesisBlockIdentifier: &types.BlockIdentifier{
 						Index: test.genesisIndex,

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -383,7 +383,7 @@ func TestOperation(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		asserter, err := NewWithResponses(
+		asserter, err := NewClientWithResponses(
 			&types.NetworkIdentifier{
 				Blockchain: "hello",
 				Network:    "world",
@@ -565,7 +565,7 @@ func TestBlock(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			asserter, err := NewWithResponses(
+			asserter, err := NewClientWithResponses(
 				&types.NetworkIdentifier{
 					Blockchain: "hello",
 					Network:    "world",

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -397,7 +397,7 @@ func TestOperation(t *testing.T) {
 					Index: 100,
 					Hash:  "block 100",
 				},
-				CurrentBlockTimestamp: 100,
+				CurrentBlockTimestamp: MinUnixEpoch + 1,
 				Peers: []*types.Peer{
 					{
 						PeerID: "peer 1",
@@ -464,7 +464,7 @@ func TestBlock(t *testing.T) {
 			block: &types.Block{
 				BlockIdentifier:       validBlockIdentifier,
 				ParentBlockIdentifier: validParentBlockIdentifier,
-				Timestamp:             1,
+				Timestamp:             MinUnixEpoch + 1,
 				Transactions:          []*types.Transaction{validTransaction},
 			},
 			err: nil,
@@ -473,7 +473,6 @@ func TestBlock(t *testing.T) {
 			block: &types.Block{
 				BlockIdentifier:       validBlockIdentifier,
 				ParentBlockIdentifier: validBlockIdentifier,
-				Timestamp:             1,
 				Transactions:          []*types.Transaction{validTransaction},
 			},
 			genesisIndex: validBlockIdentifier.Index,
@@ -487,7 +486,7 @@ func TestBlock(t *testing.T) {
 			block: &types.Block{
 				BlockIdentifier:       nil,
 				ParentBlockIdentifier: validParentBlockIdentifier,
-				Timestamp:             1,
+				Timestamp:             MinUnixEpoch + 1,
 				Transactions:          []*types.Transaction{validTransaction},
 			},
 			err: errors.New("BlockIdentifier is nil"),
@@ -496,7 +495,7 @@ func TestBlock(t *testing.T) {
 			block: &types.Block{
 				BlockIdentifier:       &types.BlockIdentifier{},
 				ParentBlockIdentifier: validParentBlockIdentifier,
-				Timestamp:             1,
+				Timestamp:             MinUnixEpoch + 1,
 				Transactions:          []*types.Transaction{validTransaction},
 			},
 			err: errors.New("BlockIdentifier.Hash is missing"),
@@ -505,7 +504,7 @@ func TestBlock(t *testing.T) {
 			block: &types.Block{
 				BlockIdentifier:       validBlockIdentifier,
 				ParentBlockIdentifier: &types.BlockIdentifier{},
-				Timestamp:             1,
+				Timestamp:             MinUnixEpoch + 1,
 				Transactions:          []*types.Transaction{validTransaction},
 			},
 			err: errors.New("BlockIdentifier.Hash is missing"),
@@ -517,7 +516,7 @@ func TestBlock(t *testing.T) {
 					Hash:  validParentBlockIdentifier.Hash,
 					Index: validBlockIdentifier.Index,
 				},
-				Timestamp:    1,
+				Timestamp:    MinUnixEpoch + 1,
 				Transactions: []*types.Transaction{validTransaction},
 			},
 			err: errors.New("BlockIdentifier.Index <= ParentBlockIdentifier.Index"),
@@ -529,24 +528,33 @@ func TestBlock(t *testing.T) {
 					Hash:  validBlockIdentifier.Hash,
 					Index: validParentBlockIdentifier.Index,
 				},
-				Timestamp:    1,
+				Timestamp:    MinUnixEpoch + 1,
 				Transactions: []*types.Transaction{validTransaction},
 			},
 			err: errors.New("BlockIdentifier.Hash == ParentBlockIdentifier.Hash"),
 		},
-		"invalid block timestamp": {
+		"invalid block timestamp less than MinUnixEpoch": {
 			block: &types.Block{
 				BlockIdentifier:       validBlockIdentifier,
 				ParentBlockIdentifier: validParentBlockIdentifier,
 				Transactions:          []*types.Transaction{validTransaction},
 			},
-			err: errors.New("Timestamp is invalid 0"),
+			err: errors.New("Timestamp 0 is before 01/01/2000"),
+		},
+		"invalid block timestamp greater than MaxUnixEpoch": {
+			block: &types.Block{
+				BlockIdentifier:       validBlockIdentifier,
+				ParentBlockIdentifier: validParentBlockIdentifier,
+				Transactions:          []*types.Transaction{validTransaction},
+				Timestamp:             MaxUnixEpoch + 1,
+			},
+			err: errors.New("Timestamp 2209017600001 is after 01/01/2040"),
 		},
 		"invalid block transaction": {
 			block: &types.Block{
 				BlockIdentifier:       validBlockIdentifier,
 				ParentBlockIdentifier: validParentBlockIdentifier,
-				Timestamp:             1,
+				Timestamp:             MinUnixEpoch + 1,
 				Transactions: []*types.Transaction{
 					{},
 				},
@@ -571,7 +579,7 @@ func TestBlock(t *testing.T) {
 						Index: 100,
 						Hash:  "block 100",
 					},
-					CurrentBlockTimestamp: 100,
+					CurrentBlockTimestamp: MinUnixEpoch + 1,
 					Peers: []*types.Peer{
 						{
 							PeerID: "peer 1",

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -30,7 +30,7 @@ func TestConstructionMetadata(t *testing.T) {
 	}{
 		"valid response": {
 			response: &types.ConstructionMetadataResponse{
-				Metadata: &map[string]interface{}{},
+				Metadata: map[string]interface{}{},
 			},
 			err: nil,
 		},

--- a/asserter/request.go
+++ b/asserter/request.go
@@ -34,7 +34,7 @@ func SupportedNetworks(supportedNetworks []*types.NetworkIdentifier) error {
 			return err
 		}
 
-		if !containsNetworkIdentifier(parsed, network) {
+		if containsNetworkIdentifier(parsed, network) {
 			return fmt.Errorf("supported network duplicate %+v", *network)
 		}
 		parsed[i] = network
@@ -53,7 +53,7 @@ func (a *Asserter) SupportedNetwork(
 	}
 
 	if !containsNetworkIdentifier(a.supportedNetworks, requestNetwork) {
-		return fmt.Errorf("%+v is not supported", *requestNetwork)
+		return fmt.Errorf("%+v is not supported", requestNetwork)
 	}
 
 	return nil

--- a/asserter/request.go
+++ b/asserter/request.go
@@ -35,7 +35,7 @@ func SupportedNetworks(supportedNetworks []*types.NetworkIdentifier) error {
 		}
 
 		if containsNetworkIdentifier(parsed, network) {
-			return fmt.Errorf("supported network duplicate %+v", *network)
+			return fmt.Errorf("supported network duplicate %+v", network)
 		}
 		parsed[i] = network
 	}
@@ -210,6 +210,10 @@ func (a *Asserter) MempoolRequest(request *types.MempoolRequest) error {
 // MempoolTransactionRequest ensures that a types.MempoolTransactionRequest
 // is well-formatted.
 func (a *Asserter) MempoolTransactionRequest(request *types.MempoolTransactionRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("MempoolTransactionRequest is nil")
 	}

--- a/asserter/request.go
+++ b/asserter/request.go
@@ -16,18 +16,65 @@ package asserter
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
+// SupportedNetworks returns an error if there is an invalid
+// types.NetworkIdentifier or there is a duplicate.
+func SupportedNetworks(supportedNetworks []*types.NetworkIdentifier) error {
+	if len(supportedNetworks) == 0 {
+		return errors.New("no supported networks")
+	}
+
+	parsed := make([]*types.NetworkIdentifier, len(supportedNetworks))
+	for i, network := range supportedNetworks {
+		if err := NetworkIdentifier(network); err != nil {
+			return err
+		}
+
+		if !containsNetworkIdentifier(parsed, network) {
+			return fmt.Errorf("supported network duplicate %+v", *network)
+		}
+		parsed[i] = network
+	}
+
+	return nil
+}
+
+// SupportedNetwork returns a boolean indicating if the requestNetwork
+// is allowed. This should be called after the requestNetwork is asserted.
+func (a *Asserter) SupportedNetwork(
+	requestNetwork *types.NetworkIdentifier,
+) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
+	if !containsNetworkIdentifier(a.supportedNetworks, requestNetwork) {
+		return fmt.Errorf("%+v is not supported", *requestNetwork)
+	}
+
+	return nil
+}
+
 // AccountBalanceRequest ensures that a types.AccountBalanceRequest
 // is well-formatted.
-func AccountBalanceRequest(request *types.AccountBalanceRequest) error {
+func (a *Asserter) AccountBalanceRequest(request *types.AccountBalanceRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("AccountBalanceRequest is nil")
 	}
 
 	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -44,7 +91,11 @@ func AccountBalanceRequest(request *types.AccountBalanceRequest) error {
 
 // BlockRequest ensures that a types.BlockRequest
 // is well-formatted.
-func BlockRequest(request *types.BlockRequest) error {
+func (a *Asserter) BlockRequest(request *types.BlockRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("BlockRequest is nil")
 	}
@@ -53,17 +104,29 @@ func BlockRequest(request *types.BlockRequest) error {
 		return err
 	}
 
+	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
 	return PartialBlockIdentifier(request.BlockIdentifier)
 }
 
 // BlockTransactionRequest ensures that a types.BlockTransactionRequest
 // is well-formatted.
-func BlockTransactionRequest(request *types.BlockTransactionRequest) error {
+func (a *Asserter) BlockTransactionRequest(request *types.BlockTransactionRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("BlockTransactionRequest is nil")
 	}
 
 	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -76,12 +139,20 @@ func BlockTransactionRequest(request *types.BlockTransactionRequest) error {
 
 // ConstructionMetadataRequest ensures that a types.ConstructionMetadataRequest
 // is well-formatted.
-func ConstructionMetadataRequest(request *types.ConstructionMetadataRequest) error {
+func (a *Asserter) ConstructionMetadataRequest(request *types.ConstructionMetadataRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("ConstructionMetadataRequest is nil")
 	}
 
 	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -94,9 +165,21 @@ func ConstructionMetadataRequest(request *types.ConstructionMetadataRequest) err
 
 // ConstructionSubmitRequest ensures that a types.ConstructionSubmitRequest
 // is well-formatted.
-func ConstructionSubmitRequest(request *types.ConstructionSubmitRequest) error {
+func (a *Asserter) ConstructionSubmitRequest(request *types.ConstructionSubmitRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("ConstructionSubmitRequest is nil")
+	}
+
+	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
 	}
 
 	if request.SignedTransaction == "" {
@@ -108,17 +191,25 @@ func ConstructionSubmitRequest(request *types.ConstructionSubmitRequest) error {
 
 // MempoolRequest ensures that a types.MempoolRequest
 // is well-formatted.
-func MempoolRequest(request *types.MempoolRequest) error {
+func (a *Asserter) MempoolRequest(request *types.MempoolRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("MempoolRequest is nil")
 	}
 
-	return NetworkIdentifier(request.NetworkIdentifier)
+	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	return a.SupportedNetwork(request.NetworkIdentifier)
 }
 
 // MempoolTransactionRequest ensures that a types.MempoolTransactionRequest
 // is well-formatted.
-func MempoolTransactionRequest(request *types.MempoolTransactionRequest) error {
+func (a *Asserter) MempoolTransactionRequest(request *types.MempoolTransactionRequest) error {
 	if request == nil {
 		return errors.New("MempoolTransactionRequest is nil")
 	}
@@ -127,12 +218,20 @@ func MempoolTransactionRequest(request *types.MempoolTransactionRequest) error {
 		return err
 	}
 
+	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
 	return TransactionIdentifier(request.TransactionIdentifier)
 }
 
 // MetadataRequest ensures that a types.MetadataRequest
 // is well-formatted.
-func MetadataRequest(request *types.MetadataRequest) error {
+func (a *Asserter) MetadataRequest(request *types.MetadataRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("MetadataRequest is nil")
 	}
@@ -142,10 +241,18 @@ func MetadataRequest(request *types.MetadataRequest) error {
 
 // NetworkRequest ensures that a types.NetworkRequest
 // is well-formatted.
-func NetworkRequest(request *types.NetworkRequest) error {
+func (a *Asserter) NetworkRequest(request *types.NetworkRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
 	if request == nil {
 		return errors.New("NetworkRequest is nil")
 	}
 
-	return NetworkIdentifier(request.NetworkIdentifier)
+	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	return a.SupportedNetwork(request.NetworkIdentifier)
 }

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -16,6 +16,7 @@ package asserter
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -27,6 +28,11 @@ var (
 	validNetworkIdentifier = &types.NetworkIdentifier{
 		Blockchain: "Bitcoin",
 		Network:    "Mainnet",
+	}
+
+	wrongNetworkIdentifier = &types.NetworkIdentifier{
+		Blockchain: "Bitcoin",
+		Network:    "Testnet",
 	}
 
 	validAccountIdentifier = &types.AccountIdentifier{
@@ -60,6 +66,13 @@ func TestAccountBalanceRequest(t *testing.T) {
 				AccountIdentifier: validAccountIdentifier,
 			},
 			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.AccountBalanceRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+				AccountIdentifier: validAccountIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
 		},
 		"nil request": {
 			request: nil,
@@ -97,7 +110,11 @@ func TestAccountBalanceRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := AccountBalanceRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.AccountBalanceRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -123,6 +140,13 @@ func TestBlockRequest(t *testing.T) {
 				},
 			},
 			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.BlockRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+				BlockIdentifier:   validPartialBlockIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
 		},
 		"nil request": {
 			request: nil,
@@ -151,7 +175,11 @@ func TestBlockRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := BlockRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.BlockRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -169,6 +197,14 @@ func TestBlockTransactionRequest(t *testing.T) {
 				TransactionIdentifier: validTransactionIdentifier,
 			},
 			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.BlockTransactionRequest{
+				NetworkIdentifier:     wrongNetworkIdentifier,
+				BlockIdentifier:       validBlockIdentifier,
+				TransactionIdentifier: validTransactionIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
 		},
 		"nil request": {
 			request: nil,
@@ -199,7 +235,11 @@ func TestBlockTransactionRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := BlockTransactionRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.BlockTransactionRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -216,6 +256,13 @@ func TestConstructionMetadataRequest(t *testing.T) {
 				Options:           map[string]interface{}{},
 			},
 			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.ConstructionMetadataRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+				Options:           map[string]interface{}{},
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
 		},
 		"nil request": {
 			request: nil,
@@ -237,7 +284,11 @@ func TestConstructionMetadataRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := ConstructionMetadataRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.ConstructionMetadataRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -250,9 +301,17 @@ func TestConstructionSubmitRequest(t *testing.T) {
 	}{
 		"valid request": {
 			request: &types.ConstructionSubmitRequest{
+				NetworkIdentifier: validNetworkIdentifier,
 				SignedTransaction: "tx",
 			},
 			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.ConstructionSubmitRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+				SignedTransaction: "tx",
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
 		},
 		"nil request": {
 			request: nil,
@@ -260,13 +319,17 @@ func TestConstructionSubmitRequest(t *testing.T) {
 		},
 		"empty tx": {
 			request: &types.ConstructionSubmitRequest{},
-			err:     errors.New("ConstructionSubmitRequest.SignedTransaction is empty"),
+			err:     errors.New("NetworkIdentifier is nil"),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := ConstructionSubmitRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.ConstructionSubmitRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -283,6 +346,12 @@ func TestMempoolRequest(t *testing.T) {
 			},
 			err: nil,
 		},
+		"invalid request wrong network": {
+			request: &types.MempoolRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
+		},
 		"nil request": {
 			request: nil,
 			err:     errors.New("MempoolRequest is nil"),
@@ -295,7 +364,11 @@ func TestMempoolRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := MempoolRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.MempoolRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -312,6 +385,13 @@ func TestMempoolTransactionRequest(t *testing.T) {
 				TransactionIdentifier: validTransactionIdentifier,
 			},
 			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.MempoolTransactionRequest{
+				NetworkIdentifier:     wrongNetworkIdentifier,
+				TransactionIdentifier: validTransactionIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
 		},
 		"nil request": {
 			request: nil,
@@ -334,7 +414,11 @@ func TestMempoolTransactionRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := MempoolTransactionRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.MempoolTransactionRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -357,7 +441,11 @@ func TestMetadataRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := MetadataRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.MetadataRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -374,6 +462,12 @@ func TestNetworkRequest(t *testing.T) {
 			},
 			err: nil,
 		},
+		"invalid request wrong network": {
+			request: &types.NetworkRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
+		},
 		"nil request": {
 			request: nil,
 			err:     errors.New("NetworkRequest is nil"),
@@ -386,7 +480,11 @@ func TestNetworkRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := NetworkRequest(test.request)
+			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
+			assert.NoError(t, err)
+			assert.NotNil(t, a)
+
+			err = a.NetworkRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -213,7 +213,7 @@ func TestConstructionMetadataRequest(t *testing.T) {
 		"valid request": {
 			request: &types.ConstructionMetadataRequest{
 				NetworkIdentifier: validNetworkIdentifier,
-				Options:           &map[string]interface{}{},
+				Options:           map[string]interface{}{},
 			},
 			err: nil,
 		},
@@ -223,7 +223,7 @@ func TestConstructionMetadataRequest(t *testing.T) {
 		},
 		"missing network": {
 			request: &types.ConstructionMetadataRequest{
-				Options: &map[string]interface{}{},
+				Options: map[string]interface{}{},
 			},
 			err: errors.New("NetworkIdentifier is nil"),
 		},

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -55,6 +55,47 @@ var (
 	}
 )
 
+func TestSupportedNetworks(t *testing.T) {
+	var tests = map[string]struct {
+		networks []*types.NetworkIdentifier
+
+		err error
+	}{
+		"valid networks": {
+			networks: []*types.NetworkIdentifier{
+				validNetworkIdentifier,
+				wrongNetworkIdentifier,
+			},
+			err: nil,
+		},
+		"no valid networks": {
+			networks: []*types.NetworkIdentifier{},
+			err:      errors.New("no supported networks"),
+		},
+		"invalid network": {
+			networks: []*types.NetworkIdentifier{
+				{
+					Blockchain: "blah",
+				},
+			},
+			err: errors.New("NetworkIdentifier.Network is missing"),
+		},
+		"duplicate networks": {
+			networks: []*types.NetworkIdentifier{
+				validNetworkIdentifier,
+				validNetworkIdentifier,
+			},
+			err: fmt.Errorf("supported network duplicate %+v", validNetworkIdentifier),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.err, SupportedNetworks(test.networks))
+		})
+	}
+}
+
 func TestAccountBalanceRequest(t *testing.T) {
 	var tests = map[string]struct {
 		request *types.AccountBalanceRequest

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,7 +53,9 @@ done
 rm -rf tmp;
 
 # Generate client + types code
-docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}":/local openapitools/openapi-generator-cli generate \
+GENERATOR_VERSION='v4.3.0'
+docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}":/local \
+  openapitools/openapi-generator-cli:${GENERATOR_VERSION} generate \
   -i /local/templates/spec.json \
   -g go \
   -t /local/templates/client \
@@ -76,7 +78,8 @@ mv client_tmp/* client;
 rm -rf client_tmp;
 
 # Add server code
-docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}":/local openapitools/openapi-generator-cli generate \
+docker run --user "$(id -u):$(id -g)" --rm -v "${PWD}":/local \
+  openapitools/openapi-generator-cli:${GENERATOR_VERSION} generate \
   -i /local/templates/spec.json \
   -g go-server \
   -t /local/templates/server \

--- a/codegen.sh
+++ b/codegen.sh
@@ -118,6 +118,9 @@ sed "${SED_IFLAG[@]}" 's/<\/code>//g' client/* server/*;
 # Fix slice containing pointers
 sed "${SED_IFLAG[@]}" 's/\*\[\]/\[\]\*/g' client/* server/*;
 
+# Fix map pointers
+sed "${SED_IFLAG[@]}" 's/\*map/map/g' client/* server/*;
+
 # Move model files to types/
 mv client/model_*.go types/;
 for file in types/model_*.go; do

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -138,6 +138,7 @@ func main() {
 	// This will be used later to assert that a fetched block is
 	// valid.
 	asserter, err := asserter.NewWithResponses(
+		primaryNetwork,
 		networkStatus,
 		networkOptions,
 	)

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -137,7 +137,7 @@ func main() {
 	//
 	// This will be used later to assert that a fetched block is
 	// valid.
-	asserter, err := asserter.NewWithResponses(
+	asserter, err := asserter.NewClientWithResponses(
 		primaryNetwork,
 		networkStatus,
 		networkOptions,

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -138,7 +138,6 @@ func main() {
 	// This will be used later to assert that a fetched block is
 	// valid.
 	asserter, err := asserter.NewWithResponses(
-		ctx,
 		networkStatus,
 		networkOptions,
 	)

--- a/examples/fetcher/main.go
+++ b/examples/fetcher/main.go
@@ -33,7 +33,6 @@ func main() {
 
 	// Step 1: Create a new fetcher
 	newFetcher := fetcher.New(
-		ctx,
 		serverURL,
 	)
 

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -32,7 +32,7 @@ func (f *Fetcher) AccountBalance(
 	network *types.NetworkIdentifier,
 	account *types.AccountIdentifier,
 	block *types.PartialBlockIdentifier,
-) (*types.BlockIdentifier, []*types.Amount, *map[string]interface{}, error) {
+) (*types.BlockIdentifier, []*types.Amount, map[string]interface{}, error) {
 	response, _, err := f.rosettaClient.AccountAPI.AccountBalance(ctx,
 		&types.AccountBalanceRequest{
 			NetworkIdentifier: network,
@@ -65,7 +65,7 @@ func (f *Fetcher) AccountBalanceRetry(
 	network *types.NetworkIdentifier,
 	account *types.AccountIdentifier,
 	block *types.PartialBlockIdentifier,
-) (*types.BlockIdentifier, []*types.Amount, *map[string]interface{}, error) {
+) (*types.BlockIdentifier, []*types.Amount, map[string]interface{}, error) {
 	backoffRetries := backoffRetries(
 		f.retryElapsedTime,
 		f.maxRetries,

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -27,8 +27,8 @@ import (
 func (f *Fetcher) ConstructionMetadata(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
-	options *map[string]interface{},
-) (*map[string]interface{}, error) {
+	options map[string]interface{},
+) (map[string]interface{}, error) {
 	metadata, _, err := f.rosettaClient.ConstructionAPI.ConstructionMetadata(ctx,
 		&types.ConstructionMetadataRequest{
 			NetworkIdentifier: network,
@@ -52,7 +52,7 @@ func (f *Fetcher) ConstructionSubmit(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	signedTransaction string,
-) (*types.TransactionIdentifier, *map[string]interface{}, error) {
+) (*types.TransactionIdentifier, map[string]interface{}, error) {
 	submitResponse, _, err := f.rosettaClient.ConstructionAPI.ConstructionSubmit(
 		ctx,
 		&types.ConstructionSubmitRequest{

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -152,6 +152,7 @@ func (f *Fetcher) InitializeAsserter(
 	}
 
 	f.Asserter, err = asserter.NewWithResponses(
+		primaryNetwork,
 		networkStatus,
 		networkOptions,
 	)

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -70,7 +70,6 @@ type Fetcher struct {
 
 // New constructs a new Fetcher with provided options.
 func New(
-	ctx context.Context,
 	serverAddress string,
 	options ...Option,
 ) *Fetcher {
@@ -153,7 +152,6 @@ func (f *Fetcher) InitializeAsserter(
 	}
 
 	f.Asserter, err = asserter.NewWithResponses(
-		ctx,
 		networkStatus,
 		networkOptions,
 	)

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -151,7 +151,7 @@ func (f *Fetcher) InitializeAsserter(
 		return nil, nil, err
 	}
 
-	f.Asserter, err = asserter.NewWithResponses(
+	f.Asserter, err = asserter.NewClientWithResponses(
 		primaryNetwork,
 		networkStatus,
 		networkOptions,

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -52,7 +52,7 @@ func (f *Fetcher) MempoolTransaction(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	transaction *types.TransactionIdentifier,
-) (*types.Transaction, *map[string]interface{}, error) {
+) (*types.Transaction, map[string]interface{}, error) {
 	response, _, err := f.rosettaClient.MempoolAPI.MempoolTransaction(
 		ctx,
 		&types.MempoolTransactionRequest{

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -28,7 +28,7 @@ import (
 func (f *Fetcher) NetworkStatus(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
-	metadata *map[string]interface{},
+	metadata map[string]interface{},
 ) (*types.NetworkStatusResponse, error) {
 	networkStatus, _, err := f.rosettaClient.NetworkAPI.NetworkStatus(
 		ctx,
@@ -53,7 +53,7 @@ func (f *Fetcher) NetworkStatus(
 func (f *Fetcher) NetworkStatusRetry(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
-	metadata *map[string]interface{},
+	metadata map[string]interface{},
 ) (*types.NetworkStatusResponse, error) {
 	backoffRetries := backoffRetries(
 		f.retryElapsedTime,
@@ -82,7 +82,7 @@ func (f *Fetcher) NetworkStatusRetry(
 // from the NetworList method.
 func (f *Fetcher) NetworkList(
 	ctx context.Context,
-	metadata *map[string]interface{},
+	metadata map[string]interface{},
 ) (*types.NetworkListResponse, error) {
 	networkList, _, err := f.rosettaClient.NetworkAPI.NetworkList(
 		ctx,
@@ -105,7 +105,7 @@ func (f *Fetcher) NetworkList(
 // with a specified number of retries and max elapsed time.
 func (f *Fetcher) NetworkListRetry(
 	ctx context.Context,
-	metadata *map[string]interface{},
+	metadata map[string]interface{},
 ) (*types.NetworkListResponse, error) {
 	backoffRetries := backoffRetries(
 		f.retryElapsedTime,
@@ -134,7 +134,7 @@ func (f *Fetcher) NetworkListRetry(
 func (f *Fetcher) NetworkOptions(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
-	metadata *map[string]interface{},
+	metadata map[string]interface{},
 ) (*types.NetworkOptionsResponse, error) {
 	NetworkOptions, _, err := f.rosettaClient.NetworkAPI.NetworkOptions(
 		ctx,
@@ -159,7 +159,7 @@ func (f *Fetcher) NetworkOptions(
 func (f *Fetcher) NetworkOptionsRetry(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
-	metadata *map[string]interface{},
+	metadata map[string]interface{},
 ) (*types.NetworkOptionsResponse, error) {
 	backoffRetries := backoffRetries(
 		f.retryElapsedTime,

--- a/server/api_account.go
+++ b/server/api_account.go
@@ -28,12 +28,19 @@ import (
 // A AccountAPIController binds http requests to an api service and writes the service results to
 // the http response
 type AccountAPIController struct {
-	service AccountAPIServicer
+	service  AccountAPIServicer
+	asserter *asserter.Asserter
 }
 
 // NewAccountAPIController creates a default api controller
-func NewAccountAPIController(s AccountAPIServicer) Router {
-	return &AccountAPIController{service: s}
+func NewAccountAPIController(
+	s AccountAPIServicer,
+	asserter *asserter.Asserter,
+) Router {
+	return &AccountAPIController{
+		service:  s,
+		asserter: asserter,
+	}
 }
 
 // Routes returns all of the api route for the AccountAPIController
@@ -60,7 +67,7 @@ func (c *AccountAPIController) AccountBalance(w http.ResponseWriter, r *http.Req
 	}
 
 	// Assert that AccountBalanceRequest is correct
-	if err := asserter.AccountBalanceRequest(accountBalanceRequest); err != nil {
+	if err := c.asserter.AccountBalanceRequest(accountBalanceRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)

--- a/server/api_block.go
+++ b/server/api_block.go
@@ -28,12 +28,19 @@ import (
 // A BlockAPIController binds http requests to an api service and writes the service results to the
 // http response
 type BlockAPIController struct {
-	service BlockAPIServicer
+	service  BlockAPIServicer
+	asserter *asserter.Asserter
 }
 
 // NewBlockAPIController creates a default api controller
-func NewBlockAPIController(s BlockAPIServicer) Router {
-	return &BlockAPIController{service: s}
+func NewBlockAPIController(
+	s BlockAPIServicer,
+	asserter *asserter.Asserter,
+) Router {
+	return &BlockAPIController{
+		service:  s,
+		asserter: asserter,
+	}
 }
 
 // Routes returns all of the api route for the BlockAPIController
@@ -66,7 +73,7 @@ func (c *BlockAPIController) Block(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Assert that BlockRequest is correct
-	if err := asserter.BlockRequest(blockRequest); err != nil {
+	if err := c.asserter.BlockRequest(blockRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -96,7 +103,7 @@ func (c *BlockAPIController) BlockTransaction(w http.ResponseWriter, r *http.Req
 	}
 
 	// Assert that BlockTransactionRequest is correct
-	if err := asserter.BlockTransactionRequest(blockTransactionRequest); err != nil {
+	if err := c.asserter.BlockTransactionRequest(blockTransactionRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -28,12 +28,19 @@ import (
 // A ConstructionAPIController binds http requests to an api service and writes the service results
 // to the http response
 type ConstructionAPIController struct {
-	service ConstructionAPIServicer
+	service  ConstructionAPIServicer
+	asserter *asserter.Asserter
 }
 
 // NewConstructionAPIController creates a default api controller
-func NewConstructionAPIController(s ConstructionAPIServicer) Router {
-	return &ConstructionAPIController{service: s}
+func NewConstructionAPIController(
+	s ConstructionAPIServicer,
+	asserter *asserter.Asserter,
+) Router {
+	return &ConstructionAPIController{
+		service:  s,
+		asserter: asserter,
+	}
 }
 
 // Routes returns all of the api route for the ConstructionAPIController
@@ -66,7 +73,7 @@ func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, 
 	}
 
 	// Assert that ConstructionMetadataRequest is correct
-	if err := asserter.ConstructionMetadataRequest(constructionMetadataRequest); err != nil {
+	if err := c.asserter.ConstructionMetadataRequest(constructionMetadataRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -96,7 +103,7 @@ func (c *ConstructionAPIController) ConstructionSubmit(w http.ResponseWriter, r 
 	}
 
 	// Assert that ConstructionSubmitRequest is correct
-	if err := asserter.ConstructionSubmitRequest(constructionSubmitRequest); err != nil {
+	if err := c.asserter.ConstructionSubmitRequest(constructionSubmitRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -28,12 +28,19 @@ import (
 // A MempoolAPIController binds http requests to an api service and writes the service results to
 // the http response
 type MempoolAPIController struct {
-	service MempoolAPIServicer
+	service  MempoolAPIServicer
+	asserter *asserter.Asserter
 }
 
 // NewMempoolAPIController creates a default api controller
-func NewMempoolAPIController(s MempoolAPIServicer) Router {
-	return &MempoolAPIController{service: s}
+func NewMempoolAPIController(
+	s MempoolAPIServicer,
+	asserter *asserter.Asserter,
+) Router {
+	return &MempoolAPIController{
+		service:  s,
+		asserter: asserter,
+	}
 }
 
 // Routes returns all of the api route for the MempoolAPIController
@@ -66,7 +73,7 @@ func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Assert that MempoolRequest is correct
-	if err := asserter.MempoolRequest(mempoolRequest); err != nil {
+	if err := c.asserter.MempoolRequest(mempoolRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -96,7 +103,7 @@ func (c *MempoolAPIController) MempoolTransaction(w http.ResponseWriter, r *http
 	}
 
 	// Assert that MempoolTransactionRequest is correct
-	if err := asserter.MempoolTransactionRequest(mempoolTransactionRequest); err != nil {
+	if err := c.asserter.MempoolTransactionRequest(mempoolTransactionRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)

--- a/server/api_network.go
+++ b/server/api_network.go
@@ -28,12 +28,19 @@ import (
 // A NetworkAPIController binds http requests to an api service and writes the service results to
 // the http response
 type NetworkAPIController struct {
-	service NetworkAPIServicer
+	service  NetworkAPIServicer
+	asserter *asserter.Asserter
 }
 
 // NewNetworkAPIController creates a default api controller
-func NewNetworkAPIController(s NetworkAPIServicer) Router {
-	return &NetworkAPIController{service: s}
+func NewNetworkAPIController(
+	s NetworkAPIServicer,
+	asserter *asserter.Asserter,
+) Router {
+	return &NetworkAPIController{
+		service:  s,
+		asserter: asserter,
+	}
 }
 
 // Routes returns all of the api route for the NetworkAPIController
@@ -72,7 +79,7 @@ func (c *NetworkAPIController) NetworkList(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Assert that MetadataRequest is correct
-	if err := asserter.MetadataRequest(metadataRequest); err != nil {
+	if err := c.asserter.MetadataRequest(metadataRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -102,7 +109,7 @@ func (c *NetworkAPIController) NetworkOptions(w http.ResponseWriter, r *http.Req
 	}
 
 	// Assert that NetworkRequest is correct
-	if err := asserter.NetworkRequest(networkRequest); err != nil {
+	if err := c.asserter.NetworkRequest(networkRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -132,7 +139,7 @@ func (c *NetworkAPIController) NetworkStatus(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Assert that NetworkRequest is correct
-	if err := asserter.NetworkRequest(networkRequest); err != nil {
+	if err := c.asserter.NetworkRequest(networkRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)

--- a/templates/server/controller-api.mustache
+++ b/templates/server/controller-api.mustache
@@ -13,11 +13,18 @@ import (
 // A {{classname}}Controller binds http requests to an api service and writes the service results to the http response
 type {{classname}}Controller struct {
 	service {{classname}}Servicer
+  asserter *asserter.Asserter
 }
 
 // New{{classname}}Controller creates a default api controller
-func New{{classname}}Controller(s {{classname}}Servicer) Router {
-	return &{{classname}}Controller{ service: s }
+func New{{classname}}Controller(
+  s {{classname}}Servicer,
+  asserter *asserter.Asserter,
+) Router {
+	return &{{classname}}Controller{
+    service: s,
+    asserter: asserter,
+  }
 }
 
 // Routes returns all of the api route for the {{classname}}Controller
@@ -45,7 +52,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	}
 
   // Assert that {{dataType}} is correct
-  if err := asserter.{{dataType}}({{paramName}}); err != nil {
+  if err := c.asserter.{{dataType}}({{paramName}}); err != nil {
     EncodeJSONResponse(&types.Error{
       Message: err.Error(),
     }, http.StatusInternalServerError, w)

--- a/types/account_balance_response.go
+++ b/types/account_balance_response.go
@@ -26,5 +26,5 @@ type AccountBalanceResponse struct {
 	// Account-based blockchains that utilize a nonce or sequence number should include that number
 	// in the metadata. This number could be unique to the identifier or global across the account
 	// address.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/account_identifier.go
+++ b/types/account_identifier.go
@@ -26,5 +26,5 @@ type AccountIdentifier struct {
 	SubAccount *SubAccountIdentifier `json:"sub_account,omitempty"`
 	// Blockchains that utilize a username model (where the address is not a derivative of a
 	// cryptographic public key) should specify the public key(s) owned by the address in metadata.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/amount.go
+++ b/types/amount.go
@@ -21,7 +21,7 @@ package types
 type Amount struct {
 	// Value of the transaction in atomic units represented as an arbitrary-sized signed integer.
 	// For example, 1 BTC would be represented by a value of 100000000.
-	Value    string                  `json:"value"`
-	Currency *Currency               `json:"currency"`
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Value    string                 `json:"value"`
+	Currency *Currency              `json:"currency"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/block.go
+++ b/types/block.go
@@ -22,7 +22,7 @@ type Block struct {
 	ParentBlockIdentifier *BlockIdentifier `json:"parent_block_identifier"`
 	// The timestamp of the block in milliseconds since the Unix Epoch. The timestamp is stored in
 	// milliseconds because some blockchains produce blocks more often than once a second.
-	Timestamp    int64                   `json:"timestamp"`
-	Transactions []*Transaction          `json:"transactions"`
-	Metadata     *map[string]interface{} `json:"metadata,omitempty"`
+	Timestamp    int64                  `json:"timestamp"`
+	Transactions []*Transaction         `json:"transactions"`
+	Metadata     map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/construction_metadata_request.go
+++ b/types/construction_metadata_request.go
@@ -26,5 +26,5 @@ type ConstructionMetadataRequest struct {
 	// possible types of metadata for construction (which may require multiple node fetches), the
 	// client can populate an options object to limit the metadata returned to only the subset
 	// required.
-	Options *map[string]interface{} `json:"options"`
+	Options map[string]interface{} `json:"options"`
 }

--- a/types/construction_metadata_response.go
+++ b/types/construction_metadata_response.go
@@ -20,5 +20,5 @@ package types
 // used for transaction construction. It is likely that the client will not inspect this metadata
 // before passing it to a client SDK that uses it for construction.
 type ConstructionMetadataResponse struct {
-	Metadata *map[string]interface{} `json:"metadata"`
+	Metadata map[string]interface{} `json:"metadata"`
 }

--- a/types/construction_submit_response.go
+++ b/types/construction_submit_response.go
@@ -19,6 +19,6 @@ package types
 // ConstructionSubmitResponse A TransactionSubmitResponse contains the transaction_identifier of a
 // submitted transaction that was accepted into the mempool.
 type ConstructionSubmitResponse struct {
-	TransactionIdentifier *TransactionIdentifier  `json:"transaction_identifier"`
-	Metadata              *map[string]interface{} `json:"metadata,omitempty"`
+	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
+	Metadata              map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/currency.go
+++ b/types/currency.go
@@ -27,5 +27,5 @@ type Currency struct {
 	Decimals int32 `json:"decimals"`
 	// Any additional information related to the currency itself.  For example, it would be useful
 	// to populate this object with the contract address of an ERC-20 token.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/mempool_transaction_response.go
+++ b/types/mempool_transaction_response.go
@@ -20,6 +20,6 @@ package types
 // transaction. It may not be possible to know the full impact of a transaction in the mempool (ex:
 // fee paid).
 type MempoolTransactionResponse struct {
-	Transaction *Transaction            `json:"transaction"`
-	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+	Transaction *Transaction           `json:"transaction"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/metadata_request.go
+++ b/types/metadata_request.go
@@ -19,5 +19,5 @@ package types
 // MetadataRequest A MetadataRequest is utilized in any request where the only argument is optional
 // metadata.
 type MetadataRequest struct {
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/network_request.go
+++ b/types/network_request.go
@@ -19,6 +19,6 @@ package types
 // NetworkRequest A NetworkRequest is utilized to retrieve some data specific exclusively to a
 // NetworkIdentifier.
 type NetworkRequest struct {
-	NetworkIdentifier *NetworkIdentifier      `json:"network_identifier"`
-	Metadata          *map[string]interface{} `json:"metadata,omitempty"`
+	NetworkIdentifier *NetworkIdentifier     `json:"network_identifier"`
+	Metadata          map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/operation.go
+++ b/types/operation.go
@@ -34,8 +34,8 @@ type Operation struct {
 	// because blockchains with smart contracts may have transactions that partially apply.
 	// Blockchains with atomic transactions (all operations succeed or all operations fail) will
 	// have the same status for each operation.
-	Status   string                  `json:"status"`
-	Account  *AccountIdentifier      `json:"account,omitempty"`
-	Amount   *Amount                 `json:"amount,omitempty"`
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Status   string                 `json:"status"`
+	Account  *AccountIdentifier     `json:"account,omitempty"`
+	Amount   *Amount                `json:"amount,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/peer.go
+++ b/types/peer.go
@@ -18,6 +18,6 @@ package types
 
 // Peer A Peer is a representation of a node's peer.
 type Peer struct {
-	PeerID   string                  `json:"peer_id"`
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	PeerID   string                 `json:"peer_id"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/sub_account_identifier.go
+++ b/types/sub_account_identifier.go
@@ -26,5 +26,5 @@ type SubAccountIdentifier struct {
 	// If the SubAccount address is not sufficient to uniquely specify a SubAccount, any other
 	// identifying information can be stored here.  It is important to note that two SubAccounts
 	// with identical addresses but differing metadata will not be considered equal by clients.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/sub_network_identifier.go
+++ b/types/sub_network_identifier.go
@@ -20,6 +20,6 @@ package types
 // query some object on a specific shard. This identifier is optional for all non-sharded
 // blockchains.
 type SubNetworkIdentifier struct {
-	Network  string                  `json:"network"`
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Network  string                 `json:"network"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -23,5 +23,5 @@ type Transaction struct {
 	Operations            []*Operation           `json:"operations"`
 	// Transactions that are related to other transactions (like a cross-shard transactioin) should
 	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/version.go
+++ b/types/version.go
@@ -30,5 +30,5 @@ type Version struct {
 	MiddlewareVersion *string `json:"middleware_version,omitempty"`
 	// Any other information that may be useful about versioning of dependent services should be
 	// returned here.
-	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }


### PR DESCRIPTION
### Motivation
In production deployments, it may be preferable to create an asserter from a set spec file instead of creating it dynamically from the node.

### Solution
Add support for creating an asserter from a file.

### Fixes
* Assert timestamp is in range 1/1/2000 - 1/1/2040 (except on genesis)
* Assert network on request is supported