### PR TITLE
Better Logging on Reconciler

### DIFF
--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/parser"
-	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
 // Option is used to overwrite default values in
@@ -53,8 +52,12 @@ func WithSeenAccounts(seen []*AccountCurrency) Option {
 				Entry: acct,
 			})
 			r.seenAccounts = append(r.seenAccounts, acct)
-			fmt.Printf("Adding to inactive queue: %s\n", types.PrettyPrintStruct(acct))
 		}
+
+		fmt.Printf(
+			"Initialized reconciler with %d previously seen accounts\n",
+			len(r.seenAccounts),
+		)
 	}
 }
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -585,11 +585,8 @@ func (r *Reconciler) reconcileInactiveAccounts(
 		// When first start syncing, this loop may run before the genesis block is synced.
 		// If this is the case, we should sleep and try again later instead of exiting.
 		if err != nil {
+			log.Println("waiting to start intactive reconciliation until a block is synced...")
 			time.Sleep(inactiveReconciliationSleep)
-			log.Printf(
-				"%s: waiting to start inactive reconciliation until current block set\n",
-				err.Error(),
-			)
 			continue
 		}
 


### PR DESCRIPTION
### Motivation
On initialization, the reconciler prints out each previously seen account that was added (super annoying when there are more than 10 previously seen accounts). Also, the reconciler prints a confusing log message when it is waiting to start inactive reconciliation.

### Solution
* Log the number of previously seen accounts initialized instead of each account.
* Log a clearer message when waiting to start the inactive reconciler.
