### PR TITLE
Handle empty inactive queue correctly

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -652,10 +652,13 @@ func (r *Reconciler) reconcileInactiveAccounts(
 			continue
 		}
 
-		nextValidIndex := r.inactiveQueue[0].LastCheck.Index + r.inactiveFrequency
-		if r.inactiveQueue[0].LastCheck == nil || // block is set to nil when loaded from previous run
-			nextValidIndex <= head.Index {
-			nextAcct := r.inactiveQueue[0]
+		nextAcct := r.inactiveQueue[0]
+		nextValidIndex := int64(-1)
+		if nextAcct.LastCheck != nil { // block is set to nil when loaded from previous run
+			nextValidIndex = nextAcct.LastCheck.Index + r.inactiveFrequency
+		}
+
+		if nextValidIndex <= head.Index {
 			r.inactiveQueue = r.inactiveQueue[1:]
 			r.inactiveQueueMutex.Unlock()
 


### PR DESCRIPTION
Fixes #67

### Changes
Fix a panic in the reconciler when attempting to access an element in an empty array. This regression was introduced in #66.

### Future PR
**INCREASE TEST COVERAGE**