### PR TITLE
Optional `OperationDescription` in Parser

### DIFF
--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -343,6 +343,23 @@ func oppositeAmounts(a *types.Operation, b *types.Operation) error {
 	return nil
 }
 
+func matchIndexValid(matches []*Match, index int) error {
+	if index >= len(matches) {
+		return fmt.Errorf(
+			"match index %d out of range",
+			index,
+		)
+	}
+	if matches[index] == nil {
+		return fmt.Errorf(
+			"match index %d is nil",
+			index,
+		)
+	}
+
+	return nil
+}
+
 // comparisonMatch ensures collections of *types.Operations
 // have either equal or opposite amounts.
 func comparisonMatch(
@@ -352,18 +369,10 @@ func comparisonMatch(
 	for _, amountMatch := range descriptions.EqualAmounts {
 		ops := []*types.Operation{}
 		for _, reqIndex := range amountMatch {
-			if reqIndex >= len(matches) {
-				return fmt.Errorf(
-					"equal amounts comparison index %d out of range",
-					reqIndex,
-				)
+			if err := matchIndexValid(matches, reqIndex); err != nil {
+				return fmt.Errorf("%w: equal amounts comparison error", err)
 			}
-			if matches[reqIndex] == nil {
-				return fmt.Errorf(
-					"equal amounts comarison index %d is nil",
-					reqIndex,
-				)
-			}
+
 			ops = append(ops, matches[reqIndex].Operations...)
 		}
 
@@ -378,29 +387,11 @@ func comparisonMatch(
 		}
 
 		// compare all possible pairs
-		if amountMatch[0] >= len(matches) {
-			return fmt.Errorf(
-				"opposite amounts comparison index %d out of range",
-				amountMatch[0],
-			)
+		if err := matchIndexValid(matches, amountMatch[0]); err != nil {
+			return fmt.Errorf("%w: opposite amounts comparison error", err)
 		}
-		if matches[amountMatch[0]] == nil {
-			return fmt.Errorf(
-				"equal amounts comarison index %d is nil",
-				amountMatch[0],
-			)
-		}
-		if amountMatch[1] >= len(matches) {
-			return fmt.Errorf(
-				"opposite amounts comparison index %d out of range",
-				amountMatch[1],
-			)
-		}
-		if matches[amountMatch[1]] == nil {
-			return fmt.Errorf(
-				"equal amounts comarison index %d is nil",
-				amountMatch[1],
-			)
+		if err := matchIndexValid(matches, amountMatch[1]); err != nil {
+			return fmt.Errorf("%w: opposite amounts comparison error", err)
 		}
 		for _, op := range matches[amountMatch[0]].Operations {
 			for _, otherOp := range matches[amountMatch[1]].Operations {

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -114,6 +114,10 @@ type OperationDescription struct {
 	// AllowRepeats indicates that multiple operations can be matched
 	// to a particular description.
 	AllowRepeats bool
+
+	// Optional indicates that not finding any operations that meet
+	// the description should not trigger an error.
+	Optional bool
 }
 
 // Descriptions contains a slice of OperationDescriptions and
@@ -354,6 +358,12 @@ func comparisonMatch(
 					reqIndex,
 				)
 			}
+			if matches[reqIndex] == nil {
+				return fmt.Errorf(
+					"equal amounts comarison index %d is nil",
+					reqIndex,
+				)
+			}
 			ops = append(ops, matches[reqIndex].Operations...)
 		}
 
@@ -374,9 +384,21 @@ func comparisonMatch(
 				amountMatch[0],
 			)
 		}
+		if matches[amountMatch[0]] == nil {
+			return fmt.Errorf(
+				"equal amounts comarison index %d is nil",
+				amountMatch[0],
+			)
+		}
 		if amountMatch[1] >= len(matches) {
 			return fmt.Errorf(
 				"opposite amounts comparison index %d out of range",
+				amountMatch[1],
+			)
+		}
+		if matches[amountMatch[1]] == nil {
+			return fmt.Errorf(
+				"equal amounts comarison index %d is nil",
 				amountMatch[1],
 			)
 		}
@@ -452,7 +474,7 @@ func MatchOperations(
 
 	// Error if any *OperationDescription is not matched
 	for i := 0; i < len(matches); i++ {
-		if matches[i] == nil {
+		if matches[i] == nil && !descriptions.OperationDescriptions[i].Optional {
 			return nil, fmt.Errorf("could not find match for description %d", i)
 		}
 	}

--- a/parser/match_operations_test.go
+++ b/parser/match_operations_test.go
@@ -1311,6 +1311,175 @@ func TestMatchOperations(t *testing.T) {
 			},
 			err: false,
 		},
+		"optional description not met": {
+			operations: []*types.Operation{
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr2",
+					},
+					Amount: &types.Amount{
+						Value: "200",
+					},
+				},
+				{}, // extra op ignored
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr1",
+					},
+					Amount: &types.Amount{
+						Value: "100",
+					},
+				},
+			},
+			descriptions: &Descriptions{
+				OperationDescriptions: []*OperationDescription{
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   PositiveAmountSign,
+						},
+						AllowRepeats: true,
+					},
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   NegativeAmountSign,
+						},
+						Optional: true,
+					},
+				},
+			},
+			matches: []*Match{
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+							},
+							Amount: &types.Amount{
+								Value: "200",
+							},
+						},
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+							},
+							Amount: &types.Amount{
+								Value: "100",
+							},
+						},
+					},
+					Amounts: []*big.Int{
+						big.NewInt(200),
+						big.NewInt(100),
+					},
+				},
+				nil,
+			},
+			err: false,
+		},
+		"optional description equal amounts not found": {
+			operations: []*types.Operation{
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr2",
+					},
+					Amount: &types.Amount{
+						Value: "200",
+					},
+				},
+				{}, // extra op ignored
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr1",
+					},
+					Amount: &types.Amount{
+						Value: "100",
+					},
+				},
+			},
+			descriptions: &Descriptions{
+				EqualAmounts: [][]int{{0, 1}},
+				OperationDescriptions: []*OperationDescription{
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   PositiveAmountSign,
+						},
+						AllowRepeats: true,
+					},
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   NegativeAmountSign,
+						},
+						Optional: true,
+					},
+				},
+			},
+			matches: nil,
+			err:     true,
+		},
+		"optional description opposite amounts not found": {
+			operations: []*types.Operation{
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr2",
+					},
+					Amount: &types.Amount{
+						Value: "200",
+					},
+				},
+				{}, // extra op ignored
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr1",
+					},
+					Amount: &types.Amount{
+						Value: "100",
+					},
+				},
+			},
+			descriptions: &Descriptions{
+				OppositeAmounts: [][]int{{0, 1}},
+				OperationDescriptions: []*OperationDescription{
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   PositiveAmountSign,
+						},
+						AllowRepeats: true,
+					},
+					{
+						Account: &AccountDescription{
+							Exists: true,
+						},
+						Amount: &AmountDescription{
+							Exists: true,
+							Sign:   NegativeAmountSign,
+						},
+						Optional: true,
+					},
+				},
+			},
+			matches: nil,
+			err:     true,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
### Motivation
Fixes #42.

### Solution
Add an `Optional` field to the `OperationDescription` struct.
