### PR TITLE
Improve Matching Functionality

### DIFF
--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -345,9 +345,7 @@ func comparisonMatch(
 	for _, amountMatch := range descriptions.EqualAmounts {
 		ops := []*types.Operation{}
 		for _, reqIndex := range amountMatch {
-			for _, op := range matches[reqIndex].Operations {
-				ops = append(ops, op)
-			}
+			ops = append(ops, matches[reqIndex].Operations...)
 		}
 
 		if err := equalAmounts(ops); err != nil {
@@ -376,6 +374,8 @@ func comparisonMatch(
 	return nil
 }
 
+// Match contains all *types.Operation matching a given OperationDescription and
+// their parsed *big.Int amounts (if populated).
 type Match struct {
 	Operations []*types.Operation
 
@@ -384,6 +384,9 @@ type Match struct {
 	Amounts []*big.Int
 }
 
+// First is a convenience method that returns the first matched operation
+// and amount (if they exist). This is used when parsing matches when
+// AllowRepeats is set to false.
 func (m *Match) First() (*types.Operation, *big.Int) {
 	if m == nil {
 		return nil, nil

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -270,7 +270,6 @@ func operationMatch(
 			}
 		}
 
-		matches[i].Operations = append(matches[i].Operations, operation)
 		if operation.Amount != nil {
 			val, err := types.AmountValue(operation.Amount)
 			if err != nil {
@@ -280,6 +279,10 @@ func operationMatch(
 		} else {
 			matches[i].Amounts = append(matches[i].Amounts, nil)
 		}
+
+		// Wait to add operation to matches in case that we "continue" when
+		// parsing operation.Amount.
+		matches[i].Operations = append(matches[i].Operations, operation)
 		return true
 	}
 

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -345,6 +345,12 @@ func comparisonMatch(
 	for _, amountMatch := range descriptions.EqualAmounts {
 		ops := []*types.Operation{}
 		for _, reqIndex := range amountMatch {
+			if reqIndex >= len(matches) {
+				return fmt.Errorf(
+					"equal amounts comparison index %d out of range",
+					reqIndex,
+				)
+			}
 			ops = append(ops, matches[reqIndex].Operations...)
 		}
 
@@ -359,6 +365,18 @@ func comparisonMatch(
 		}
 
 		// compare all possible pairs
+		if amountMatch[0] >= len(matches) {
+			return fmt.Errorf(
+				"opposite amounts comparison index %d out of range",
+				amountMatch[0],
+			)
+		}
+		if amountMatch[1] >= len(matches) {
+			return fmt.Errorf(
+				"opposite amounts comparison index %d out of range",
+				amountMatch[1],
+			)
+		}
 		for _, op := range matches[amountMatch[0]].Operations {
 			for _, otherOp := range matches[amountMatch[1]].Operations {
 				if err := oppositeAmounts(

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -131,11 +131,6 @@ type Descriptions struct {
 	// will error if all groups of operations aren't opposites.
 	OppositeAmounts [][]int
 
-	// NetZeroAmounts are specified using the operation indicies of
-	// OperationDescriptions to handle out of order matches. MatchOperations
-	// will error if all groups of operations don't net to zero.
-	NetZeroAmounts [][]int
-
 	// ErrUnmatched indicates that an error should be returned
 	// if all operations cannot be matched to a description.
 	ErrUnmatched bool
@@ -376,7 +371,6 @@ func comparisonMatch(
 				}
 			}
 		}
-
 	}
 
 	return nil
@@ -391,6 +385,10 @@ type Match struct {
 }
 
 func (m *Match) First() (*types.Operation, *big.Int) {
+	if m == nil {
+		return nil, nil
+	}
+
 	if len(m.Operations) > 0 {
 		return m.Operations[0], m.Amounts[0]
 	}

--- a/parser/match_operations_test.go
+++ b/parser/match_operations_test.go
@@ -15,6 +15,7 @@
 package parser
 
 import (
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestMatchOperations(t *testing.T) {
 		operations   []*types.Operation
 		descriptions *Descriptions
 
-		matches []*types.Operation
+		matches []*Match
 		err     bool
 	}{
 		"simple transfer (with extra op)": {
@@ -73,22 +74,32 @@ func TestMatchOperations(t *testing.T) {
 					},
 				},
 			},
-			matches: []*types.Operation{
+			matches: []*Match{
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr1",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+							},
+							Amount: &types.Amount{
+								Value: "-100",
+							},
+						},
 					},
-					Amount: &types.Amount{
-						Value: "-100",
-					},
+					Amounts: []*big.Int{big.NewInt(-100)},
 				},
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr2",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+							},
+							Amount: &types.Amount{
+								Value: "100",
+							},
+						},
 					},
-					Amount: &types.Amount{
-						Value: "100",
-					},
+					Amounts: []*big.Int{big.NewInt(100)},
 				},
 			},
 			err: false,
@@ -114,8 +125,8 @@ func TestMatchOperations(t *testing.T) {
 				},
 			},
 			descriptions: &Descriptions{
-				RejectExtraOperations: true,
-				OppositeAmounts:       [][]int{{0, 1}},
+				ErrUnmatched:    true,
+				OppositeAmounts: [][]int{{0, 1}},
 				OperationDescriptions: []*OperationDescription{
 					{
 						Account: &AccountDescription{
@@ -227,22 +238,32 @@ func TestMatchOperations(t *testing.T) {
 					},
 				},
 			},
-			matches: []*types.Operation{
+			matches: []*Match{
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr2",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+							},
+							Amount: &types.Amount{
+								Value: "100",
+							},
+						},
 					},
-					Amount: &types.Amount{
-						Value: "100",
-					},
+					Amounts: []*big.Int{big.NewInt(100)},
 				},
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr1",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+							},
+							Amount: &types.Amount{
+								Value: "100",
+							},
+						},
 					},
-					Amount: &types.Amount{
-						Value: "100",
-					},
+					Amounts: []*big.Int{big.NewInt(100)},
 				},
 			},
 			err: false,
@@ -306,30 +327,40 @@ func TestMatchOperations(t *testing.T) {
 					},
 				},
 			},
