### PR TITLE
Automatically Encode/Decode Hex

### DIFF
--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -15,7 +15,6 @@
 package asserter
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -58,8 +57,8 @@ func PublicKey(
 		return errors.New("PublicKey cannot be nil")
 	}
 
-	if err := checkHex(publicKey.HexBytes); err != nil {
-		return fmt.Errorf("%w public key does not have valid hex", err)
+	if len(publicKey.Bytes) == 0 {
+		return errors.New("public key bytes cannot be empty")
 	}
 
 	if err := CurveType(publicKey.CurveType); err != nil {
@@ -82,24 +81,6 @@ func CurveType(
 	}
 }
 
-// checkHex returns an error if a
-// string is not valid hex or if
-// it is empty.
-func checkHex(
-	hexString string,
-) error {
-	if len(hexString) == 0 {
-		return errors.New("hex string cannot be empty")
-	}
-
-	_, err := hex.DecodeString(hexString)
-	if err != nil {
-		return fmt.Errorf("%w: %s is not a valid hex string", err, hexString)
-	}
-
-	return nil
-}
-
 // SigningPayload returns an error
 // if a *types.SigningPayload is nil,
 // has an empty address, has invlaid hex,
@@ -115,8 +96,8 @@ func SigningPayload(
 		return errors.New("signing payload address cannot be empty")
 	}
 
-	if err := checkHex(signingPayload.HexBytes); err != nil {
-		return fmt.Errorf("%w signature payload is not a valid hex string", err)
+	if len(signingPayload.Bytes) == 0 {
+		return errors.New("signing payload bytes cannot be empty")
 	}
 
 	// SignatureType can be optionally populated
@@ -160,8 +141,8 @@ func Signatures(
 			return fmt.Errorf("requested signature type does not match returned signature type")
 		}
 
-		if err := checkHex(signature.HexBytes); err != nil {
-			return fmt.Errorf("%w: signature %d has invalid hex", err, i)
+		if len(signature.Bytes) == 0 {
+			return fmt.Errorf("signature %d bytes cannot be empty", i)
 		}
 	}
 

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -82,23 +82,22 @@ func TestPublicKey(t *testing.T) {
 	}{
 		"valid public key": {
 			publicKey: &types.PublicKey{
-				HexBytes:  "48656c6c6f20476f7068657221",
+				Bytes:     []byte("blah"),
 				CurveType: types.Secp256k1,
 			},
 		},
 		"nil public key": {
 			err: errors.New("PublicKey cannot be nil"),
 		},
-		"invalid hex": {
+		"invalid bytes": {
 			publicKey: &types.PublicKey{
-				HexBytes:  "hello",
 				CurveType: types.Secp256k1,
 			},
-			err: errors.New("hello is not a valid hex string"),
+			err: errors.New("public key bytes cannot be empty"),
 		},
 		"invalid curve": {
 			publicKey: &types.PublicKey{
-				HexBytes:  "48656c6c6f20476f7068657221",
+				Bytes:     []byte("hello"),
 				CurveType: "test",
 			},
 			err: errors.New("test is not a supported CurveType"),
@@ -125,14 +124,14 @@ func TestSigningPayload(t *testing.T) {
 	}{
 		"valid signing payload": {
 			signingPayload: &types.SigningPayload{
-				Address:  "hello",
-				HexBytes: "48656c6c6f20476f7068657221",
+				Address: "hello",
+				Bytes:   []byte("blah"),
 			},
 		},
 		"valid signing payload with signature type": {
 			signingPayload: &types.SigningPayload{
 				Address:       "hello",
-				HexBytes:      "48656c6c6f20476f7068657221",
+				Bytes:         []byte("blah"),
 				SignatureType: types.Ed25519,
 			},
 		},
@@ -141,20 +140,20 @@ func TestSigningPayload(t *testing.T) {
 		},
 		"empty address": {
 			signingPayload: &types.SigningPayload{
-				HexBytes: "48656c6c6f20476f7068657221",
+				Bytes: []byte("blah"),
 			},
 			err: errors.New("signing payload address cannot be empty"),
 		},
-		"empty hex": {
+		"empty bytes": {
 			signingPayload: &types.SigningPayload{
 				Address: "hello",
 			},
-			err: errors.New("hex string cannot be empty"),
+			err: errors.New("signing payload bytes cannot be empty"),
 		},
 		"invalid signature": {
 			signingPayload: &types.SigningPayload{
 				Address:       "hello",
-				HexBytes:      "48656c6c6f20476f7068657221",
+				Bytes:         []byte("blah"),
 				SignatureType: "blah",
 			},
 			err: errors.New("blah is not a supported SignatureType"),
@@ -183,21 +182,21 @@ func TestSignatures(t *testing.T) {
 			signatures: []*types.Signature{
 				{
 					SigningPayload: &types.SigningPayload{
-						Address:  validAccount.Address,
-						HexBytes: "48656c6c6f20476f7068657221",
+						Address: validAccount.Address,
+						Bytes:   []byte("blah"),
 					},
 					PublicKey:     validPublicKey,
 					SignatureType: types.Ed25519,
-					HexBytes:      "656c6c6f20476f7068657221",
+					Bytes:         []byte("hello"),
 				},
 				{
 					SigningPayload: &types.SigningPayload{
-						Address:  validAccount.Address,
-						HexBytes: "48656c6c6f20476f7068657221",
+						Address: validAccount.Address,
+						Bytes:   []byte("blah"),
 					},
 					PublicKey:     validPublicKey,
 					SignatureType: types.EcdsaRecovery,
-					HexBytes:      "656c6c6f20476f7068657221",
+					Bytes:         []byte("hello"),
 				},
 			},
 		},
@@ -206,12 +205,12 @@ func TestSignatures(t *testing.T) {
 				{
 					SigningPayload: &types.SigningPayload{
 						Address:       validAccount.Address,
-						HexBytes:      "48656c6c6f20476f7068657221",
+						Bytes:         []byte("blah"),
 						SignatureType: types.Ed25519,
 					},
 					PublicKey:     validPublicKey,
 					SignatureType: types.Ed25519,
-					HexBytes:      "656c6c6f20476f7068657221",
+					Bytes:         []byte("hello"),
 				},
 			},
 		},
@@ -222,36 +221,36 @@ func TestSignatures(t *testing.T) {
 			signatures: []*types.Signature{
 				{
 					SigningPayload: &types.SigningPayload{
-						Address:  validAccount.Address,
-						HexBytes: "48656c6c6f20476f7068657221",
+						Address: validAccount.Address,
+						Bytes:   []byte("blah"),
 					},
 					PublicKey:     validPublicKey,
 					SignatureType: types.EcdsaRecovery,
-					HexBytes:      "656c6c6f20476f7068657221",
+					Bytes:         []byte("hello"),
 				},
 				{
 					SigningPayload: &types.SigningPayload{
 						Address:       validAccount.Address,
-						HexBytes:      "48656c6c6f20476f7068657221",
+						Bytes:         []byte("blah"),
 						SignatureType: types.Ed25519,
 					},
 					PublicKey:     validPublicKey,
 					SignatureType: types.Ed25519,
 				},
 			},
-			err: errors.New("signature 1 has invalid hex"),
+			err: errors.New("signature 1 bytes cannot be empty"),
 		},
 		"signature type mismatch": {
 			signatures: []*types.Signature{
 				{
 					SigningPayload: &types.SigningPayload{
 						Address:       validAccount.Address,
-						HexBytes:      "48656c6c6f20476f7068657221",
+						Bytes:         []byte("blah"),
 						SignatureType: types.EcdsaRecovery,
 					},
 					PublicKey:     validPublicKey,
 					SignatureType: types.Ed25519,
-					HexBytes:      "656c6c6f20476f7068657221",
+					Bytes:         []byte("hello"),
 				},
 			},
 			err: errors.New("requested signature type does not match"),

--- a/asserter/request_test.go
+++ b/asserter/request_test.go
@@ -55,7 +55,7 @@ var (
 	}
 
 	validPublicKey = &types.PublicKey{
-		HexBytes:  "48656c6c6f20476f7068657221",
+		Bytes:     []byte("hello"),
 		CurveType: types.Secp256k1,
 	}
 
@@ -148,12 +148,12 @@ var (
 	validSignatures = []*types.Signature{
 		{
 			SigningPayload: &types.SigningPayload{
-				Address:  validAccount.Address,
-				HexBytes: "48656c6c6f20476f7068657221",
+				Address: validAccount.Address,
+				Bytes:   []byte("blah"),
 			},
 			PublicKey:     validPublicKey,
 			SignatureType: types.Ed25519,
-			HexBytes:      "656c6c6f20476f7068657221",
+			Bytes:         []byte("hello"),
 		},
 	}
 
@@ -161,12 +161,12 @@ var (
 		{
 			SigningPayload: &types.SigningPayload{
 				Address:       validAccount.Address,
-				HexBytes:      "48656c6c6f20476f7068657221",
+				Bytes:         []byte("blah"),
 				SignatureType: types.EcdsaRecovery,
 			},
 			PublicKey:     validPublicKey,
 			SignatureType: types.Ed25519,
-			HexBytes:      "656c6c6f20476f7068657221",
+			Bytes:         []byte("hello"),
 		},
 	}
 
@@ -174,12 +174,12 @@ var (
 		{
 			SigningPayload: &types.SigningPayload{
 				Address:       validAccount.Address,
-				HexBytes:      "48656c6c6f20476f7068657221",
+				Bytes:         []byte("blah"),
 				SignatureType: types.Ed25519,
 			},
 			PublicKey:     validPublicKey,
 			SignatureType: types.Ed25519,
-			HexBytes:      "656c6c6f20476f7068657221",
+			Bytes:         []byte("hello"),
 		},
 	}
 
@@ -187,7 +187,7 @@ var (
 		{
 			SigningPayload: &types.SigningPayload{
 				Address:       validAccount.Address,
-				HexBytes:      "48656c6c6f20476f7068657221",
+				Bytes:         []byte("blah"),
 				SignatureType: types.Ed25519,
 			},
 			PublicKey:     validPublicKey,
@@ -662,15 +662,14 @@ func TestConstructionDeriveRequest(t *testing.T) {
 			},
 			err: errors.New("PublicKey cannot be nil"),
 		},
-		"invalid hex public key": {
+		"empty public key bytes": {
 			request: &types.ConstructionDeriveRequest{
 				NetworkIdentifier: validNetworkIdentifier,
 				PublicKey: &types.PublicKey{
-					HexBytes:  "hello",
 					CurveType: types.Secp256k1,
 				},
 			},
-			err: errors.New("not a valid hex string public key"),
+			err: errors.New("public key bytes cannot be empty"),
 		},
 	}
 
@@ -875,7 +874,7 @@ func TestConstructionCombineRequest(t *testing.T) {
 				UnsignedTransaction: "blah",
 				Signatures:          emptySignature,
 			},
-			err: errors.New("hex string cannot be empty"),
+			err: errors.New("signature 0 bytes cannot be empty"),
 		},
 		"signature type match": {
 			request: &types.ConstructionCombineRequest{

--- a/codegen.sh
+++ b/codegen.sh
@@ -156,6 +156,11 @@ sed "${SED_IFLAG[@]}" 's/package client/package types/g' types/*;
 # shellcheck disable=SC2013
 for file in $(grep -Ril "hex_bytes" types)
 do
+  if [[ "${file}" == *"_test.go"* ]];then
+    echo "Skipping injection for ${file}";
+    continue;
+  fi
+
   RAW_NAME=$(echo "${file}" | cut -c7- | rev | cut -c4- | rev);
   STRUCT_NAME=$(echo "${RAW_NAME}" | perl -pe 's/(?:\b|_)(\p{Ll})/\u$1/g');
   MARSHAL_CONTENTS=$(sed "s/STRUCT_NAME/${STRUCT_NAME}/g" < templates/marshal.txt);

--- a/codegen.sh
+++ b/codegen.sh
@@ -32,7 +32,7 @@ esac
 # Remove existing client generated code
 mkdir -p tmp;
 DIRS=( types client server )
-IGNORED_FILES=( README.md utils.go utils_test.go )
+IGNORED_FILES=( README.md utils.go utils_test.go marshal_test.go )
 
 for dir in "${DIRS[@]}"
 do

--- a/codegen.sh
+++ b/codegen.sh
@@ -125,6 +125,10 @@ sed "${SED_IFLAG[@]}" 's/ECDSA_RECOVERY/EcdsaRecovery/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/ECDSA/Ecdsa/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/ED25519/Ed25519/g' client/* server/*;
 
+# Convert HexBytes to Bytes
+sed "${SED_IFLAG[@]}" '/Hex-encoded public key bytes in the format specified by the CurveType/d' client/* server/*;
+sed "${SED_IFLAG[@]}" -E 's/HexBytes[[:space:]]+string/Bytes []byte/g' client/* server/*;
+
 # Remove special characters
 sed "${SED_IFLAG[@]}" 's/&#x60;//g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/\&quot;//g' client/* server/*;

--- a/codegen.sh
+++ b/codegen.sh
@@ -153,6 +153,7 @@ done
 sed "${SED_IFLAG[@]}" 's/package client/package types/g' types/*;
 
 # Inject Custom Marshaling Logic
+# shellcheck disable=SC2013
 for file in $(grep -Ril "hex_bytes" types)
 do
   echo "${file}"
@@ -161,6 +162,7 @@ do
   echo "${STRUCT_NAME}"
   MARSHAL_CONTENTS=$(sed "s/STRUCT_NAME/${STRUCT_NAME}/g" < templates/marshal.txt);
   echo "${MARSHAL_CONTENTS}" >> "${file}";
+  # shellcheck disable=SC1004
   sed "${SED_IFLAG[@]}" 's/package types/package types\
     import \(\
     \"encoding\/hex\"\

--- a/codegen.sh
+++ b/codegen.sh
@@ -156,10 +156,8 @@ sed "${SED_IFLAG[@]}" 's/package client/package types/g' types/*;
 # shellcheck disable=SC2013
 for file in $(grep -Ril "hex_bytes" types)
 do
-  echo "${file}"
   RAW_NAME=$(echo "${file}" | cut -c7- | rev | cut -c4- | rev);
   STRUCT_NAME=$(echo "${RAW_NAME}" | perl -pe 's/(?:\b|_)(\p{Ll})/\u$1/g');
-  echo "${STRUCT_NAME}"
   MARSHAL_CONTENTS=$(sed "s/STRUCT_NAME/${STRUCT_NAME}/g" < templates/marshal.txt);
   echo "${MARSHAL_CONTENTS}" >> "${file}";
   # shellcheck disable=SC1004

--- a/templates/marshal.txt
+++ b/templates/marshal.txt
@@ -1,0 +1,41 @@
+
+// MarshalJSON overrides the default JSON marshaler
+// and encodes bytes as hex instead of base64.
+func (s *STRUCT_NAME) MarshalJSON() ([]byte, error) {
+	type Alias STRUCT_NAME
+	j, err := json.Marshal(struct {
+		Bytes string `json:"hex_bytes"`
+		*Alias
+	}{
+		Bytes: hex.EncodeToString(s.Bytes),
+		Alias: (*Alias)(s),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
+// UnmarshalJSON overrides the default JSON unmarshaler
+// and decodes bytes from hex instead of base64.
+func (s *STRUCT_NAME) UnmarshalJSON(b []byte) error {
+	type Alias STRUCT_NAME
+  r := struct {
+		Bytes string `json:"hex_bytes"`
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+	err := json.Unmarshal(b, &r)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := hex.DecodeString(r.Bytes)
+	if err != nil {
+		return err
+	}
+
+	s.Bytes = bytes
+	return nil
+}

--- a/types/marshal_test.go
+++ b/types/marshal_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 import (
@@ -38,4 +52,10 @@ func TestCustomMarshal(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, s, s2)
+
+	// Invalid Hex Check
+	s3 := &PublicKey{}
+	err = json.Unmarshal([]byte(`{"hex_bytes":"hello"}`), s3)
+	assert.Error(t, err)
+	assert.Len(t, s3.Bytes, 0)
 }

--- a/types/marshal_test.go
+++ b/types/marshal_test.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomMarshal(t *testing.T) {
+	// We only test PublicKey because the marshaling logic
+	// is all codegen.
+	s := &PublicKey{
+		CurveType: Secp256k1,
+		Bytes:     []byte("hsdjkfhkasjfhkjasdhfkjasdnfkjabsdfkjhakjsfdhjksadhfjk23478923645yhsdfn"),
+	}
+
+	j, err := json.Marshal(s)
+	assert.NoError(t, err)
+
+	// Simple Hex Check
+	simpleType := struct {
+		HexBytes string `json:"hex_bytes"`
+	}{}
+
+	err = json.Unmarshal(j, &simpleType)
+	assert.NoError(t, err)
+
+	b, err := hex.DecodeString(simpleType.HexBytes)
+	assert.NoError(t, err)
+
+	assert.Equal(t, s.Bytes, b)
+
+	// Full Unmarshal Check
+	s2 := &PublicKey{}
+	err = json.Unmarshal(j, s2)
+	assert.NoError(t, err)
+
+	assert.Equal(t, s, s2)
+}

--- a/types/public_key.go
+++ b/types/public_key.go
@@ -19,7 +19,6 @@ package types
 // PublicKey PublicKey contains a public key byte array for a particular CurveType encoded in hex.
 // Note that there is no PrivateKey struct as this is NEVER the concern of an implementation.
 type PublicKey struct {
-	// Hex-encoded public key bytes in the format specified by the CurveType.
-	HexBytes  string    `json:"hex_bytes"`
+	Bytes     []byte    `json:"hex_bytes"`
 	CurveType CurveType `json:"curve_type"`
 }

--- a/types/signature.go
+++ b/types/signature.go
@@ -24,5 +24,5 @@ type Signature struct {
 	SigningPayload *SigningPayload `json:"signing_payload"`
 	PublicKey      *PublicKey      `json:"public_key"`
 	SignatureType  SignatureType   `json:"signature_type"`
-	HexBytes       string          `json:"hex_bytes"`
+	Bytes          []byte          `json:"hex_bytes"`
 }

--- a/types/signature.go
+++ b/types/signature.go
@@ -16,6 +16,11 @@
 
 package types
 
+import (
+	"encoding/hex"
+	"encoding/json"
+)
+
 // Signature Signature contains the payload that was signed, the public keys of the keypairs used to
 // produce the signature, the signature (encoded in hex), and the SignatureType. PublicKey is often
 // times not known during construction of the signing payloads but may be needed to combine
@@ -25,4 +30,45 @@ type Signature struct {
 	PublicKey      *PublicKey      `json:"public_key"`
 	SignatureType  SignatureType   `json:"signature_type"`
 	Bytes          []byte          `json:"hex_bytes"`
+}
+
+// MarshalJSON overrides the default JSON marshaler
+// and encodes bytes as hex instead of base64.
+func (s *Signature) MarshalJSON() ([]byte, error) {
+	type Alias Signature
+	j, err := json.Marshal(struct {
+		Bytes string `json:"hex_bytes"`
+		*Alias
+	}{
+		Bytes: hex.EncodeToString(s.Bytes),
+		Alias: (*Alias)(s),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
+// UnmarshalJSON overrides the default JSON unmarshaler
+// and decodes bytes from hex instead of base64.
+func (s *Signature) UnmarshalJSON(b []byte) error {
+	type Alias Signature
+	r := struct {
+		Bytes string `json:"hex_bytes"`
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+	err := json.Unmarshal(b, &r)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := hex.DecodeString(r.Bytes)
+	if err != nil {
+		return err
+	}
+
+	s.Bytes = bytes
+	return nil
 }

--- a/types/signing_payload.go
+++ b/types/signing_payload.go
@@ -22,6 +22,6 @@ package types
 type SigningPayload struct {
 	// The network-specific address of the account that should sign the payload.
 	Address       string        `json:"address"`
-	HexBytes      string        `json:"hex_bytes"`
+	Bytes         []byte        `json:"hex_bytes"`
 	SignatureType SignatureType `json:"signature_type,omitempty"`
 }


### PR DESCRIPTION
### Motivation
#55 does not automatically unwrap hex-encoded bytes for users of the SDK. This means that developers that use the SDK need to duplicate hex decoding/encoding code whenever interacting with these encoded bytes.

### Solution
* Implement a custom JSON marshaler/unmarshaler that automatically encodes/decodes bytes to hex.
* Use codegen scripts to automatically add this custom JSON marshaler/unmarshaler to any types that have hex encoded bytes.