### PR TITLE
Inactive Reconciler Performance when --lookup-balance-by-block=false

### DIFF
--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/parser"
+	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
 // Option is used to overwrite default values in
@@ -59,7 +60,7 @@ func WithSeenAccounts(seen []*AccountCurrency) Option {
 			r.inactiveQueue = append(r.inactiveQueue, &InactiveEntry{
 				Entry: acct,
 			})
-			r.seenAccounts = append(r.seenAccounts, acct)
+			r.seenAccounts[types.Hash(acct)] = struct{}{}
 		}
 
 		fmt.Printf(

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -85,3 +85,11 @@ func WithLookupBalanceByBlock(lookup bool) Option {
 		r.lookupBalanceByBlock = lookup
 	}
 }
+
+// WithInactiveFrequency is how many blocks the reconciler
+// should wait between inactive reconciliations on each account.
+func WithInactiveFrequency(blocks int64) Option {
+	return func(r *Reconciler) {
+		r.inactiveFrequency = blocks
+	}
+}

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -94,3 +94,11 @@ func WithInactiveFrequency(blocks int64) Option {
 		r.inactiveFrequency = blocks
 	}
 }
+
+// WithDebugLogging determines if verbose logs should
+// be printed.
+func WithDebugLogging(debug bool) Option {
+	return func(r *Reconciler) {
+		r.debugLogging = debug
+	}
+}

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -616,6 +616,14 @@ func (r *Reconciler) reconcileInactiveAccounts(
 			continue
 		}
 
+		if head.Index < r.highWaterMark {
+			if r.debugLogging {
+				log.Println("waiting to continue intactive reconciliation until reaching high water mark...")
+			}
+			time.Sleep(inactiveReconciliationSleep)
+			continue
+		}
+
 		r.inactiveQueueMutex.Lock()
 		nextValidIndex := r.inactiveQueue[0].LastCheck.Index + r.inactiveFrequency
 		if len(r.inactiveQueue) > 0 &&

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -729,7 +729,10 @@ func ExtractAmount(
 		return b, nil
 	}
 
-	return nil, fmt.Errorf("could not extract amount for %+v", currency)
+	return nil, fmt.Errorf(
+		"account balance response does could not contain currency %s",
+		types.PrettyPrintStruct(currency),
+	)
 }
 
 // ContainsAccountCurrency returns a boolean indicating if a
@@ -764,7 +767,12 @@ func GetCurrencyBalance(
 
 	liveAmount, err := ExtractAmount(liveBalances, currency)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf(
+			"%w: could not get %s currency balance for %s",
+			err,
+			types.PrettyPrintStruct(currency),
+			types.PrettyPrintStruct(account),
+		)
 	}
 
 	return liveBlock, liveAmount.Value, nil

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -43,7 +43,7 @@ const (
 	// that can be enqueued to reconcile before new
 	// requests are dropped.
 	// TODO: Make configurable
-	backlogThreshold = 1000
+	backlogThreshold = 50000
 
 	// waitToCheckDiff is the syncing difference (live-head)
 	// to retry instead of exiting. In other words, if the

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -273,7 +273,14 @@ func TestExtractAmount(t *testing.T) {
 	t.Run("Non-existent currency", func(t *testing.T) {
 		result, err := ExtractAmount(balances, badCurr)
 		assert.Nil(t, result)
-		assert.EqualError(t, err, fmt.Errorf("could not extract amount for %+v", badCurr).Error())
+		assert.EqualError(
+			t,
+			err,
+			fmt.Errorf(
+				"account balance response does could not contain currency %s",
+				types.PrettyPrintStruct(badCurr),
+			).Error(),
+		)
 	})
 
 	t.Run("Simple account", func(t *testing.T) {


### PR DESCRIPTION
### Motivation
Fix #65 

### Solution
* Ensure all seen accounts are added to the `inactiveAccountQueue` even if we are far behind tip
* Ensure accounts aren't leaked from the `inactiveAccountQueue` (could occur if accounts
* Improve performance by changing frequent operation (`seenAccounts` check on each block) from `O(n)` to `~O(1)` (caused reconciler to get much slower as more accounts seen).
* Ensure `inactive reconciler` respects the `highWaterMark` (so useless queries are not performed during syncing).
* Fix edge case issue where an account could be added to the queue multiple times (in different go routines). This fix was possible because a lookup is performed while holding the lock and that lookup is now `~O(1)` time now.

### Other Thoughts
We could further optimize the `reconciler` to cache balances it retrieved when behind tip so that reconciliation could begin before making it to tip. This would require some careful thinking and testing and should be attempted in another PR.