-			matches: []*types.Operation{
+			matches: []*Match{
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr1",
-					},
-					Amount: &types.Amount{
-						Value: "-100",
-						Currency: &types.Currency{
-							Symbol:   "ETH",
-							Decimals: 18,
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+							},
+							Amount: &types.Amount{
+								Value: "-100",
+								Currency: &types.Currency{
+									Symbol:   "ETH",
+									Decimals: 18,
+								},
+							},
 						},
 					},
+					Amounts: []*big.Int{big.NewInt(-100)},
 				},
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr2",
-					},
-					Amount: &types.Amount{
-						Value: "100",
-						Currency: &types.Currency{
-							Symbol:   "BTC",
-							Decimals: 8,
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+							},
+							Amount: &types.Amount{
+								Value: "100",
+								Currency: &types.Currency{
+									Symbol:   "BTC",
+									Decimals: 8,
+								},
+							},
 						},
 					},
+					Amounts: []*big.Int{big.NewInt(100)},
 				},
 			},
 			err: false,
@@ -453,28 +484,38 @@ func TestMatchOperations(t *testing.T) {
 					},
 				},
 			},
-			matches: []*types.Operation{
+			matches: []*Match{
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr1",
-						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub",
-							Metadata: map[string]interface{}{
-								"validator": "10",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub",
+									Metadata: map[string]interface{}{
+										"validator": "10",
+									},
+								},
+							},
+							Amount: &types.Amount{
+								Value: "-100",
 							},
 						},
 					},
-					Amount: &types.Amount{
-						Value: "-100",
-					},
+					Amounts: []*big.Int{big.NewInt(-100)},
 				},
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr2",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+							},
+							Amount: &types.Amount{
+								Value: "100",
+							},
+						},
 					},
-					Amount: &types.Amount{
-						Value: "100",
-					},
+					Amounts: []*big.Int{big.NewInt(100)},
 				},
 			},
 			err: false,
@@ -550,7 +591,9 @@ func TestMatchOperations(t *testing.T) {
 							Address: "sub 2",
 						},
 					},
-					Amount: &types.Amount{}, // allowed because no amount requirement provided
+					Amount: &types.Amount{
+						Value: "100",
+					}, // allowed because no amount requirement provided
 				},
 			},
 			descriptions: &Descriptions{
@@ -571,23 +614,35 @@ func TestMatchOperations(t *testing.T) {
 					},
 				},
 			},
-			matches: []*types.Operation{
+			matches: []*Match{
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr2",
-						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub 2",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub 2",
+								},
+							},
+							Amount: &types.Amount{
+								Value: "100",
+							},
 						},
 					},
-					Amount: &types.Amount{},
+					Amounts: []*big.Int{big.NewInt(100)},
 				},
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr1",
-						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub 1",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub 1",
+								},
+							},
 						},
 					},
+					Amounts: []*big.Int{nil},
 				},
 			},
 			err: false,
@@ -681,25 +736,35 @@ func TestMatchOperations(t *testing.T) {
 					},
 				},
 			},
-			matches: []*types.Operation{
+			matches: []*Match{
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr2",
-						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub 2",
-						},
-					},
-				},
-				{
-					Account: &types.AccountIdentifier{
-						Address: "addr1",
-						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub 1",
-							Metadata: map[string]interface{}{
-								"validator": -1000,
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub 2",
+								},
 							},
 						},
 					},
+					Amounts: []*big.Int{nil},
+				},
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub 1",
+									Metadata: map[string]interface{}{
+										"validator": -1000,
+									},
+								},
+							},
+						},
+					},
+					Amounts: []*big.Int{nil},
 				},
 			},
 			err: false,
