### PR TITLE
Track OperationGroup Currencies

### DIFF
--- a/asserter/account.go
+++ b/asserter/account.go
@@ -20,12 +20,12 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-// containsCurrency returns a boolean indicating if a
+// ContainsCurrency returns a boolean indicating if a
 // *types.Currency is contained within a slice of
 // *types.Currency. The check for equality takes
 // into account everything within the types.Currency
 // struct (including currency.Metadata).
-func containsCurrency(currencies []*types.Currency, currency *types.Currency) bool {
+func ContainsCurrency(currencies []*types.Currency, currency *types.Currency) bool {
 	for _, curr := range currencies {
 		if types.Hash(curr) == types.Hash(currency) {
 			return true
@@ -44,7 +44,7 @@ func assertBalanceAmounts(amounts []*types.Amount) error {
 	currencies := make([]*types.Currency, 0)
 	for _, amount := range amounts {
 		// Ensure a currency is used at most once in balance.Amounts
-		if containsCurrency(currencies, amount.Currency) {
+		if ContainsCurrency(currencies, amount.Currency) {
 			return fmt.Errorf("currency %+v used in balance multiple times", amount.Currency)
 		}
 		currencies = append(currencies, amount.Currency)

--- a/asserter/account_test.go
+++ b/asserter/account_test.go
@@ -126,7 +126,7 @@ func TestContainsCurrency(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			exists := containsCurrency(test.currencies, test.currency)
+			exists := ContainsCurrency(test.currencies, test.currency)
 			assert.Equal(t, test.contains, exists)
 		})
 	}

--- a/parser/group_operations.go
+++ b/parser/group_operations.go
@@ -23,10 +23,10 @@ import (
 // If all operations in a group have the same operation.Type,
 // the Type is also populated.
 type OperationGroup struct {
-	Type               string
-	Operations         []*types.Operation
-	Currencies         []*types.Currency
-	NilCurrencyPresent bool
+	Type             string
+	Operations       []*types.Operation
+	Currencies       []*types.Currency
+	NilAmountPresent bool
 }
 
 func containsInt(valid []int, value int) bool {
@@ -56,7 +56,7 @@ func addOperationToGroup(
 
 	// Handle nil currency
 	if op.Amount == nil {
-		destination.NilCurrencyPresent = true
+		destination.NilAmountPresent = true
 		return
 	}
 
@@ -88,7 +88,7 @@ func GroupOperations(transaction *types.Transaction) []*OperationGroup {
 				opGroups[key].Currencies = []*types.Currency{op.Amount.Currency}
 			} else {
 				opGroups[key].Currencies = []*types.Currency{}
-				opGroups[key].NilCurrencyPresent = true
+				opGroups[key].NilAmountPresent = true
 			}
 
 			opAssignments[i] = key

--- a/parser/group_operations_test.go
+++ b/parser/group_operations_test.go
@@ -39,6 +39,11 @@ func TestGroupOperations(t *testing.T) {
 							Index: 0,
 						},
 						Type: "op 0",
+						Amount: &types.Amount{
+							Currency: &types.Currency{
+								Symbol: "BTC",
+							},
+						},
 					},
 					{
 						OperationIdentifier: &types.OperationIdentifier{
@@ -63,11 +68,22 @@ func TestGroupOperations(t *testing.T) {
 								Index: 0,
 							},
 							Type: "op 0",
+							Amount: &types.Amount{
+								Currency: &types.Currency{
+									Symbol: "BTC",
+								},
+							},
+						},
+					},
+					Currencies: []*types.Currency{
+						{
+							Symbol: "BTC",
 						},
 					},
 				},
 				{
-					Type: "op 1",
+					Type:               "op 1",
+					NilCurrencyPresent: true,
 					Operations: []*types.Operation{
 						{
 							OperationIdentifier: &types.OperationIdentifier{
@@ -76,9 +92,11 @@ func TestGroupOperations(t *testing.T) {
 							Type: "op 1",
 						},
 					},
+					Currencies: []*types.Currency{},
 				},
 				{
-					Type: "op 2",
+					Type:               "op 2",
+					NilCurrencyPresent: true,
 					Operations: []*types.Operation{
 						{
 							OperationIdentifier: &types.OperationIdentifier{
@@ -87,6 +105,7 @@ func TestGroupOperations(t *testing.T) {
 							Type: "op 2",
 						},
 					},
+					Currencies: []*types.Currency{},
 				},
 			},
 		},
@@ -98,6 +117,11 @@ func TestGroupOperations(t *testing.T) {
 							Index: 0,
 						},
 						Type: "type 0",
+						Amount: &types.Amount{
+							Currency: &types.Currency{
+								Symbol: "BTC",
+							},
+						},
 					},
 					{
 						OperationIdentifier: &types.OperationIdentifier{
@@ -110,6 +134,11 @@ func TestGroupOperations(t *testing.T) {
 							Index: 2,
 						},
 						Type: "type 2",
+						Amount: &types.Amount{
+							Currency: &types.Currency{
+								Symbol: "BTC",
+							},
+						},
 					},
 					{
 						OperationIdentifier: &types.OperationIdentifier{
@@ -119,6 +148,11 @@ func TestGroupOperations(t *testing.T) {
 							{Index: 2},
 						},
 						Type: "type 2",
+						Amount: &types.Amount{
+							Currency: &types.Currency{
+								Symbol: "ETH",
+							},
+						},
 					},
 					{
 						OperationIdentifier: &types.OperationIdentifier{
@@ -137,6 +171,11 @@ func TestGroupOperations(t *testing.T) {
 							{Index: 0},
 						},
 						Type: "type 0",
+						Amount: &types.Amount{
+							Currency: &types.Currency{
+								Symbol: "BTC",
+							},
+						},
 					},
 				},
 			},
@@ -149,6 +188,11 @@ func TestGroupOperations(t *testing.T) {
 								Index: 0,
 							},
 							Type: "type 0",
+							Amount: &types.Amount{
+								Currency: &types.Currency{
+									Symbol: "BTC",
+								},
+							},
 						},
 						{
 							OperationIdentifier: &types.OperationIdentifier{
@@ -158,11 +202,22 @@ func TestGroupOperations(t *testing.T) {
 								{Index: 0},
 							},
 							Type: "type 0",
+							Amount: &types.Amount{
+								Currency: &types.Currency{
+									Symbol: "BTC",
+								},
+							},
+						},
+					},
+					Currencies: []*types.Currency{
+						{
+							Symbol: "BTC",
 						},
 					},
 				},
 				{
-					Type: "type 1",
+					Type:               "type 1",
+					NilCurrencyPresent: true,
 					Operations: []*types.Operation{
 						{
 							OperationIdentifier: &types.OperationIdentifier{
@@ -171,15 +226,30 @@ func TestGroupOperations(t *testing.T) {
 							Type: "type 1",
 						},
 					},
+					Currencies: []*types.Currency{},
 				},
 				{
-					Type: "",
+					Type:               "",
+					NilCurrencyPresent: true,
+					Currencies: []*types.Currency{
+						{
+							Symbol: "BTC",
+						},
+						{
+							Symbol: "ETH",
+						},
+					},
 					Operations: []*types.Operation{
 						{
 							OperationIdentifier: &types.OperationIdentifier{
 								Index: 2,
 							},
 							Type: "type 2",
+							Amount: &types.Amount{
+								Currency: &types.Currency{
+									Symbol: "BTC",
+								},
+							},
 						},
 						{
 							OperationIdentifier: &types.OperationIdentifier{
@@ -189,6 +259,11 @@ func TestGroupOperations(t *testing.T) {
 								{Index: 2},
 							},
 							Type: "type 2",
+							Amount: &types.Amount{
+								Currency: &types.Currency{
+									Symbol: "ETH",
+								},
+							},
 						},
 						{
 							OperationIdentifier: &types.OperationIdentifier{

--- a/parser/group_operations_test.go
+++ b/parser/group_operations_test.go
@@ -82,8 +82,8 @@ func TestGroupOperations(t *testing.T) {
 					},
 				},
 				{
-					Type:               "op 1",
-					NilCurrencyPresent: true,
+					Type:             "op 1",
+					NilAmountPresent: true,
 					Operations: []*types.Operation{
 						{
 							OperationIdentifier: &types.OperationIdentifier{
@@ -95,8 +95,8 @@ func TestGroupOperations(t *testing.T) {
 					Currencies: []*types.Currency{},
 				},
 				{
-					Type:               "op 2",
-					NilCurrencyPresent: true,
+					Type:             "op 2",
+					NilAmountPresent: true,
 					Operations: []*types.Operation{
 						{
 							OperationIdentifier: &types.OperationIdentifier{
@@ -216,8 +216,8 @@ func TestGroupOperations(t *testing.T) {
 					},
 				},
 				{
-					Type:               "type 1",
-					NilCurrencyPresent: true,
+					Type:             "type 1",
+					NilAmountPresent: true,
 					Operations: []*types.Operation{
 						{
 							OperationIdentifier: &types.OperationIdentifier{
@@ -229,8 +229,8 @@ func TestGroupOperations(t *testing.T) {
 					Currencies: []*types.Currency{},
 				},
 				{
-					Type:               "",
-					NilCurrencyPresent: true,
+					Type:             "",
+					NilAmountPresent: true,
 					Currencies: []*types.Currency{
 						{
 							Symbol: "BTC",


### PR DESCRIPTION
### Motivation
When parsing an `OperationGroup` it is often useful to know which currencies were present and if there were any operations with `op.Amount == nil`.

### Solution
`OperationGroup` now has a slice of `*types.Currency` that contains all currencies present in an `OperationGroup` and a boolean indicating if any operation has a `nil` Amount.

