### PR TITLE
Make ExemptOperation public

### DIFF
--- a/parser/balance_changes.go
+++ b/parser/balance_changes.go
@@ -31,10 +31,10 @@ type BalanceChange struct {
 	Difference string                   `json:"difference,omitempty"`
 }
 
-// exemptOperation is a function that returns a boolean indicating
+// ExemptOperation is a function that returns a boolean indicating
 // if the operation should be skipped eventhough it passes other
 // checks indiciating it should be considered a balance change.
-type exemptOperation func(*types.Operation) bool
+type ExemptOperation func(*types.Operation) bool
 
 // skipOperation returns a boolean indicating whether
 // an operation should be processed. An operation will

--- a/parser/balance_changes_test.go
+++ b/parser/balance_changes_test.go
@@ -106,7 +106,7 @@ func TestBalanceChanges(t *testing.T) {
 		orphan        bool
 		changes       []*BalanceChange
 		allowedStatus []*types.OperationStatus
-		exemptFunc    exemptOperation
+		exemptFunc    ExemptOperation
 		err           error
 	}{
 		"simple block": {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -21,11 +21,11 @@ import (
 // Parser provides support for parsing Rosetta blocks.
 type Parser struct {
 	Asserter   *asserter.Asserter
-	ExemptFunc exemptOperation
+	ExemptFunc ExemptOperation
 }
 
 // New creates a new Parser.
-func New(asserter *asserter.Asserter, exemptFunc exemptOperation) *Parser {
+func New(asserter *asserter.Asserter, exemptFunc ExemptOperation) *Parser {
 	return &Parser{
 		Asserter:   asserter,
 		ExemptFunc: exemptFunc,


### PR DESCRIPTION
Fast follow to #21 to make the `ExemptOperation` type public.
