### PR TITLE
Initialize Reconciler with Previously Seen Addresses

### DIFF
--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reconciler
 
 import (

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -1,0 +1,62 @@
+package reconciler
+
+import (
+	"fmt"
+
+	"github.com/coinbase/rosetta-sdk-go/parser"
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+// Option is used to overwrite default values in
+// Reconciler construction. Any Option not provided
+// falls back to the default value.
+type Option func(r *Reconciler)
+
+// WithReconcilerConcurrency overrides the default reconciler
+// concurrency.
+func WithReconcilerConcurrency(concurrency int) Option {
+	return func(r *Reconciler) {
+		r.reconcilerConcurrency = concurrency
+	}
+}
+
+// WithInterestingAccounts adds interesting accounts
+// to check at each block.
+func WithInterestingAccounts(interesting []*AccountCurrency) Option {
+	return func(r *Reconciler) {
+		r.interestingAccounts = interesting
+	}
+}
+
+// WithSeenAccounts adds accounts to the seenAccounts
+// slice and inactiveQueue for inactive reconciliation.
+func WithSeenAccounts(seen []*AccountCurrency) Option {
+	return func(r *Reconciler) {
+		for _, acct := range seen {
+			// When block is not set, it is assumed that the account should
+			// be checked as soon as possible.
+			r.inactiveQueue = append(r.inactiveQueue, &InactiveEntry{
+				accountCurrency: acct,
+			})
+			r.seenAccounts = append(r.seenAccounts, acct)
+			fmt.Printf("Adding to inactive queue: %s\n", types.PrettyPrintStruct(acct))
+		}
+	}
+}
+
+// WithLookupBalanceByBlock sets lookupBlockByBalance
+// and instantiates the correct changeQueue.
+func WithLookupBalanceByBlock(lookup bool) Option {
+	return func(r *Reconciler) {
+		// When lookupBalanceByBlock is disabled, we must check
+		// balance changes asynchronously. Using a buffered
+		// channel allows us to add balance changes without blocking.
+		if !lookup {
+			r.changeQueue = make(chan *parser.BalanceChange, backlogThreshold)
+		}
+
+		// We don't do anything if lookup == true because the default
+		// is already to create a non-buffered channel.
+		r.lookupBalanceByBlock = lookup
+	}
+}

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -50,7 +50,7 @@ func WithSeenAccounts(seen []*AccountCurrency) Option {
 			// When block is not set, it is assumed that the account should
 			// be checked as soon as possible.
 			r.inactiveQueue = append(r.inactiveQueue, &InactiveEntry{
-				accountCurrency: acct,
+				Entry: acct,
 			})
 			r.seenAccounts = append(r.seenAccounts, acct)
 			fmt.Printf("Adding to inactive queue: %s\n", types.PrettyPrintStruct(acct))

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -431,7 +431,7 @@ func (r *Reconciler) accountReconciliation(
 				// Don't wait to check if we are very far behind
 				log.Printf(
 					"Skipping reconciliation for %s: %d blocks behind\n",
-					simpleAccountCurrency(accountCurrency),
+					types.PrettyPrintStruct(accountCurrency),
 					diff,
 				)
 
@@ -529,21 +529,6 @@ func (r *Reconciler) inactiveAccountQueue(
 	}
 
 	return nil
-}
-
-// simpleAccountCurrency returns a string that is a simple
-// representation of an AccountCurrency struct.
-func simpleAccountCurrency(
-	accountCurrency *AccountCurrency,
-) string {
-	acctString := accountCurrency.Account.Address
-	if accountCurrency.Account.SubAccount != nil {
-		acctString += accountCurrency.Account.SubAccount.Address
-	}
-
-	acctString += accountCurrency.Currency.Symbol
-
-	return acctString
 }
 
 // reconcileActiveAccounts selects an account

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -83,7 +83,7 @@ func TestNewReconciler(t *testing.T) {
 				r := templateReconciler()
 				r.inactiveQueue = []*InactiveEntry{
 					{
-						accountCurrency: accountCurrency,
+						Entry: accountCurrency,
 					},
 				}
 				r.seenAccounts = []*AccountCurrency{
@@ -530,8 +530,8 @@ func TestInactiveAccountQueue(t *testing.T) {
 		assert.ElementsMatch(t, r.seenAccounts, []*AccountCurrency{accountCurrency})
 		assert.ElementsMatch(t, r.inactiveQueue, []*InactiveEntry{
 			{
-				accountCurrency: accountCurrency,
-				lastCheck:       block,
+				Entry:     accountCurrency,
+				LastCheck: block,
 			},
 		})
 	})
@@ -552,12 +552,12 @@ func TestInactiveAccountQueue(t *testing.T) {
 		)
 		assert.ElementsMatch(t, r.inactiveQueue, []*InactiveEntry{
 			{
-				accountCurrency: accountCurrency,
-				lastCheck:       block,
+				Entry:     accountCurrency,
+				LastCheck: block,
 			},
 			{
-				accountCurrency: accountCurrency2,
-				lastCheck:       block2,
+				Entry:     accountCurrency2,
+				LastCheck: block2,
 			},
 		})
 	})
@@ -598,8 +598,8 @@ func TestInactiveAccountQueue(t *testing.T) {
 		)
 		assert.ElementsMatch(t, r.inactiveQueue, []*InactiveEntry{
 			{
-				accountCurrency: accountCurrency,
-				lastCheck:       block,
+				Entry:     accountCurrency,
+				LastCheck: block,
 			},
 		})
 	})
@@ -620,12 +620,12 @@ func TestInactiveAccountQueue(t *testing.T) {
 		)
 		assert.ElementsMatch(t, r.inactiveQueue, []*InactiveEntry{
 			{
-				accountCurrency: accountCurrency,
-				lastCheck:       block,
+				Entry:     accountCurrency,
+				LastCheck: block,
 			},
 			{
-				accountCurrency: accountCurrency2,
-				lastCheck:       block2,
+				Entry:     accountCurrency2,
+				LastCheck: block2,
 			},
 		})
 	})


### PR DESCRIPTION
### Motivation
When restarting the `Reconciler`, the record of previously seen accounts and the inactive reconciliation queue is discarded. Upon restart of the reconciler, there is no way to repopulate this record of previously seen `AccountCurrency`. In the `rosetta-cli`, this can lead to inactive reconciliation not checking all accounts if reconciliation is restarted using the same datastore (common practice).

### Solution
* Allow the `Reconciler` to be instantiated with previously seen accounts.
* Add a method `NewAccountSeen` to the `Reconciler.Handler` that is called whenever a new account is observed. This allows the client to store these new accounts persistently (to later provide for reconciler instantiation).
