### PR TITLE
Sort OperationGroup Results

### DIFF
--- a/parser/group_operations.go
+++ b/parser/group_operations.go
@@ -41,6 +41,7 @@ func containsInt(valid []int, value int) bool {
 	return false
 }
 
+// addOperationToGroup appends a *types.Operation to an *OperationGroup.
 func addOperationToGroup(
 	destination *OperationGroup,
 	destinationIndex int,
@@ -68,6 +69,11 @@ func addOperationToGroup(
 	}
 }
 
+// sortOperationGroups returns a slice of OperationGroups sorted by the lowest
+// OperationIdentifier.Index in each group. This function also sorts all
+// operations in each OperationGroup by OperationIdentifier.Index. It can be
+// useful to consumers to have a deterministic ordering of groups and ops within
+// each group.
 func sortOperationGroups(opLen int, opGroups map[int]*OperationGroup) []*OperationGroup {
 	sliceGroups := []*OperationGroup{}
 
@@ -91,13 +97,15 @@ func sortOperationGroups(opLen int, opGroups map[int]*OperationGroup) []*Operati
 }
 
 // GroupOperations parses all of a transaction's opertations and returns a slice
-// of each group of related operations. This should ONLY be called on operations
-// that have already been asserted for correctness. Assertion ensures there are
-// no duplicate operation indexes, operations are sorted, and that operations
-// only reference operations with an index less than theirs.
+// of each group of related operations (assuming transitive relatedness). This
+// should ONLY be called on operations that have already been asserted for
+// correctness. Assertion ensures there are no duplicate operation indexes,
+// operations are sorted, and that operations only reference operations with
+// an index less than theirs.
 //
 // OperationGroups are returned in ascending order based on the lowest
-// operation index in the group.
+// OperationIdentifier.Index in the group. The operations in each OperationGroup
+// are also sorted.
 func GroupOperations(transaction *types.Transaction) []*OperationGroup {
 	ops := transaction.Operations
 	opGroups := map[int]*OperationGroup{} // using a map makes group merges much easier

--- a/parser/group_operations.go
+++ b/parser/group_operations.go
@@ -108,7 +108,16 @@ func sortOperationGroups(opLen int, opGroups map[int]*OperationGroup) []*Operati
 // are also sorted.
 func GroupOperations(transaction *types.Transaction) []*OperationGroup {
 	ops := transaction.Operations
-	opGroups := map[int]*OperationGroup{} // using a map makes group merges much easier
+
+	// We use a map of ints to keep track of *OperationGroup instead of a slice
+	// because merging groups involves removing and combing many items. While we
+	// could manipulate a slice (leaving holes where groups were merged), it
+	// seemed less complex to manipulate a map.
+	//
+	// Nonetheless, either solution avoids modifying up to `n` opAssignments
+	// whenever 2 groups merge (this occurs when merging groups in a slice without
+	// leaving holes).
+	opGroups := map[int]*OperationGroup{}
 	opAssignments := make([]int, len(ops))
 	for i, op := range ops {
 		// Create new group

--- a/parser/group_operations_test.go
+++ b/parser/group_operations_test.go
@@ -22,6 +22,71 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSortOperationGroups(t *testing.T) {
+	m := map[int]*OperationGroup{
+		2: {
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 2,
+					},
+				},
+			},
+		},
+		0: {
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 1,
+					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: 0,
+						},
+					},
+				},
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 0,
+					},
+				},
+			},
+		},
+	}
+
+	sortedGroups := sortOperationGroups(3, m)
+	assert.Equal(t, []*OperationGroup{
+		{
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 0,
+					},
+				},
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 1,
+					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: 0,
+						},
+					},
+				},
+			},
+		},
+		{
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 2,
+					},
+				},
+			},
+		},
+	}, sortedGroups)
+}
+
 func TestGroupOperations(t *testing.T) {
 	var tests = map[string]struct {
 		transaction *types.Transaction

--- a/parser/group_operations_test.go
+++ b/parser/group_operations_test.go
@@ -33,6 +33,15 @@ func TestSortOperationGroups(t *testing.T) {
 				},
 			},
 		},
+		4: {
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 4,
+					},
+				},
+			},
+		},
 		0: {
 			Operations: []*types.Operation{
 				{
@@ -47,14 +56,33 @@ func TestSortOperationGroups(t *testing.T) {
 				},
 				{
 					OperationIdentifier: &types.OperationIdentifier{
+						Index: 3,
+					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: 1,
+						},
+					},
+				},
+				{
+					OperationIdentifier: &types.OperationIdentifier{
 						Index: 0,
+					},
+				},
+			},
+		},
+		5: {
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 5,
 					},
 				},
 			},
 		},
 	}
 
-	sortedGroups := sortOperationGroups(3, m)
+	sortedGroups := sortOperationGroups(6, m)
 	assert.Equal(t, []*OperationGroup{
 		{
 			Operations: []*types.Operation{
@@ -73,6 +101,16 @@ func TestSortOperationGroups(t *testing.T) {
 						},
 					},
 				},
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 3,
+					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: 1,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -80,6 +118,24 @@ func TestSortOperationGroups(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: 2,
+					},
+				},
+			},
+		},
+		{
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 4,
+					},
+				},
+			},
+		},
+		{
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: 5,
 					},
 				},
 			},


### PR DESCRIPTION
### Motivation
It can be very useful for clients to receive a **deterministic ordering** of `OperationGroups` and `Operations` within an `OperationGroup` when calling `GroupOperations`.

### Solution
Sort all `OperationGroups` in a transaction by the lowest `OperationIdentifier.Index` in each group. Then, sort all `Operations` in an `OperationGroup` by `OperationIdentifier.Index`, ascending.
