### PR TITLE
Support v1.4.0 Spec Update

### DIFF
--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -86,6 +86,7 @@ func TestNew(t *testing.T) {
 						Retriable: true,
 					},
 				},
+				HistoricalBalanceLookup: true,
 			},
 		}
 
@@ -210,7 +211,7 @@ func TestNew(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(fmt.Sprintf("%s with responses", name), func(t *testing.T) {
-			asserter, err := NewClientWithResponses(
+			asserter, err := NewWithResponses(
 				test.network,
 				test.networkStatus,
 				test.networkOptions,
@@ -223,7 +224,7 @@ func TestNew(t *testing.T) {
 			}
 
 			assert.NotNil(t, asserter)
-			configuration, err := asserter.ClientConfiguration()
+			configuration, err := asserter.Configuration()
 			assert.NoError(t, err)
 			assert.Equal(t, test.network, configuration.NetworkIdentifier)
 			assert.Equal(
@@ -242,6 +243,7 @@ func TestNew(t *testing.T) {
 				configuration.AllowedOperationStatuses,
 			)
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, configuration.AllowedErrors)
+			assert.Equal(t, test.networkOptions.Allow.HistoricalBalanceLookup, configuration.HistoricalBalanceLookup)
 		})
 
 		t.Run(fmt.Sprintf("%s with file", name), func(t *testing.T) {
@@ -251,6 +253,7 @@ func TestNew(t *testing.T) {
 				AllowedOperationTypes:    test.networkOptions.Allow.OperationTypes,
 				AllowedOperationStatuses: test.networkOptions.Allow.OperationStatuses,
 				AllowedErrors:            test.networkOptions.Allow.Errors,
+				HistoricalBalanceLookup:  test.networkOptions.Allow.HistoricalBalanceLookup,
 			}
 			tmpfile, err := ioutil.TempFile("", "test.json")
 			assert.NoError(t, err)
@@ -263,7 +266,7 @@ func TestNew(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NoError(t, tmpfile.Close())
 
-			asserter, err := NewClientWithFile(
+			asserter, err := NewWithFile(
 				tmpfile.Name(),
 			)
 
@@ -274,7 +277,7 @@ func TestNew(t *testing.T) {
 			}
 
 			assert.NotNil(t, asserter)
-			configuration, err := asserter.ClientConfiguration()
+			configuration, err := asserter.Configuration()
 			assert.NoError(t, err)
 			assert.Equal(t, test.network, configuration.NetworkIdentifier)
 			assert.Equal(
@@ -293,11 +296,12 @@ func TestNew(t *testing.T) {
 				configuration.AllowedOperationStatuses,
 			)
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, configuration.AllowedErrors)
+			assert.Equal(t, test.networkOptions.Allow.HistoricalBalanceLookup, configuration.HistoricalBalanceLookup)
 		})
 	}
 
 	t.Run("non-existent file", func(t *testing.T) {
-		asserter, err := NewClientWithFile(
+		asserter, err := NewWithFile(
 			"blah",
 		)
 		assert.Error(t, err)
@@ -313,7 +317,7 @@ func TestNew(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, tmpfile.Close())
 
-		asserter, err := NewClientWithFile(
+		asserter, err := NewWithFile(
 			tmpfile.Name(),
 		)
 

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -66,7 +66,7 @@ func TestNew(t *testing.T) {
 
 		validNetworkOptions = &types.NetworkOptionsResponse{
 			Version: &types.Version{
-				RosettaVersion: "1.2.3",
+				RosettaVersion: "1.4.0",
 				NodeVersion:    "1.0",
 			},
 			Allow: &types.Allow{
@@ -92,7 +92,7 @@ func TestNew(t *testing.T) {
 
 		invalidNetworkOptions = &types.NetworkOptionsResponse{
 			Version: &types.Version{
-				RosettaVersion: "1.2.3",
+				RosettaVersion: "1.4.0",
 				NodeVersion:    "1.0",
 			},
 			Allow: &types.Allow{
@@ -111,7 +111,7 @@ func TestNew(t *testing.T) {
 
 		duplicateStatuses = &types.NetworkOptionsResponse{
 			Version: &types.Version{
-				RosettaVersion: "1.2.3",
+				RosettaVersion: "1.4.0",
 				NodeVersion:    "1.0",
 			},
 			Allow: &types.Allow{
@@ -140,7 +140,7 @@ func TestNew(t *testing.T) {
 
 		duplicateTypes = &types.NetworkOptionsResponse{
 			Version: &types.Version{
-				RosettaVersion: "1.2.3",
+				RosettaVersion: "1.4.0",
 				NodeVersion:    "1.0",
 			},
 			Allow: &types.Allow{

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -243,7 +243,11 @@ func TestNew(t *testing.T) {
 				configuration.AllowedOperationStatuses,
 			)
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, configuration.AllowedErrors)
-			assert.Equal(t, test.networkOptions.Allow.HistoricalBalanceLookup, configuration.HistoricalBalanceLookup)
+			assert.Equal(
+				t,
+				test.networkOptions.Allow.HistoricalBalanceLookup,
+				configuration.HistoricalBalanceLookup,
+			)
 		})
 
 		t.Run(fmt.Sprintf("%s with file", name), func(t *testing.T) {
@@ -296,7 +300,11 @@ func TestNew(t *testing.T) {
 				configuration.AllowedOperationStatuses,
 			)
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, configuration.AllowedErrors)
-			assert.Equal(t, test.networkOptions.Allow.HistoricalBalanceLookup, configuration.HistoricalBalanceLookup)
+			assert.Equal(
+				t,
+				test.networkOptions.Allow.HistoricalBalanceLookup,
+				configuration.HistoricalBalanceLookup,
+			)
 		})
 	}
 

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -211,7 +211,7 @@ func TestNew(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(fmt.Sprintf("%s with responses", name), func(t *testing.T) {
-			asserter, err := NewWithResponses(
+			asserter, err := NewClientWithResponses(
 				test.network,
 				test.networkStatus,
 				test.networkOptions,
@@ -224,7 +224,7 @@ func TestNew(t *testing.T) {
 			}
 
 			assert.NotNil(t, asserter)
-			configuration, err := asserter.Configuration()
+			configuration, err := asserter.ClientConfiguration()
 			assert.NoError(t, err)
 			assert.Equal(t, test.network, configuration.NetworkIdentifier)
 			assert.Equal(
@@ -243,11 +243,6 @@ func TestNew(t *testing.T) {
 				configuration.AllowedOperationStatuses,
 			)
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, configuration.AllowedErrors)
-			assert.Equal(
-				t,
-				test.networkOptions.Allow.HistoricalBalanceLookup,
-				configuration.HistoricalBalanceLookup,
-			)
 		})
 
 		t.Run(fmt.Sprintf("%s with file", name), func(t *testing.T) {
@@ -257,7 +252,6 @@ func TestNew(t *testing.T) {
 				AllowedOperationTypes:    test.networkOptions.Allow.OperationTypes,
 				AllowedOperationStatuses: test.networkOptions.Allow.OperationStatuses,
 				AllowedErrors:            test.networkOptions.Allow.Errors,
-				HistoricalBalanceLookup:  test.networkOptions.Allow.HistoricalBalanceLookup,
 			}
 			tmpfile, err := ioutil.TempFile("", "test.json")
 			assert.NoError(t, err)
@@ -270,7 +264,7 @@ func TestNew(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NoError(t, tmpfile.Close())
 
-			asserter, err := NewWithFile(
+			asserter, err := NewClientWithFile(
 				tmpfile.Name(),
 			)
 
@@ -281,7 +275,7 @@ func TestNew(t *testing.T) {
 			}
 
 			assert.NotNil(t, asserter)
-			configuration, err := asserter.Configuration()
+			configuration, err := asserter.ClientConfiguration()
 			assert.NoError(t, err)
 			assert.Equal(t, test.network, configuration.NetworkIdentifier)
 			assert.Equal(
@@ -300,16 +294,11 @@ func TestNew(t *testing.T) {
 				configuration.AllowedOperationStatuses,
 			)
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, configuration.AllowedErrors)
-			assert.Equal(
-				t,
-				test.networkOptions.Allow.HistoricalBalanceLookup,
-				configuration.HistoricalBalanceLookup,
-			)
 		})
 	}
 
 	t.Run("non-existent file", func(t *testing.T) {
-		asserter, err := NewWithFile(
+		asserter, err := NewClientWithFile(
 			"blah",
 		)
 		assert.Error(t, err)
@@ -325,7 +314,7 @@ func TestNew(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, tmpfile.Close())
 
-		asserter, err := NewWithFile(
+		asserter, err := NewClientWithFile(
 			tmpfile.Name(),
 		)
 

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -186,14 +186,12 @@ func (a *Asserter) Operation(
 		return err
 	}
 
-	if construction {
-		if len(operation.Status) != 0 {
-			return errors.New("operation.Status must be empty for construction")
-		}
-	} else {
-		if err := a.OperationStatus(operation.Status); err != nil {
-			return err
-		}
+	if construction && len(operation.Status) != 0 {
+		return errors.New("operation.Status must be empty for construction")
+	}
+
+	if err := a.OperationStatus(operation.Status); err != nil && !construction {
+		return err
 	}
 
 	if operation.Amount == nil {

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -446,7 +446,7 @@ func TestOperation(t *testing.T) {
 			},
 			&types.NetworkOptionsResponse{
 				Version: &types.Version{
-					RosettaVersion: "1.3.1",
+					RosettaVersion: "1.4.0",
 					NodeVersion:    "1.0",
 				},
 				Allow: &types.Allow{
@@ -818,7 +818,7 @@ func TestBlock(t *testing.T) {
 				},
 				&types.NetworkOptionsResponse{
 					Version: &types.Version{
-						RosettaVersion: "1.3.1",
+						RosettaVersion: "1.4.0",
 						NodeVersion:    "1.0",
 					},
 					Allow: &types.Allow{

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -811,7 +811,11 @@ func TestBlock(t *testing.T) {
 			assert.NotNil(t, asserter)
 			assert.NoError(t, err)
 
-			assert.Equal(t, test.err, asserter.Block(test.block))
+			if test.err != nil {
+				err = asserter.Block(test.block)
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.err.Error())
+			}
 		})
 	}
 }

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -423,7 +423,7 @@ func TestOperation(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		asserter, err := NewWithResponses(
+		asserter, err := NewClientWithResponses(
 			&types.NetworkIdentifier{
 				Blockchain: "hello",
 				Network:    "world",
@@ -795,7 +795,7 @@ func TestBlock(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			asserter, err := NewWithResponses(
+			asserter, err := NewClientWithResponses(
 				&types.NetworkIdentifier{
 					Blockchain: "hello",
 					Network:    "world",

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -811,10 +811,12 @@ func TestBlock(t *testing.T) {
 			assert.NotNil(t, asserter)
 			assert.NoError(t, err)
 
+			err = asserter.Block(test.block)
 			if test.err != nil {
-				err = asserter.Block(test.block)
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -15,7 +15,9 @@
 package asserter
 
 import (
+	"encoding/hex"
 	"errors"
+	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -44,4 +46,130 @@ func ConstructionSubmit(
 	}
 
 	return nil
+}
+
+// PublicKey returns an error if
+// the *types.PublicKey is nil, is not
+// valid hex, or has an undefined CurveType.
+func PublicKey(
+	publicKey *types.PublicKey,
+) error {
+	if publicKey == nil {
+		return errors.New("PublicKey cannot be nil")
+	}
+
+	if err := checkHex(publicKey.HexBytes); err != nil {
+		return fmt.Errorf("%w public key does not have valid hex", err)
+	}
+
+	if err := CurveType(publicKey.CurveType); err != nil {
+		return fmt.Errorf("%w public key curve type is not supported", err)
+	}
+
+	return nil
+}
+
+// CurveType returns an error if
+// the curve is not a valid types.CurveType.
+func CurveType(
+	curve types.CurveType,
+) error {
+	switch curve {
+	case types.Secp256k1, types.Edwards25519:
+		return nil
+	default:
+		return fmt.Errorf("%s is not a supported CurveType", curve)
+	}
+}
+
+// checkHex returns an error if a
+// string is not valid hex or if
+// it is empty.
+func checkHex(
+	hexString string,
+) error {
+	if len(hexString) == 0 {
+		return errors.New("hex string cannot be empty")
+	}
+
+	_, err := hex.DecodeString(hexString)
+	if err != nil {
+		return fmt.Errorf("%w: %s is not a valid hex string", err, hexString)
+	}
+
+	return nil
+}
+
+// SigningPayload returns an error
+// if a *types.SigningPayload is nil,
+// has an empty address, has invlaid hex,
+// or has an invalid SignatureType (if populated).
+func SigningPayload(
+	signingPayload *types.SigningPayload,
+) error {
+	if signingPayload == nil {
+		return errors.New("signing payload cannot be nil")
+	}
+
+	if len(signingPayload.Address) == 0 {
+		return errors.New("signing payload address cannot be empty")
+	}
+
+	if err := checkHex(signingPayload.HexBytes); err != nil {
+		return fmt.Errorf("%w signature payload is not a valid hex string", err)
+	}
+
+	// SignatureType can be optionally populated
+	if len(signingPayload.SignatureType) == 0 {
+		return nil
+	}
+
+	if err := SignatureType(signingPayload.SignatureType); err != nil {
+		return fmt.Errorf("%w signature payload signature type is not valid", err)
+	}
+
+	return nil
+}
+
+// Signatures returns an error if any
+// *types.Signature is invalid.
+func Signatures(
+	signatures []*types.Signature,
+) error {
+	if len(signatures) == 0 {
+		return errors.New("signatures cannot be empty")
+	}
+
+	for i, signature := range signatures {
+		if err := SigningPayload(signature.SigningPayload); err != nil {
+			return fmt.Errorf("%w: signature %d has invalid signing payload", err, i)
+		}
+
+		if err := PublicKey(signature.PublicKey); err != nil {
+			return fmt.Errorf("%w: signature %d has invalid public key", err, i)
+		}
+
+		if err := SignatureType(signature.SignatureType); err != nil {
+			return fmt.Errorf("%w: signature %d has invalid signature type", err, i)
+		}
+
+		if err := checkHex(signature.HexBytes); err != nil {
+			return fmt.Errorf("%w: signature %d has invalid hex", err, i)
+		}
+	}
+
+	return nil
+}
+
+// SignatureType returns an error if
+// signature is not a valid types.SignatureType.
+func SignatureType(
+	signature types.SignatureType,
+) error {
+	switch signature {
+	case types.Ecdsa, types.EcdsaRecovery, types.Ed25519:
+		return nil
+	default:
+		return fmt.Errorf("%s is not a supported SignatureType", signature)
+	}
 }

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -153,6 +153,13 @@ func Signatures(
 			return fmt.Errorf("%w: signature %d has invalid signature type", err, i)
 		}
 
+		// Return an error if the requested signature type does not match the
+		// signture type in the returned signature.
+		if len(signature.SigningPayload.SignatureType) > 0 &&
+			signature.SigningPayload.SignatureType != signature.SignatureType {
+			return fmt.Errorf("requested signature type does not match returned signature type")
+		}
+
 		if err := checkHex(signature.HexBytes); err != nil {
 			return fmt.Errorf("%w: signature %d has invalid hex", err, i)
 		}

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -117,3 +117,59 @@ func TestPublicKey(t *testing.T) {
 		})
 	}
 }
+
+func TestSigningPayload(t *testing.T) {
+	var tests = map[string]struct {
+		signingPayload *types.SigningPayload
+		err            error
+	}{
+		"valid signing payload": {
+			signingPayload: &types.SigningPayload{
+				Address:  "hello",
+				HexBytes: "48656c6c6f20476f7068657221",
+			},
+		},
+		"valid signing payload with signature type": {
+			signingPayload: &types.SigningPayload{
+				Address:       "hello",
+				HexBytes:      "48656c6c6f20476f7068657221",
+				SignatureType: types.Ed25519,
+			},
+		},
+		"nil signing payload": {
+			err: errors.New("signing payload cannot be nil"),
+		},
+		"empty address": {
+			signingPayload: &types.SigningPayload{
+				HexBytes: "48656c6c6f20476f7068657221",
+			},
+			err: errors.New("signing payload address cannot be empty"),
+		},
+		"empty hex": {
+			signingPayload: &types.SigningPayload{
+				Address: "hello",
+			},
+			err: errors.New("hex string cannot be empty"),
+		},
+		"invalid signature": {
+			signingPayload: &types.SigningPayload{
+				Address:       "hello",
+				HexBytes:      "48656c6c6f20476f7068657221",
+				SignatureType: "blah",
+			},
+			err: errors.New("blah is not a supported SignatureType"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := SigningPayload(test.signingPayload)
+			if test.err != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -173,3 +173,100 @@ func TestSigningPayload(t *testing.T) {
 		})
 	}
 }
+
+func TestSignatures(t *testing.T) {
+	var tests = map[string]struct {
+		signatures []*types.Signature
+		err        error
+	}{
+		"valid signatures": {
+			signatures: []*types.Signature{
+				{
+					SigningPayload: &types.SigningPayload{
+						Address:  validAccount.Address,
+						HexBytes: "48656c6c6f20476f7068657221",
+					},
+					PublicKey:     validPublicKey,
+					SignatureType: types.Ed25519,
+					HexBytes:      "656c6c6f20476f7068657221",
+				},
+				{
+					SigningPayload: &types.SigningPayload{
+						Address:  validAccount.Address,
+						HexBytes: "48656c6c6f20476f7068657221",
+					},
+					PublicKey:     validPublicKey,
+					SignatureType: types.EcdsaRecovery,
+					HexBytes:      "656c6c6f20476f7068657221",
+				},
+			},
+		},
+		"signature type match": {
+			signatures: []*types.Signature{
+				{
+					SigningPayload: &types.SigningPayload{
+						Address:       validAccount.Address,
+						HexBytes:      "48656c6c6f20476f7068657221",
+						SignatureType: types.Ed25519,
+					},
+					PublicKey:     validPublicKey,
+					SignatureType: types.Ed25519,
+					HexBytes:      "656c6c6f20476f7068657221",
+				},
+			},
+		},
+		"nil signatures": {
+			err: errors.New("signatures cannot be empty"),
+		},
+		"empty signature": {
+			signatures: []*types.Signature{
+				{
+					SigningPayload: &types.SigningPayload{
+						Address:  validAccount.Address,
+						HexBytes: "48656c6c6f20476f7068657221",
+					},
+					PublicKey:     validPublicKey,
+					SignatureType: types.EcdsaRecovery,
+					HexBytes:      "656c6c6f20476f7068657221",
+				},
+				{
+					SigningPayload: &types.SigningPayload{
+						Address:       validAccount.Address,
+						HexBytes:      "48656c6c6f20476f7068657221",
+						SignatureType: types.Ed25519,
+					},
+					PublicKey:     validPublicKey,
+					SignatureType: types.Ed25519,
+				},
+			},
+			err: errors.New("signature 1 has invalid hex"),
+		},
+		"signature type mismatch": {
+			signatures: []*types.Signature{
+				{
+					SigningPayload: &types.SigningPayload{
+						Address:       validAccount.Address,
+						HexBytes:      "48656c6c6f20476f7068657221",
+						SignatureType: types.EcdsaRecovery,
+					},
+					PublicKey:     validPublicKey,
+					SignatureType: types.Ed25519,
+					HexBytes:      "656c6c6f20476f7068657221",
+				},
+			},
+			err: errors.New("requested signature type does not match"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := Signatures(test.signatures)
+			if test.err != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -74,3 +74,46 @@ func TestConstructionSubmit(t *testing.T) {
 		})
 	}
 }
+
+func TestPublicKey(t *testing.T) {
+	var tests = map[string]struct {
+		publicKey *types.PublicKey
+		err       error
+	}{
+		"valid public key": {
+			publicKey: &types.PublicKey{
+				HexBytes:  "48656c6c6f20476f7068657221",
+				CurveType: types.Secp256k1,
+			},
+		},
+		"nil public key": {
+			err: errors.New("PublicKey cannot be nil"),
+		},
+		"invalid hex": {
+			publicKey: &types.PublicKey{
+				HexBytes:  "hello",
+				CurveType: types.Secp256k1,
+			},
+			err: errors.New("hello is not a valid hex string"),
+		},
+		"invalid curve": {
+			publicKey: &types.PublicKey{
+				HexBytes:  "48656c6c6f20476f7068657221",
+				CurveType: "test",
+			},
+			err: errors.New("test is not a supported CurveType"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := PublicKey(test.publicKey)
+			if test.err != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -85,7 +85,7 @@ func TestVersion(t *testing.T) {
 	var (
 		middlewareVersion        = "1.2"
 		invalidMiddlewareVersion = ""
-		validRosettaVersion      = "1.2.4"
+		validRosettaVersion      = "1.4.0"
 	)
 
 	var tests = map[string]struct {
@@ -109,7 +109,7 @@ func TestVersion(t *testing.T) {
 		},
 		"old RosettaVersion": {
 			version: &types.Version{
-				RosettaVersion: "1.2.2",
+				RosettaVersion: "1.2.0",
 				NodeVersion:    "1.0",
 			},
 			err: nil,

--- a/asserter/request.go
+++ b/asserter/request.go
@@ -189,24 +189,6 @@ func (a *Asserter) ConstructionSubmitRequest(request *types.ConstructionSubmitRe
 	return nil
 }
 
-// MempoolRequest ensures that a types.MempoolRequest
-// is well-formatted.
-func (a *Asserter) MempoolRequest(request *types.MempoolRequest) error {
-	if a == nil {
-		return ErrAsserterNotInitialized
-	}
-
-	if request == nil {
-		return errors.New("MempoolRequest is nil")
-	}
-
-	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
-		return err
-	}
-
-	return a.SupportedNetwork(request.NetworkIdentifier)
-}
-
 // MempoolTransactionRequest ensures that a types.MempoolTransactionRequest
 // is well-formatted.
 func (a *Asserter) MempoolTransactionRequest(request *types.MempoolTransactionRequest) error {
@@ -263,4 +245,66 @@ func (a *Asserter) NetworkRequest(request *types.NetworkRequest) error {
 	}
 
 	return nil
+}
+
+// ConstructionDeriveRequest ensures that a types.ConstructionDeriveRequest
+// is well-formatted.
+func (a *Asserter) ConstructionDeriveRequest(request *types.ConstructionDeriveRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
+	return errors.New("not implemented")
+}
+
+// ConstructionPreprocessRequest ensures that a types.ConstructionPreprocessRequest
+// is well-formatted.
+func (a *Asserter) ConstructionPreprocessRequest(
+	request *types.ConstructionPreprocessRequest,
+) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
+	return errors.New("not implemented")
+}
+
+// ConstructionPayloadsRequest ensures that a types.ConstructionPayloadsRequest
+// is well-formatted.
+func (a *Asserter) ConstructionPayloadsRequest(request *types.ConstructionPayloadsRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
+	return errors.New("not implemented")
+}
+
+// ConstructionCombineRequest ensures that a types.ConstructionCombineRequest
+// is well-formatted.
+func (a *Asserter) ConstructionCombineRequest(request *types.ConstructionCombineRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
+	return errors.New("not implemented")
+}
+
+// ConstructionHashRequest ensures that a types.ConstructionHashRequest
+// is well-formatted.
+func (a *Asserter) ConstructionHashRequest(request *types.ConstructionHashRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
+	return errors.New("not implemented")
+}
+
+// ConstructionParseRequest ensures that a types.ConstructionParseRequest
+// is well-formatted.
+func (a *Asserter) ConstructionParseRequest(request *types.ConstructionParseRequest) error {
+	if a == nil {
+		return ErrAsserterNotInitialized
+	}
+
+	return errors.New("not implemented")
 }

--- a/asserter/request.go
+++ b/asserter/request.go
@@ -274,7 +274,7 @@ func (a *Asserter) ConstructionPreprocessRequest(
 		return err
 	}
 
-	if err := a.Operations(request.Operations, false); err != nil {
+	if err := a.Operations(request.Operations, true); err != nil {
 		return err
 	}
 
@@ -296,7 +296,7 @@ func (a *Asserter) ConstructionPayloadsRequest(request *types.ConstructionPayloa
 		return err
 	}
 
-	if err := a.Operations(request.Operations, false); err != nil {
+	if err := a.Operations(request.Operations, true); err != nil {
 		return err
 	}
 

--- a/asserter/request.go
+++ b/asserter/request.go
@@ -59,6 +59,22 @@ func (a *Asserter) SupportedNetwork(
 	return nil
 }
 
+// ValidSupportedNetwork returns an error if a types.NetworkIdentifier
+// is not valid or not supported.
+func (a *Asserter) ValidSupportedNetwork(
+	requestNetwork *types.NetworkIdentifier,
+) error {
+	if err := NetworkIdentifier(requestNetwork); err != nil {
+		return err
+	}
+
+	if err := a.SupportedNetwork(requestNetwork); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // AccountBalanceRequest ensures that a types.AccountBalanceRequest
 // is well-formatted.
 func (a *Asserter) AccountBalanceRequest(request *types.AccountBalanceRequest) error {
@@ -70,11 +86,7 @@ func (a *Asserter) AccountBalanceRequest(request *types.AccountBalanceRequest) e
 		return errors.New("AccountBalanceRequest is nil")
 	}
 
-	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
-		return err
-	}
-
-	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -100,11 +112,7 @@ func (a *Asserter) BlockRequest(request *types.BlockRequest) error {
 		return errors.New("BlockRequest is nil")
 	}
 
-	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
-		return err
-	}
-
-	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -122,11 +130,7 @@ func (a *Asserter) BlockTransactionRequest(request *types.BlockTransactionReques
 		return errors.New("BlockTransactionRequest is nil")
 	}
 
-	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
-		return err
-	}
-
-	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -148,11 +152,7 @@ func (a *Asserter) ConstructionMetadataRequest(request *types.ConstructionMetada
 		return errors.New("ConstructionMetadataRequest is nil")
 	}
 
-	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
-		return err
-	}
-
-	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -174,11 +174,7 @@ func (a *Asserter) ConstructionSubmitRequest(request *types.ConstructionSubmitRe
 		return errors.New("ConstructionSubmitRequest is nil")
 	}
 
-	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
-		return err
-	}
-
-	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -200,11 +196,7 @@ func (a *Asserter) MempoolTransactionRequest(request *types.MempoolTransactionRe
 		return errors.New("MempoolTransactionRequest is nil")
 	}
 
-	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
-		return err
-	}
-
-	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -236,11 +228,7 @@ func (a *Asserter) NetworkRequest(request *types.NetworkRequest) error {
 		return errors.New("NetworkRequest is nil")
 	}
 
-	if err := NetworkIdentifier(request.NetworkIdentifier); err != nil {
-		return err
-	}
-
-	if err := a.SupportedNetwork(request.NetworkIdentifier); err != nil {
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
 		return err
 	}
 
@@ -254,7 +242,19 @@ func (a *Asserter) ConstructionDeriveRequest(request *types.ConstructionDeriveRe
 		return ErrAsserterNotInitialized
 	}
 
-	return errors.New("not implemented")
+	if request == nil {
+		return errors.New("ConstructionDeriveRequest is nil")
+	}
+
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if err := PublicKey(request.PublicKey); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConstructionPreprocessRequest ensures that a types.ConstructionPreprocessRequest
@@ -266,7 +266,19 @@ func (a *Asserter) ConstructionPreprocessRequest(
 		return ErrAsserterNotInitialized
 	}
 
-	return errors.New("not implemented")
+	if request == nil {
+		return errors.New("ConstructionPreprocessRequest is nil")
+	}
+
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if err := a.Operations(request.Operations, false); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConstructionPayloadsRequest ensures that a types.ConstructionPayloadsRequest
@@ -276,7 +288,19 @@ func (a *Asserter) ConstructionPayloadsRequest(request *types.ConstructionPayloa
 		return ErrAsserterNotInitialized
 	}
 
-	return errors.New("not implemented")
+	if request == nil {
+		return errors.New("ConstructionPayloadsRequest is nil")
+	}
+
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if err := a.Operations(request.Operations, false); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConstructionCombineRequest ensures that a types.ConstructionCombineRequest
@@ -286,7 +310,23 @@ func (a *Asserter) ConstructionCombineRequest(request *types.ConstructionCombine
 		return ErrAsserterNotInitialized
 	}
 
-	return errors.New("not implemented")
+	if request == nil {
+		return errors.New("ConstructionCombineRequest is nil")
+	}
+
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if len(request.UnsignedTransaction) == 0 {
+		return errors.New("UnsignedTransaction cannot be empty")
+	}
+
+	if err := Signatures(request.Signatures); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConstructionHashRequest ensures that a types.ConstructionHashRequest
@@ -296,7 +336,19 @@ func (a *Asserter) ConstructionHashRequest(request *types.ConstructionHashReques
 		return ErrAsserterNotInitialized
 	}
 
-	return errors.New("not implemented")
+	if request == nil {
+		return errors.New("ConstructionHashRequest is nil")
+	}
+
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if len(request.SignedTransaction) == 0 {
+		return errors.New("SignedTransaction cannot be empty")
+	}
+
+	return nil
 }
 
 // ConstructionParseRequest ensures that a types.ConstructionParseRequest
@@ -306,5 +358,17 @@ func (a *Asserter) ConstructionParseRequest(request *types.ConstructionParseRequ
 		return ErrAsserterNotInitialized
 	}
 
-	return errors.New("not implemented")
+	if request == nil {
+		return errors.New("ConstructionParseRequest is nil")
+	}
+
+	if err := a.ValidSupportedNetwork(request.NetworkIdentifier); err != nil {
+		return err
+	}
+
+	if len(request.Transaction) == 0 {
+		return errors.New("Transaction cannot be empty")
+	}
+
+	return nil
 }

--- a/asserter/request.go
+++ b/asserter/request.go
@@ -98,6 +98,10 @@ func (a *Asserter) AccountBalanceRequest(request *types.AccountBalanceRequest) e
 		return nil
 	}
 
+	if request.BlockIdentifier != nil && !a.historicalBalanceLookup {
+		return errors.New("historical balance lookup is not supported")
+	}
+
 	return PartialBlockIdentifier(request.BlockIdentifier)
 }
 

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -39,11 +39,7 @@ var (
 		Address: "acct1",
 	}
 
-	genesisBlockIndex      = int64(0)
-	genesisBlockIdentifier = &types.BlockIdentifier{
-		Index: genesisBlockIndex,
-		Hash:  "block 0",
-	}
+	genesisBlockIndex           = int64(0)
 	validBlockIndex             = int64(1000)
 	validPartialBlockIdentifier = &types.PartialBlockIdentifier{
 		Index: &validBlockIndex,

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -861,7 +861,7 @@ func TestConstructionCombineRequest(t *testing.T) {
 			},
 			err: errors.New("signatures cannot be empty"),
 		},
-		"singature type mismatch": {
+		"signature type mismatch": {
 			request: &types.ConstructionCombineRequest{
 				NetworkIdentifier:   validNetworkIdentifier,
 				UnsignedTransaction: "blah",
@@ -877,7 +877,7 @@ func TestConstructionCombineRequest(t *testing.T) {
 			},
 			err: errors.New("hex string cannot be empty"),
 		},
-		"singature type match": {
+		"signature type match": {
 			request: &types.ConstructionCombineRequest{
 				NetworkIdentifier:   validNetworkIdentifier,
 				UnsignedTransaction: "blah",

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -376,45 +376,6 @@ func TestConstructionSubmitRequest(t *testing.T) {
 	}
 }
 
-func TestMempoolRequest(t *testing.T) {
-	var tests = map[string]struct {
-		request *types.MempoolRequest
-		err     error
-	}{
-		"valid request": {
-			request: &types.MempoolRequest{
-				NetworkIdentifier: validNetworkIdentifier,
-			},
-			err: nil,
-		},
-		"invalid request wrong network": {
-			request: &types.MempoolRequest{
-				NetworkIdentifier: wrongNetworkIdentifier,
-			},
-			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
-		},
-		"nil request": {
-			request: nil,
-			err:     errors.New("MempoolRequest is nil"),
-		},
-		"empty tx": {
-			request: &types.MempoolRequest{},
-			err:     errors.New("NetworkIdentifier is nil"),
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.MempoolRequest(test.request)
-			assert.Equal(t, test.err, err)
-		})
-	}
-}
-
 func TestMempoolTransactionRequest(t *testing.T) {
 	var tests = map[string]struct {
 		request *types.MempoolTransactionRequest

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -941,3 +941,46 @@ func TestConstructionHashRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestConstructionParseRequest(t *testing.T) {
+	var tests = map[string]struct {
+		request *types.ConstructionParseRequest
+		err     error
+	}{
+		"valid request": {
+			request: &types.ConstructionParseRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Transaction:       "blah",
+			},
+			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.ConstructionParseRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
+		},
+		"nil request": {
+			request: nil,
+			err:     errors.New("ConstructionParseRequest is nil"),
+		},
+		"empty signed transaction": {
+			request: &types.ConstructionParseRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+			},
+			err: errors.New("Transaction cannot be empty"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := a.ConstructionParseRequest(test.request)
+			if test.err != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -39,7 +39,11 @@ var (
 		Address: "acct1",
 	}
 
-	genesisBlockIndex           = int64(0)
+	genesisBlockIndex      = int64(0)
+	genesisBlockIdentifier = &types.BlockIdentifier{
+		Index: genesisBlockIndex,
+		Hash:  "block 0",
+	}
 	validBlockIndex             = int64(1000)
 	validPartialBlockIdentifier = &types.PartialBlockIdentifier{
 		Index: &validBlockIndex,
@@ -58,7 +62,106 @@ var (
 		HexBytes:  "48656c6c6f20476f7068657221",
 		CurveType: types.Secp256k1,
 	}
+
+	validAmount = &types.Amount{
+		Value: "1000",
+		Currency: &types.Currency{
+			Symbol:   "BTC",
+			Decimals: 8,
+		},
+	}
+
+	validAccount = &types.AccountIdentifier{
+		Address: "test",
+	}
+
+	validOps = []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(0),
+			},
+			Type:    "PAYMENT",
+			Account: validAccount,
+			Amount:  validAmount,
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(1),
+			},
+			RelatedOperations: []*types.OperationIdentifier{
+				{
+					Index: int64(0),
+				},
+			},
+			Type:    "PAYMENT",
+			Account: validAccount,
+			Amount:  validAmount,
+		},
+	}
+
+	unsupportedTypeOps = []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(0),
+			},
+			Type:    "STAKE",
+			Account: validAccount,
+			Amount:  validAmount,
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(1),
+			},
+			RelatedOperations: []*types.OperationIdentifier{
+				{
+					Index: int64(0),
+				},
+			},
+			Type:    "PAYMENT",
+			Account: validAccount,
+			Amount:  validAmount,
+		},
+	}
+
+	invalidOps = []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(0),
+			},
+			Type:    "PAYMENT",
+			Status:  "SUCCESS",
+			Account: validAccount,
+			Amount:  validAmount,
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: int64(1),
+			},
+			RelatedOperations: []*types.OperationIdentifier{
+				{
+					Index: int64(0),
+				},
+			},
+			Type:    "PAYMENT",
+			Status:  "SUCCESS",
+			Account: validAccount,
+			Amount:  validAmount,
+		},
+	}
+
+	a, aErr = NewServer(
+		[]string{"PAYMENT"},
+		true,
+		[]*types.NetworkIdentifier{validNetworkIdentifier},
+	)
 )
+
+func TestNewWithOptions(t *testing.T) {
+	t.Run("ensure asserter initialized", func(t *testing.T) {
+		assert.NotNil(t, a)
+		assert.NoError(t, aErr)
+	})
+}
 
 func TestSupportedNetworks(t *testing.T) {
 	var tests = map[string]struct {
@@ -156,11 +259,7 @@ func TestAccountBalanceRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.AccountBalanceRequest(test.request)
+			err := a.AccountBalanceRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -221,11 +320,7 @@ func TestBlockRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.BlockRequest(test.request)
+			err := a.BlockRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -281,11 +376,7 @@ func TestBlockTransactionRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.BlockTransactionRequest(test.request)
+			err := a.BlockTransactionRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -330,11 +421,7 @@ func TestConstructionMetadataRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.ConstructionMetadataRequest(test.request)
+			err := a.ConstructionMetadataRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -371,11 +458,7 @@ func TestConstructionSubmitRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.ConstructionSubmitRequest(test.request)
+			err := a.ConstructionSubmitRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -421,11 +504,7 @@ func TestMempoolTransactionRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.MempoolTransactionRequest(test.request)
+			err := a.MempoolTransactionRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -448,11 +527,7 @@ func TestMetadataRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.MetadataRequest(test.request)
+			err := a.MetadataRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -487,11 +562,7 @@ func TestNetworkRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
-
-			err = a.NetworkRequest(test.request)
+			err := a.NetworkRequest(test.request)
 			assert.Equal(t, test.err, err)
 		})
 	}
@@ -539,11 +610,71 @@ func TestConstructionDeriveRequest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			a, err := NewServer([]*types.NetworkIdentifier{validNetworkIdentifier})
-			assert.NoError(t, err)
-			assert.NotNil(t, a)
+			err := a.ConstructionDeriveRequest(test.request)
+			if test.err != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
-			err = a.ConstructionDeriveRequest(test.request)
+func TestConstructionPreprocessRequest(t *testing.T) {
+	var tests = map[string]struct {
+		request *types.ConstructionPreprocessRequest
+		err     error
+	}{
+		"valid request": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        validOps,
+			},
+			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
+		},
+		"nil request": {
+			request: nil,
+			err:     errors.New("ConstructionPreprocessRequest is nil"),
+		},
+		"nil operations": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+			},
+			err: errors.New("operations cannot be empty"),
+		},
+		"empty operations": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        []*types.Operation{},
+			},
+			err: errors.New("operations cannot be empty"),
+		},
+		"unsupported operation type": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        unsupportedTypeOps,
+			},
+			err: errors.New("Operation.Type STAKE is invalid"),
+		},
+		"invalid operations": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        invalidOps,
+			},
+			err: errors.New("must be empty for construction"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := a.ConstructionPreprocessRequest(test.request)
 			if test.err != nil {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), test.err.Error())

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -898,3 +898,46 @@ func TestConstructionCombineRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestConstructionHashRequest(t *testing.T) {
+	var tests = map[string]struct {
+		request *types.ConstructionHashRequest
+		err     error
+	}{
+		"valid request": {
+			request: &types.ConstructionHashRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				SignedTransaction: "blah",
+			},
+			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.ConstructionHashRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
+		},
+		"nil request": {
+			request: nil,
+			err:     errors.New("ConstructionHashRequest is nil"),
+		},
+		"empty signed transaction": {
+			request: &types.ConstructionHashRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+			},
+			err: errors.New("SignedTransaction cannot be empty"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := a.ConstructionHashRequest(test.request)
+			if test.err != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -704,3 +704,68 @@ func TestConstructionPreprocessRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestConstructionPayloadsRequest(t *testing.T) {
+	var tests = map[string]struct {
+		request *types.ConstructionPayloadsRequest
+		err     error
+	}{
+		"valid request": {
+			request: &types.ConstructionPayloadsRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        validOps,
+				Metadata:          map[string]interface{}{"test": "hello"},
+			},
+			err: nil,
+		},
+		"invalid request wrong network": {
+			request: &types.ConstructionPayloadsRequest{
+				NetworkIdentifier: wrongNetworkIdentifier,
+			},
+			err: fmt.Errorf("%+v is not supported", wrongNetworkIdentifier),
+		},
+		"nil request": {
+			request: nil,
+			err:     errors.New("ConstructionPayloadsRequest is nil"),
+		},
+		"nil operations": {
+			request: &types.ConstructionPayloadsRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+			},
+			err: errors.New("operations cannot be empty"),
+		},
+		"empty operations": {
+			request: &types.ConstructionPayloadsRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        []*types.Operation{},
+			},
+			err: errors.New("operations cannot be empty"),
+		},
+		"unsupported operation type": {
+			request: &types.ConstructionPayloadsRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        unsupportedTypeOps,
+			},
+			err: errors.New("Operation.Type STAKE is invalid"),
+		},
+		"invalid operations": {
+			request: &types.ConstructionPayloadsRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        invalidOps,
+			},
+			err: errors.New("must be empty for construction"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := a.ConstructionPayloadsRequest(test.request)
+			if test.err != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/client/api_account.go
+++ b/client/api_account.go
@@ -33,14 +33,17 @@ var (
 // AccountAPIService AccountAPI service
 type AccountAPIService service
 
-// AccountBalance Get an array of all Account Balances for an Account Identifier and the Block
-// Identifier at which the balance lookup was performed.  Some consumers of account balance data
-// need to know at which block the balance was calculated to reconcile account balance changes.  To
-// get all balances associated with an account, it may be necessary to perform multiple balance
-// requests with unique Account Identifiers.  If the client supports it, passing nil
-// AccountIdentifier metadata to the request should fetch all balances (if applicable).  It is also
-// possible to perform a historical balance lookup (if the server supports it) by passing in an
-// optional BlockIdentifier.
+// AccountBalance Get an array of all AccountBalances for an AccountIdentifier and the
+// BlockIdentifier at which the balance lookup was performed. The BlockIdentifier must always be
+// returned because some consumers of account balance data need to know specifically at which block
+// the balance was calculated to compare balances they compute from operations with the balance
+// returned by the node. It is important to note that making a balance request for an account
+// without populating the SubAccountIdentifier should not result in the balance of all possible
+// SubAccountIdentifiers being returned. Rather, it should result in the balance pertaining to no
+// SubAccountIdentifiers being returned (sometimes called the liquid balance). To get all balances
+// associated with an account, it may be necessary to perform multiple balance requests with unique
+// AccountIdentifiers. It is also possible to perform a historical balance lookup (if the server
+// supports it) by passing in an optional BlockIdentifier.
 func (a *AccountAPIService) AccountBalance(
 	ctx _context.Context,
 	accountBalanceRequest *types.AccountBalanceRequest,

--- a/client/api_block.go
+++ b/client/api_block.go
@@ -106,14 +106,14 @@ func (a *BlockAPIService) Block(
 
 // BlockTransaction Get a transaction in a block by its Transaction Identifier. This endpoint should
 // only be used when querying a node for a block does not return all transactions contained within
-// it.  All transactions returned by this endpoint must be appended to any transactions returned by
+// it. All transactions returned by this endpoint must be appended to any transactions returned by
 // the /block method by consumers of this data. Fetching a transaction by hash is considered an
-// Explorer Method (which is classified under the Future Work section).  Calling this endpoint
+// Explorer Method (which is classified under the Future Work section). Calling this endpoint
 // requires reference to a BlockIdentifier because transaction parsing can change depending on which
 // block contains the transaction. For example, in Bitcoin it is necessary to know which block
 // contains a transaction to determine the destination of fee payments. Without specifying a block
 // identifier, the node would have to infer which block to use (which could change during a re-org).
-//  Implementations that require fetching previous transactions to populate the response (ex:
+// Implementations that require fetching previous transactions to populate the response (ex:
 // Previous UTXOs in Bitcoin) may find it useful to run a cache within the Rosetta server in the
 // /data directory (on a path that does not conflict with the node).
 func (a *BlockAPIService) BlockTransaction(

--- a/client/api_construction.go
+++ b/client/api_construction.go
@@ -33,16 +33,222 @@ var (
 // ConstructionAPIService ConstructionAPI service
 type ConstructionAPIService service
 
+// ConstructionCombine Combine creates a network-specific transaction from an unsigned transaction
+// and an array of provided signatures. The signed transaction returned from this method will be
+// sent to the /construction/submit endpoint by the caller.
+func (a *ConstructionAPIService) ConstructionCombine(
+	ctx _context.Context,
+	constructionCombineRequest *types.ConstructionCombineRequest,
+) (*types.ConstructionCombineResponse, *types.Error, error) {
+	var (
+		localVarPostBody interface{}
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/construction/combine"
+	localVarHeaderParams := make(map[string]string)
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = constructionCombineRequest
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(ctx, r)
+	if err != nil || localVarHTTPResponse == nil {
+		return nil, nil, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	defer localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, &v, fmt.Errorf("%+v", v)
+	}
+
+	var v types.ConstructionCombineResponse
+	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &v, nil, nil
+}
+
+// ConstructionDerive Derive returns the network-specific address associated with a public key.
+// Blockchains that require an on-chain action to create an account should not implement this
+// method.
+func (a *ConstructionAPIService) ConstructionDerive(
+	ctx _context.Context,
+	constructionDeriveRequest *types.ConstructionDeriveRequest,
+) (*types.ConstructionDeriveResponse, *types.Error, error) {
+	var (
+		localVarPostBody interface{}
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/construction/derive"
+	localVarHeaderParams := make(map[string]string)
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = constructionDeriveRequest
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(ctx, r)
+	if err != nil || localVarHTTPResponse == nil {
+		return nil, nil, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	defer localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, &v, fmt.Errorf("%+v", v)
+	}
+
+	var v types.ConstructionDeriveResponse
+	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &v, nil, nil
+}
+
+// ConstructionHash TransactionHash returns the network-specific transaction hash for a signed
+// transaction.
+func (a *ConstructionAPIService) ConstructionHash(
+	ctx _context.Context,
+	constructionHashRequest *types.ConstructionHashRequest,
+) (*types.ConstructionHashResponse, *types.Error, error) {
+	var (
+		localVarPostBody interface{}
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/construction/hash"
+	localVarHeaderParams := make(map[string]string)
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = constructionHashRequest
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(ctx, r)
+	if err != nil || localVarHTTPResponse == nil {
+		return nil, nil, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	defer localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, &v, fmt.Errorf("%+v", v)
+	}
+
+	var v types.ConstructionHashResponse
+	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &v, nil, nil
+}
+
 // ConstructionMetadata Get any information required to construct a transaction for a specific
 // network. Metadata returned here could be a recent hash to use, an account sequence number, or
-// even arbitrary chain state. It is up to the client to correctly populate the options object with
-// any network-specific details to ensure the correct metadata is retrieved.  It is important to
-// clarify that this endpoint should not pre-construct any transactions for the client (this should
-// happen in the SDK). This endpoint is left purposely unstructured because of the wide scope of
-// metadata that could be required.  In a future version of the spec, we plan to pass an array of
-// Rosetta Operations to specify which metadata should be received and to create a transaction in an
-// accompanying SDK. This will help to insulate the client from chain-specific details that are
-// currently required here.
+// even arbitrary chain state. The request used when calling this endpoint is often created by
+// calling /construction/preprocess in an offline environment. It is important to clarify that this
+// endpoint should not pre-construct any transactions for the client (this should happen in
+// /construction/payloads). This endpoint is left purposely unstructured because of the wide scope
+// of metadata that could be required.
 func (a *ConstructionAPIService) ConstructionMetadata(
 	ctx _context.Context,
 	constructionMetadataRequest *types.ConstructionMetadataRequest,
@@ -110,9 +316,225 @@ func (a *ConstructionAPIService) ConstructionMetadata(
 	return &v, nil, nil
 }
 
+// ConstructionParse Parse is called on both unsigned and signed transactions to understand the
+// intent of the formulated transaction. This is run as a sanity check before signing (after
+// /construction/payloads) and before broadcast (after /construction/combine).
+func (a *ConstructionAPIService) ConstructionParse(
+	ctx _context.Context,
+	constructionParseRequest *types.ConstructionParseRequest,
+) (*types.ConstructionParseResponse, *types.Error, error) {
+	var (
+		localVarPostBody interface{}
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/construction/parse"
+	localVarHeaderParams := make(map[string]string)
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = constructionParseRequest
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(ctx, r)
+	if err != nil || localVarHTTPResponse == nil {
+		return nil, nil, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	defer localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, &v, fmt.Errorf("%+v", v)
+	}
+
+	var v types.ConstructionParseResponse
+	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &v, nil, nil
+}
+
+// ConstructionPayloads Payloads is called with an array of operations and the response from
+// /construction/metadata. It returns an unsigned transaction blob and a collection of payloads that
+// must be signed by particular addresses using a certain SignatureType. The array of operations
+// provided in transaction construction often times can not specify all \effects\ of a transaction
+// (consider invoked transactions in Ethereum). However, they can deterministically specify the
+// \intent\ of the transaction, which is sufficient for construction. For this reason, parsing the
+// corresponding transaction in the Data API (when it lands on chain) will contain a superset of
+// whatever operations were provided during construction.
+func (a *ConstructionAPIService) ConstructionPayloads(
+	ctx _context.Context,
+	constructionPayloadsRequest *types.ConstructionPayloadsRequest,
+) (*types.ConstructionPayloadsResponse, *types.Error, error) {
+	var (
+		localVarPostBody interface{}
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/construction/payloads"
+	localVarHeaderParams := make(map[string]string)
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = constructionPayloadsRequest
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(ctx, r)
+	if err != nil || localVarHTTPResponse == nil {
+		return nil, nil, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	defer localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, &v, fmt.Errorf("%+v", v)
+	}
+
+	var v types.ConstructionPayloadsResponse
+	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &v, nil, nil
+}
+
+// ConstructionPreprocess Preprocess is called prior to /construction/payloads to construct a
+// request for any metadata that is needed for transaction construction given (i.e. account nonce).
+// The request returned from this method will be used by the caller (in a different execution
+// environment) to call the /construction/metadata endpoint.
+func (a *ConstructionAPIService) ConstructionPreprocess(
+	ctx _context.Context,
+	constructionPreprocessRequest *types.ConstructionPreprocessRequest,
+) (*types.ConstructionPreprocessResponse, *types.Error, error) {
+	var (
+		localVarPostBody interface{}
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/construction/preprocess"
+	localVarHeaderParams := make(map[string]string)
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = constructionPreprocessRequest
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(ctx, r)
+	if err != nil || localVarHTTPResponse == nil {
+		return nil, nil, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	defer localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, &v, fmt.Errorf("%+v", v)
+	}
+
+	var v types.ConstructionPreprocessResponse
+	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &v, nil, nil
+}
+
 // ConstructionSubmit Submit a pre-signed transaction to the node. This call should not block on the
 // transaction being included in a block. Rather, it should return immediately with an indication of
-// whether or not the transaction was included in the mempool.  The transaction submission response
+// whether or not the transaction was included in the mempool. The transaction submission response
 // should only return a 200 status if the submitted transaction could be included in the mempool.
 // Otherwise, it should return an error.
 func (a *ConstructionAPIService) ConstructionSubmit(

--- a/client/api_mempool.go
+++ b/client/api_mempool.go
@@ -36,7 +36,7 @@ type MempoolAPIService service
 // Mempool Get all Transaction Identifiers in the mempool
 func (a *MempoolAPIService) Mempool(
 	ctx _context.Context,
-	mempoolRequest *types.MempoolRequest,
+	networkRequest *types.NetworkRequest,
 ) (*types.MempoolResponse, *types.Error, error) {
 	var (
 		localVarPostBody interface{}
@@ -64,7 +64,7 @@ func (a *MempoolAPIService) Mempool(
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = mempoolRequest
+	localVarPostBody = networkRequest
 
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarPostBody, localVarHeaderParams)
 	if err != nil {
@@ -104,10 +104,10 @@ func (a *MempoolAPIService) Mempool(
 // MempoolTransaction Get a transaction in the mempool by its Transaction Identifier. This is a
 // separate request than fetching a block transaction (/block/transaction) because some blockchain
 // nodes need to know that a transaction query is for something in the mempool instead of a
-// transaction in a block.  Transactions may not be fully parsable until they are in a block (ex:
-// may not be possible to determine the fee to pay before a transaction is executed). On this
-// endpoint, it is ok that returned transactions are only estimates of what may actually be included
-// in a block.
+// transaction in a block. Transactions may not be fully parsable until they are in a block (ex: may
+// not be possible to determine the fee to pay before a transaction is executed). On this endpoint,
+// it is ok that returned transactions are only estimates of what may actually be included in a
+// block.
 func (a *MempoolAPIService) MempoolTransaction(
 	ctx _context.Context,
 	mempoolTransactionRequest *types.MempoolTransactionRequest,

--- a/client/api_network.go
+++ b/client/api_network.go
@@ -33,8 +33,7 @@ var (
 // NetworkAPIService NetworkAPI service
 type NetworkAPIService service
 
-// NetworkList This endpoint returns a list of NetworkIdentifiers that the Rosetta server can
-// handle.
+// NetworkList This endpoint returns a list of NetworkIdentifiers that the Rosetta server supports.
 func (a *NetworkAPIService) NetworkList(
 	ctx _context.Context,
 	metadataRequest *types.MetadataRequest,
@@ -104,7 +103,7 @@ func (a *NetworkAPIService) NetworkList(
 
 // NetworkOptions This endpoint returns the version information and allowed network-specific types
 // for a NetworkIdentifier. Any NetworkIdentifier returned by /network/list should be accessible
-// here.  Because options are retrievable in the context of a NetworkIdentifier, it is possible to
+// here. Because options are retrievable in the context of a NetworkIdentifier, it is possible to
 // define unique options for each network.
 func (a *NetworkAPIService) NetworkOptions(
 	ctx _context.Context,

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ var (
 	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
 )
 
-// APIClient manages communication with the Rosetta API v1.3.1
+// APIClient manages communication with the Rosetta API v1.4.0
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,7 +53,7 @@ done
 rm -rf tmp;
 
 # Download spec file from releases
-ROSETTA_SPEC_VERSION=v1.3.1
+ROSETTA_SPEC_VERSION=v1.4.0
 curl -L https://github.com/coinbase/rosetta-specifications/releases/download/${ROSETTA_SPEC_VERSION}/api.json -o api.json;
 
 # Generate client + types code
@@ -113,6 +113,17 @@ sed "${SED_IFLAG[@]}" 's/Api/API/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/Json/JSON/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/Id /ID /g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/Url/URL/g' client/* server/*;
+
+# Fix enum pointers
+sed "${SED_IFLAG[@]}" 's/*CurveType/CurveType/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/*SignatureType/SignatureType/g' client/* server/*;
+
+# Fix CurveTypes and SignatureTypes
+sed "${SED_IFLAG[@]}" 's/SECP256K1/Secp256k1/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/EDWARDS25519/Edwards25519/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/ECDSA_RECOVERY/EcdsaRecovery/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/ECDSA/Ecdsa/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/ED25519/Ed25519/g' client/* server/*;
 
 # Remove special characters
 sed "${SED_IFLAG[@]}" 's/&#x60;//g' client/* server/*;

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -124,7 +124,7 @@ func main() {
 	//
 	// This will be used later to assert that a fetched block is
 	// valid.
-	asserter, err := asserter.NewWithResponses(
+	asserter, err := asserter.NewClientWithResponses(
 		primaryNetwork,
 		networkStatus,
 		networkOptions,

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -124,7 +124,7 @@ func main() {
 	//
 	// This will be used later to assert that a fetched block is
 	// valid.
-	asserter, err := asserter.NewClientWithResponses(
+	asserter, err := asserter.NewWithResponses(
 		primaryNetwork,
 		networkStatus,
 		networkOptions,

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -59,7 +59,7 @@ func main() {
 	// The asserter automatically rejects incorrectly formatted
 	// requests.
 	asserter, err := asserter.NewServer(
-		[]string{"PAYMENT"},
+		[]string{"Transfer", "Reward"},
 		false,
 		[]*types.NetworkIdentifier{network},
 	)

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -58,7 +58,11 @@ func main() {
 
 	// The asserter automatically rejects incorrectly formatted
 	// requests.
-	asserter, err := asserter.NewServer([]*types.NetworkIdentifier{network})
+	asserter, err := asserter.NewServer(
+		[]string{"PAYMENT"},
+		false,
+		[]*types.NetworkIdentifier{network},
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/server/services/network_service.go
+++ b/examples/server/services/network_service.go
@@ -75,7 +75,7 @@ func (s *NetworkAPIService) NetworkOptions(
 ) (*types.NetworkOptionsResponse, *types.Error) {
 	return &types.NetworkOptionsResponse{
 		Version: &types.Version{
-			RosettaVersion: "1.3.0",
+			RosettaVersion: "1.4.0",
 			NodeVersion:    "0.0.1",
 		},
 		Allow: &types.Allow{

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -125,7 +125,7 @@ func TestBlockRetry(t *testing.T) {
 			}))
 
 			defer ts.Close()
-			a, err := asserter.NewClientWithOptions(
+			a, err := asserter.NewWithOptions(
 				basicNetwork,
 				&types.BlockIdentifier{
 					Index: 0,
@@ -134,6 +134,7 @@ func TestBlockRetry(t *testing.T) {
 				basicNetworkOptions.Allow.OperationTypes,
 				basicNetworkOptions.Allow.OperationStatuses,
 				nil,
+				false,
 			)
 			assert.NoError(err)
 

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -125,7 +125,7 @@ func TestBlockRetry(t *testing.T) {
 			}))
 
 			defer ts.Close()
-			a, err := asserter.NewWithOptions(
+			a, err := asserter.NewClientWithOptions(
 				basicNetwork,
 				&types.BlockIdentifier{
 					Index: 0,
@@ -134,7 +134,6 @@ func TestBlockRetry(t *testing.T) {
 				basicNetworkOptions.Allow.OperationTypes,
 				basicNetworkOptions.Allow.OperationStatuses,
 				nil,
-				false,
 			)
 			assert.NoError(err)
 

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -157,7 +157,7 @@ func (f *Fetcher) InitializeAsserter(
 		return nil, nil, err
 	}
 
-	f.Asserter, err = asserter.NewClientWithResponses(
+	f.Asserter, err = asserter.NewWithResponses(
 		primaryNetwork,
 		networkStatus,
 		networkOptions,

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -157,7 +157,7 @@ func (f *Fetcher) InitializeAsserter(
 		return nil, nil, err
 	}
 
-	f.Asserter, err = asserter.NewWithResponses(
+	f.Asserter, err = asserter.NewClientWithResponses(
 		primaryNetwork,
 		networkStatus,
 		networkOptions,

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -30,7 +30,7 @@ func (f *Fetcher) Mempool(
 ) ([]*types.TransactionIdentifier, error) {
 	response, _, err := f.rosettaClient.MempoolAPI.Mempool(
 		ctx,
-		&types.MempoolRequest{
+		&types.NetworkRequest{
 			NetworkIdentifier: network,
 		},
 	)

--- a/fetcher/network_test.go
+++ b/fetcher/network_test.go
@@ -47,7 +47,7 @@ var (
 
 	basicNetworkOptions = &types.NetworkOptionsResponse{
 		Version: &types.Version{
-			RosettaVersion: "1.3.1",
+			RosettaVersion: "1.4.0",
 			NodeVersion:    "0.0.1",
 		},
 		Allow: &types.Allow{

--- a/parser/balance_changes_test.go
+++ b/parser/balance_changes_test.go
@@ -310,7 +310,7 @@ func simpleTransactionFactory(
 func simpleAsserterConfiguration(
 	allowedStatus []*types.OperationStatus,
 ) (*asserter.Asserter, error) {
-	return asserter.NewWithOptions(
+	return asserter.NewClientWithOptions(
 		&types.NetworkIdentifier{
 			Blockchain: "bitcoin",
 			Network:    "mainnet",
@@ -322,6 +322,5 @@ func simpleAsserterConfiguration(
 		[]string{"Transfer"},
 		allowedStatus,
 		[]*types.Error{},
-		false,
 	)
 }

--- a/parser/balance_changes_test.go
+++ b/parser/balance_changes_test.go
@@ -310,7 +310,7 @@ func simpleTransactionFactory(
 func simpleAsserterConfiguration(
 	allowedStatus []*types.OperationStatus,
 ) (*asserter.Asserter, error) {
-	return asserter.NewClientWithOptions(
+	return asserter.NewWithOptions(
 		&types.NetworkIdentifier{
 			Blockchain: "bitcoin",
 			Network:    "mainnet",
@@ -322,5 +322,6 @@ func simpleAsserterConfiguration(
 		[]string{"Transfer"},
 		allowedStatus,
 		[]*types.Error{},
+		false,
 	)
 }

--- a/server/api.go
+++ b/server/api.go
@@ -49,7 +49,13 @@ type BlockAPIRouter interface {
 // pass the data to a ConstructionAPIServicer to perform the required actions, then write the
 // service results to the http response.
 type ConstructionAPIRouter interface {
+	ConstructionCombine(http.ResponseWriter, *http.Request)
+	ConstructionDerive(http.ResponseWriter, *http.Request)
+	ConstructionHash(http.ResponseWriter, *http.Request)
 	ConstructionMetadata(http.ResponseWriter, *http.Request)
+	ConstructionParse(http.ResponseWriter, *http.Request)
+	ConstructionPayloads(http.ResponseWriter, *http.Request)
+	ConstructionPreprocess(http.ResponseWriter, *http.Request)
 	ConstructionSubmit(http.ResponseWriter, *http.Request)
 }
 
@@ -102,10 +108,34 @@ type BlockAPIServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type ConstructionAPIServicer interface {
+	ConstructionCombine(
+		context.Context,
+		*types.ConstructionCombineRequest,
+	) (*types.ConstructionCombineResponse, *types.Error)
+	ConstructionDerive(
+		context.Context,
+		*types.ConstructionDeriveRequest,
+	) (*types.ConstructionDeriveResponse, *types.Error)
+	ConstructionHash(
+		context.Context,
+		*types.ConstructionHashRequest,
+	) (*types.ConstructionHashResponse, *types.Error)
 	ConstructionMetadata(
 		context.Context,
 		*types.ConstructionMetadataRequest,
 	) (*types.ConstructionMetadataResponse, *types.Error)
+	ConstructionParse(
+		context.Context,
+		*types.ConstructionParseRequest,
+	) (*types.ConstructionParseResponse, *types.Error)
+	ConstructionPayloads(
+		context.Context,
+		*types.ConstructionPayloadsRequest,
+	) (*types.ConstructionPayloadsResponse, *types.Error)
+	ConstructionPreprocess(
+		context.Context,
+		*types.ConstructionPreprocessRequest,
+	) (*types.ConstructionPreprocessResponse, *types.Error)
 	ConstructionSubmit(
 		context.Context,
 		*types.ConstructionSubmitRequest,
@@ -117,7 +147,7 @@ type ConstructionAPIServicer interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type MempoolAPIServicer interface {
-	Mempool(context.Context, *types.MempoolRequest) (*types.MempoolResponse, *types.Error)
+	Mempool(context.Context, *types.NetworkRequest) (*types.MempoolResponse, *types.Error)
 	MempoolTransaction(
 		context.Context,
 		*types.MempoolTransactionRequest,

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -47,10 +47,46 @@ func NewConstructionAPIController(
 func (c *ConstructionAPIController) Routes() Routes {
 	return Routes{
 		{
+			"ConstructionCombine",
+			strings.ToUpper("Post"),
+			"/construction/combine",
+			c.ConstructionCombine,
+		},
+		{
+			"ConstructionDerive",
+			strings.ToUpper("Post"),
+			"/construction/derive",
+			c.ConstructionDerive,
+		},
+		{
+			"ConstructionHash",
+			strings.ToUpper("Post"),
+			"/construction/hash",
+			c.ConstructionHash,
+		},
+		{
 			"ConstructionMetadata",
 			strings.ToUpper("Post"),
 			"/construction/metadata",
 			c.ConstructionMetadata,
+		},
+		{
+			"ConstructionParse",
+			strings.ToUpper("Post"),
+			"/construction/parse",
+			c.ConstructionParse,
+		},
+		{
+			"ConstructionPayloads",
+			strings.ToUpper("Post"),
+			"/construction/payloads",
+			c.ConstructionPayloads,
+		},
+		{
+			"ConstructionPreprocess",
+			strings.ToUpper("Post"),
+			"/construction/preprocess",
+			c.ConstructionPreprocess,
 		},
 		{
 			"ConstructionSubmit",
@@ -61,7 +97,97 @@ func (c *ConstructionAPIController) Routes() Routes {
 	}
 }
 
-// ConstructionMetadata - Get Transaction Construction Metadata
+// ConstructionCombine - Create Network Transaction from Signatures
+func (c *ConstructionAPIController) ConstructionCombine(w http.ResponseWriter, r *http.Request) {
+	constructionCombineRequest := &types.ConstructionCombineRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&constructionCombineRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	// Assert that ConstructionCombineRequest is correct
+	if err := c.asserter.ConstructionCombineRequest(constructionCombineRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	result, serviceErr := c.service.ConstructionCombine(r.Context(), constructionCombineRequest)
+	if serviceErr != nil {
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+// ConstructionDerive - Derive an Address from a PublicKey
+func (c *ConstructionAPIController) ConstructionDerive(w http.ResponseWriter, r *http.Request) {
+	constructionDeriveRequest := &types.ConstructionDeriveRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&constructionDeriveRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	// Assert that ConstructionDeriveRequest is correct
+	if err := c.asserter.ConstructionDeriveRequest(constructionDeriveRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	result, serviceErr := c.service.ConstructionDerive(r.Context(), constructionDeriveRequest)
+	if serviceErr != nil {
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+// ConstructionHash - Get the Hash of a Signed Transaction
+func (c *ConstructionAPIController) ConstructionHash(w http.ResponseWriter, r *http.Request) {
+	constructionHashRequest := &types.ConstructionHashRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&constructionHashRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	// Assert that ConstructionHashRequest is correct
+	if err := c.asserter.ConstructionHashRequest(constructionHashRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	result, serviceErr := c.service.ConstructionHash(r.Context(), constructionHashRequest)
+	if serviceErr != nil {
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+// ConstructionMetadata - Get Metadata for Transaction Construction
 func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, r *http.Request) {
 	constructionMetadataRequest := &types.ConstructionMetadataRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&constructionMetadataRequest); err != nil {
@@ -82,6 +208,99 @@ func (c *ConstructionAPIController) ConstructionMetadata(w http.ResponseWriter, 
 	}
 
 	result, serviceErr := c.service.ConstructionMetadata(r.Context(), constructionMetadataRequest)
+	if serviceErr != nil {
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+// ConstructionParse - Parse a Transaction
+func (c *ConstructionAPIController) ConstructionParse(w http.ResponseWriter, r *http.Request) {
+	constructionParseRequest := &types.ConstructionParseRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&constructionParseRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	// Assert that ConstructionParseRequest is correct
+	if err := c.asserter.ConstructionParseRequest(constructionParseRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	result, serviceErr := c.service.ConstructionParse(r.Context(), constructionParseRequest)
+	if serviceErr != nil {
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+// ConstructionPayloads - Generate an Unsigned Transaction and Signing Payloads
+func (c *ConstructionAPIController) ConstructionPayloads(w http.ResponseWriter, r *http.Request) {
+	constructionPayloadsRequest := &types.ConstructionPayloadsRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&constructionPayloadsRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	// Assert that ConstructionPayloadsRequest is correct
+	if err := c.asserter.ConstructionPayloadsRequest(constructionPayloadsRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	result, serviceErr := c.service.ConstructionPayloads(r.Context(), constructionPayloadsRequest)
+	if serviceErr != nil {
+		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	EncodeJSONResponse(result, http.StatusOK, w)
+}
+
+// ConstructionPreprocess - Create a Request to Fetch Metadata
+func (c *ConstructionAPIController) ConstructionPreprocess(w http.ResponseWriter, r *http.Request) {
+	constructionPreprocessRequest := &types.ConstructionPreprocessRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&constructionPreprocessRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	// Assert that ConstructionPreprocessRequest is correct
+	if err := c.asserter.ConstructionPreprocessRequest(constructionPreprocessRequest); err != nil {
+		EncodeJSONResponse(&types.Error{
+			Message: err.Error(),
+		}, http.StatusInternalServerError, w)
+
+		return
+	}
+
+	result, serviceErr := c.service.ConstructionPreprocess(
+		r.Context(),
+		constructionPreprocessRequest,
+	)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -63,8 +63,8 @@ func (c *MempoolAPIController) Routes() Routes {
 
 // Mempool - Get All Mempool Transactions
 func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
-	mempoolRequest := &types.MempoolRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&mempoolRequest); err != nil {
+	networkRequest := &types.NetworkRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&networkRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -72,8 +72,8 @@ func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Assert that MempoolRequest is correct
-	if err := c.asserter.MempoolRequest(mempoolRequest); err != nil {
+	// Assert that NetworkRequest is correct
+	if err := c.asserter.NetworkRequest(networkRequest); err != nil {
 		EncodeJSONResponse(&types.Error{
 			Message: err.Error(),
 		}, http.StatusInternalServerError, w)
@@ -81,7 +81,7 @@ func (c *MempoolAPIController) Mempool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, serviceErr := c.service.Mempool(r.Context(), mempoolRequest)
+	result, serviceErr := c.service.Mempool(r.Context(), networkRequest)
 	if serviceErr != nil {
 		EncodeJSONResponse(serviceErr, http.StatusInternalServerError, w)
 

--- a/types/allow.go
+++ b/types/allow.go
@@ -30,4 +30,7 @@ type Allow struct {
 	// All Errors that this implementation could return. Any error that is returned during parsing
 	// that is not listed here will cause client validation to error.
 	Errors []*Error `json:"errors"`
+	// Any Rosetta implementation that supports querying the balance of an account at any height in
+	// the past should set this to true.
+	HistoricalBalanceLookup bool `json:"historical_balance_lookup"`
 }

--- a/types/construction_combine_request.go
+++ b/types/construction_combine_request.go
@@ -16,12 +16,11 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionCombineRequest ConstructionCombineRequest is the input to the `/construction/combine`
+// endpoint. It contains the unsigned transaction blob returned by `/construction/payloads` and all
+// required signatures to create a network transaction.
+type ConstructionCombineRequest struct {
+	NetworkIdentifier   *NetworkIdentifier `json:"network_identifier"`
+	UnsignedTransaction string             `json:"unsigned_transaction"`
+	Signatures          []*Signature       `json:"signatures"`
 }

--- a/types/construction_combine_response.go
+++ b/types/construction_combine_response.go
@@ -16,12 +16,8 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionCombineResponse ConstructionCombineResponse is returned by `/construction/combine`.
+// The network payload will be sent directly to the `construction/submit` endpoint.
+type ConstructionCombineResponse struct {
+	SignedTransaction string `json:"signed_transaction"`
 }

--- a/types/construction_derive_request.go
+++ b/types/construction_derive_request.go
@@ -16,12 +16,12 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionDeriveRequest ConstructionDeriveRequest is passed to the `/construction/derive`
+// endpoint. Network is provided in the request because some blockchains have different address
+// formats for different networks. Metadata is provided in the request because some blockchains
+// allow for multiple address types (i.e. different address for validators vs normal accounts).
+type ConstructionDeriveRequest struct {
+	NetworkIdentifier *NetworkIdentifier     `json:"network_identifier"`
+	PublicKey         *PublicKey             `json:"public_key"`
+	Metadata          map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/construction_derive_response.go
+++ b/types/construction_derive_response.go
@@ -16,12 +16,10 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
+// ConstructionDeriveResponse ConstructionDeriveResponse is returned by the `/construction/derive`
+// endpoint.
+type ConstructionDeriveResponse struct {
+	// Address in network-specific format.
+	Address  string                 `json:"address"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/construction_hash_request.go
+++ b/types/construction_hash_request.go
@@ -16,12 +16,9 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionHashRequest ConstructionHashRequest is the input to the `/construction/hash`
+// endpoint.
+type ConstructionHashRequest struct {
+	NetworkIdentifier *NetworkIdentifier `json:"network_identifier"`
+	SignedTransaction string             `json:"signed_transaction"`
 }

--- a/types/construction_hash_response.go
+++ b/types/construction_hash_response.go
@@ -16,12 +16,8 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionHashResponse ConstructionHashResponse is the output of the `/construction/hash`
+// endpoint.
+type ConstructionHashResponse struct {
+	TransactionHash string `json:"transaction_hash"`
 }

--- a/types/construction_metadata_response.go
+++ b/types/construction_metadata_response.go
@@ -17,8 +17,7 @@
 package types
 
 // ConstructionMetadataResponse The ConstructionMetadataResponse returns network-specific metadata
-// used for transaction construction. It is likely that the client will not inspect this metadata
-// before passing it to a client SDK that uses it for construction.
+// used for transaction construction.
 type ConstructionMetadataResponse struct {
 	Metadata map[string]interface{} `json:"metadata"`
 }

--- a/types/construction_parse_request.go
+++ b/types/construction_parse_request.go
@@ -16,12 +16,13 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionParseRequest ConstructionParseRequest is the input to the `/construction/parse`
+// endpoint. It allows the caller to parse either an unsigned or signed transaction.
+type ConstructionParseRequest struct {
+	NetworkIdentifier *NetworkIdentifier `json:"network_identifier"`
+	// Signed is a boolean indicating whether the transaction is signed.
+	Signed bool `json:"signed"`
+	// This must be either the unsigned transaction blob returned by `/construction/payloads` or the
+	// signed transaction blob returned by `/construction/combine`.
+	Transaction string `json:"transaction"`
 }

--- a/types/construction_parse_response.go
+++ b/types/construction_parse_response.go
@@ -16,12 +16,12 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
+// ConstructionParseResponse ConstructionParseResponse contains an array of operations that occur in
+// a transaction blob. This should match the array of operations provided to
+// `/construction/preprocess` and `/construction/payloads`.
+type ConstructionParseResponse struct {
+	Operations []*Operation `json:"operations"`
+	// All signers of a particular transaction. If the transaction is unsigned, it should be empty.
+	Signers  []string               `json:"signers"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/construction_payloads_request.go
+++ b/types/construction_payloads_request.go
@@ -16,12 +16,11 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionPayloadsRequest ConstructionPayloadsRequest is the request to
+// `/construction/payloads`. It contains the network, a slice of operations, and arbitrary metadata
+// that was returned by the call to `/construction/metadata`.
+type ConstructionPayloadsRequest struct {
+	NetworkIdentifier *NetworkIdentifier     `json:"network_identifier"`
+	Operations        []*Operation           `json:"operations"`
+	Metadata          map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/construction_payloads_response.go
+++ b/types/construction_payloads_response.go
@@ -16,8 +16,11 @@
 
 package types
 
-// MempoolRequest A MempoolRequest is utilized to retrieve all transaction identifiers in the
-// mempool for a particular network_identifier.
-type MempoolRequest struct {
-	NetworkIdentifier *NetworkIdentifier `json:"network_identifier"`
+// ConstructionPayloadsResponse ConstructionTransactionResponse is returned by
+// `/construction/payloads`. It contains an unsigned transaction blob (that is usually needed to
+// construct the a network transaction from a collection of signatures) and an array of payloads
+// that must be signed by the caller.
+type ConstructionPayloadsResponse struct {
+	UnsignedTransaction string            `json:"unsigned_transaction"`
+	Payloads            []*SigningPayload `json:"payloads"`
 }

--- a/types/construction_preprocess_request.go
+++ b/types/construction_preprocess_request.go
@@ -16,12 +16,11 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionPreprocessRequest ConstructionPreprocessRequest is passed to the
+// `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata
+// it needs to request for construction.
+type ConstructionPreprocessRequest struct {
+	NetworkIdentifier *NetworkIdentifier     `json:"network_identifier"`
+	Operations        []*Operation           `json:"operations"`
+	Metadata          map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/construction_preprocess_response.go
+++ b/types/construction_preprocess_response.go
@@ -16,12 +16,10 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// ConstructionPreprocessResponse ConstructionPreprocessResponse contains the request that will be
+// sent directly to `/construction/metadata`. If it is not necessary to make a request to
+// `/construction/metadata`, options should be null.
+type ConstructionPreprocessResponse struct {
+	// The options that will be sent directly to `/construction/metadata` by the caller.
+	Options map[string]interface{} `json:"options,omitempty"`
 }

--- a/types/currency.go
+++ b/types/currency.go
@@ -21,11 +21,11 @@ package types
 type Currency struct {
 	// Canonical symbol associated with a currency.
 	Symbol string `json:"symbol"`
-	// Number of decimal places in the standard unit representation of the amount.  For example, BTC
+	// Number of decimal places in the standard unit representation of the amount. For example, BTC
 	// has 8 decimals. Note that it is not possible to represent the value of some currency in
 	// atomic units that is not base 10.
 	Decimals int32 `json:"decimals"`
-	// Any additional information related to the currency itself.  For example, it would be useful
-	// to populate this object with the contract address of an ERC-20 token.
+	// Any additional information related to the currency itself. For example, it would be useful to
+	// populate this object with the contract address of an ERC-20 token.
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/curve_type.go
+++ b/types/curve_type.go
@@ -16,12 +16,13 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
-}
+// CurveType CurveType is the type of cryptographic curve associated with a PublicKey.  * secp256k1:
+// SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y
+// (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf)
+type CurveType string
+
+// List of CurveType
+const (
+	Secp256k1    CurveType = "secp256k1"
+	Edwards25519 CurveType = "edwards25519"
+)

--- a/types/error.go
+++ b/types/error.go
@@ -26,4 +26,8 @@ type Error struct {
 	Message string `json:"message"`
 	// An error is retriable if the same request may succeed if submitted again.
 	Retriable bool `json:"retriable"`
+	// Often times it is useful to return context specific to the request that caused the error
+	// (i.e. a sample of the stack trace or impacted account) in addition to the standard error
+	// message.
+	Details map[string]interface{} `json:"details,omitempty"`
 }

--- a/types/network_status_response.go
+++ b/types/network_status_response.go
@@ -17,12 +17,15 @@
 package types
 
 // NetworkStatusResponse NetworkStatusResponse contains basic information about the node's view of a
-// blockchain network.
+// blockchain network. If a Rosetta implementation prunes historical state, it should populate the
+// optional `oldest_block_identifier` field with the oldest block available to query. If this is not
+// populated, it is assumed that the `genesis_block_identifier` is the oldest queryable block.
 type NetworkStatusResponse struct {
 	CurrentBlockIdentifier *BlockIdentifier `json:"current_block_identifier"`
 	// The timestamp of the block in milliseconds since the Unix Epoch. The timestamp is stored in
 	// milliseconds because some blockchains produce blocks more often than once a second.
 	CurrentBlockTimestamp  int64            `json:"current_block_timestamp"`
 	GenesisBlockIdentifier *BlockIdentifier `json:"genesis_block_identifier"`
+	OldestBlockIdentifier  *BlockIdentifier `json:"oldest_block_identifier,omitempty"`
 	Peers                  []*Peer          `json:"peers"`
 }

--- a/types/operation.go
+++ b/types/operation.go
@@ -27,7 +27,7 @@ type Operation struct {
 	// linking operations in a call tree.
 	RelatedOperations []*OperationIdentifier `json:"related_operations,omitempty"`
 	// The network-specific type of the operation. Ensure that any type that can be returned here is
-	// also specified in the NetowrkStatus. This can be very useful to downstream consumers that
+	// also specified in the NetworkStatus. This can be very useful to downstream consumers that
 	// parse all block data.
 	Type string `json:"type"`
 	// The network-specific status of the operation. Status is not defined on the transaction object

--- a/types/operation_identifier.go
+++ b/types/operation_identifier.go
@@ -20,11 +20,12 @@ package types
 // transaction.
 type OperationIdentifier struct {
 	// The operation index is used to ensure each operation has a unique identifier within a
-	// transaction.  To clarify, there may not be any notion of an operation index in the blockchain
-	// being described.
+	// transaction. This index is only relative to the transaction and NOT GLOBAL. The operations in
+	// each transaction should start from index 0. To clarify, there may not be any notion of an
+	// operation index in the blockchain being described.
 	Index int64 `json:"index"`
 	// Some blockchains specify an operation index that is essential for client use. For example,
-	// Bitcoin uses a network_index to identify which UTXO was used in a transaction.  network_index
+	// Bitcoin uses a network_index to identify which UTXO was used in a transaction. network_index
 	// should not be populated if there is no notion of an operation index in a blockchain
 	// (typically most account-based blockchains).
 	NetworkIndex *int64 `json:"network_index,omitempty"`

--- a/types/operation_status.go
+++ b/types/operation_status.go
@@ -24,7 +24,7 @@ type OperationStatus struct {
 	// An Operation is considered successful if the Operation.Amount should affect the
 	// Operation.Account. Some blockchains (like Bitcoin) only include successful operations in
 	// blocks but other blockchains (like Ethereum) include unsuccessful operations that incur a
-	// fee.  To reconcile the computed balance from the stream of Operations, it is critical to
+	// fee. To reconcile the computed balance from the stream of Operations, it is critical to
 	// understand which Operation.Status indicate an Operation is successful and should affect an
 	// Account.
 	Successful bool `json:"successful"`

--- a/types/public_key.go
+++ b/types/public_key.go
@@ -16,12 +16,10 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// PublicKey PublicKey contains a public key byte array for a particular CurveType encoded in hex.
+// Note that there is no PrivateKey struct as this is NEVER the concern of an implementation.
+type PublicKey struct {
+	// Hex-encoded public key bytes in the format specified by the CurveType.
+	HexBytes  string    `json:"hex_bytes"`
+	CurveType CurveType `json:"curve_type"`
 }

--- a/types/signature.go
+++ b/types/signature.go
@@ -16,12 +16,13 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// Signature Signature contains the payload that was signed, the public keys of the keypairs used to
+// produce the signature, the signature (encoded in hex), and the SignatureType. PublicKey is often
+// times not known during construction of the signing payloads but may be needed to combine
+// signatures properly.
+type Signature struct {
+	SigningPayload *SigningPayload `json:"signing_payload"`
+	PublicKey      *PublicKey      `json:"public_key"`
+	SignatureType  SignatureType   `json:"signature_type"`
+	HexBytes       string          `json:"hex_bytes"`
 }

--- a/types/signature_type.go
+++ b/types/signature_type.go
@@ -16,12 +16,14 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
-}
+// SignatureType SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s
+// (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65
+// bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
+type SignatureType string
+
+// List of SignatureType
+const (
+	Ecdsa         SignatureType = "ecdsa"
+	EcdsaRecovery SignatureType = "ecdsa_recovery"
+	Ed25519       SignatureType = "ed25519"
+)

--- a/types/signing_payload.go
+++ b/types/signing_payload.go
@@ -16,12 +16,12 @@
 
 package types
 
-// Transaction Transactions contain an array of Operations that are attributable to the same
-// TransactionIdentifier.
-type Transaction struct {
-	TransactionIdentifier *TransactionIdentifier `json:"transaction_identifier"`
-	Operations            []*Operation           `json:"operations"`
-	// Transactions that are related to other transactions (like a cross-shard transaction) should
-	// include the tranaction_identifier of these transactions in the metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+// SigningPayload SigningPayload is signed by the client with the keypair associated with an address
+// using the specified SignatureType. SignatureType can be optionally populated if there is a
+// restriction on the signature scheme that can be used to sign the payload.
+type SigningPayload struct {
+	// The network-specific address of the account that should sign the payload.
+	Address       string        `json:"address"`
+	HexBytes      string        `json:"hex_bytes"`
+	SignatureType SignatureType `json:"signature_type,omitempty"`
 }

--- a/types/sub_account_identifier.go
+++ b/types/sub_account_identifier.go
@@ -24,7 +24,7 @@ type SubAccountIdentifier struct {
 	// that uniquely specifies a SubAccount.
 	Address string `json:"address"`
 	// If the SubAccount address is not sufficient to uniquely specify a SubAccount, any other
-	// identifying information can be stored here.  It is important to note that two SubAccounts
-	// with identical addresses but differing metadata will not be considered equal by clients.
+	// identifying information can be stored here. It is important to note that two SubAccounts with
+	// identical addresses but differing metadata will not be considered equal by clients.
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }


### PR DESCRIPTION
### Changes
* Add support for [v1.4.0](https://github.com/coinbase/rosetta-specifications/releases/tag/v1.4.0) of the specification (with support for the new `Construction API`)
* Update examples
* Automatically reject historical balance queries if not supported
* Update `asserter/request.go` 

### Future PR
* Update `fetcher` to support new endpoints and assert correctness of responses (`asserter/construction.go`): #56 