@@ -792,22 +857,32 @@ func TestMatchOperations(t *testing.T) {
 					{},
 				},
 			},
-			matches: []*types.Operation{
+			matches: []*Match{
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr1",
-						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub 3",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub 3",
+								},
+							},
 						},
 					},
+					Amounts: []*big.Int{nil},
 				},
 				{
-					Account: &types.AccountIdentifier{
-						Address: "addr2",
-						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub 2",
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub 2",
+								},
+							},
 						},
 					},
+					Amounts: []*big.Int{nil},
 				},
 			},
 			err: false,
@@ -835,6 +910,91 @@ func TestMatchOperations(t *testing.T) {
 			}
 
 			assert.Equal(t, test.matches, matches)
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	var tests = map[string]struct {
+		m *Match
+
+		op     *types.Operation
+		amount *big.Int
+	}{
+		"nil match": {},
+		"empty match": {
+			m: &Match{},
+		},
+		"single op match": {
+			m: &Match{
+				Operations: []*types.Operation{
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 1,
+						},
+					},
+				},
+				Amounts: []*big.Int{
+					big.NewInt(100),
+				},
+			},
+			op: &types.Operation{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: 1,
+				},
+			},
+			amount: big.NewInt(100),
+		},
+		"multi-op match": {
+			m: &Match{
+				Operations: []*types.Operation{
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 1,
+						},
+					},
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 2,
+						},
+					},
+				},
+				Amounts: []*big.Int{
+					big.NewInt(100),
+					big.NewInt(200),
+				},
+			},
+			op: &types.Operation{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: 1,
+				},
+			},
+			amount: big.NewInt(100),
+		},
+		"single op match with nil amount": {
+			m: &Match{
+				Operations: []*types.Operation{
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 1,
+						},
+					},
+				},
+				Amounts: []*big.Int{nil},
+			},
+			op: &types.Operation{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: 1,
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			op, amount := test.m.First()
+			assert.Equal(t, test.op, op)
+			assert.Equal(t, test.amount, amount)
 		})
 	}
 }

--- a/parser/match_operations_test.go
+++ b/parser/match_operations_test.go
@@ -1154,6 +1154,163 @@ func TestMatchOperations(t *testing.T) {
 			matches: nil,
 			err:     true,
 		},
+		"complex repeated op": {
+			operations: []*types.Operation{
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr2",
+					},
+					Amount: &types.Amount{
+						Value: "200",
+					},
+					Type: "output",
+				},
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr3",
+					},
+					Amount: &types.Amount{
+						Value: "200",
+					},
+					Type: "output",
+				},
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr1",
+					},
+					Amount: &types.Amount{
+						Value: "-200",
+					},
+					Type: "input",
+				},
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr4",
+					},
+					Amount: &types.Amount{
+						Value: "-200",
+					},
+					Type: "input",
+				},
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr5",
+					},
+					Amount: &types.Amount{
+						Value: "-1000",
+					},
+					Type: "runoff",
+				},
+			},
+			descriptions: &Descriptions{
+				OppositeAmounts: [][]int{{0, 1}},
+				OperationDescriptions: []*OperationDescription{
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   PositiveAmountSign,
+						},
+						AllowRepeats: true,
+						Type:         "output",
+					},
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   NegativeAmountSign,
+						},
+						AllowRepeats: true,
+						Type:         "input",
+					},
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   NegativeAmountSign,
+						},
+						AllowRepeats: true,
+					},
+				},
+			},
+			matches: []*Match{
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+							},
+							Amount: &types.Amount{
+								Value: "200",
+							},
+							Type: "output",
+						},
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr3",
+							},
+							Amount: &types.Amount{
+								Value: "200",
+							},
+							Type: "output",
+						},
+					},
+					Amounts: []*big.Int{
+						big.NewInt(200),
+						big.NewInt(200),
+					},
+				},
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+							},
+							Amount: &types.Amount{
+								Value: "-200",
+							},
+							Type: "input",
+						},
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr4",
+							},
+							Amount: &types.Amount{
+								Value: "-200",
+							},
+							Type: "input",
+						},
+					},
+					Amounts: []*big.Int{
+						big.NewInt(-200),
+						big.NewInt(-200),
+					},
+				},
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr5",
+							},
+							Amount: &types.Amount{
+								Value: "-1000",
+							},
+							Type: "runoff",
+						},
+					},
+					Amounts: []*big.Int{
+						big.NewInt(-1000),
+					},
+				},
+			},
+			err: false,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
### Motivation
Fixes #38, #39, #40.

### Solution
Return a new `Match` struct instead of `*types.Operation` from `MatchOperations`. This new struct allows for multiple `*types.Operation` to be matched with a given `OperationDescription`.
