### PR TITLE
Bug when asserting ConstructionParseResponses

### DIFF
--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -111,8 +111,8 @@ func ConstructionHashResponse(
 // not have a valid set of operations or
 // if the signers is empty.
 func (a *Asserter) ConstructionParseResponse(
-	signed bool,
 	response *types.ConstructionParseResponse,
+	signed bool,
 ) error {
 	if a == nil {
 		return ErrAsserterNotInitialized

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -111,6 +111,7 @@ func ConstructionHashResponse(
 // not have a valid set of operations or
 // if the signers is empty.
 func (a *Asserter) ConstructionParseResponse(
+	signed bool,
 	response *types.ConstructionParseResponse,
 ) error {
 	if a == nil {
@@ -129,8 +130,12 @@ func (a *Asserter) ConstructionParseResponse(
 		return fmt.Errorf("%w unable to parse operations", err)
 	}
 
-	if len(response.Signers) == 0 {
+	if signed && len(response.Signers) == 0 {
 		return errors.New("signers cannot be empty")
+	}
+
+	if !signed && len(response.Signers) > 0 {
+		return errors.New("signers should be empty for unsigned txs")
 	}
 
 	for i, signer := range response.Signers {

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -347,7 +347,7 @@ func TestConstructionParseResponse(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := asserter.ConstructionParseResponse(true, test.response)
+			err := asserter.ConstructionParseResponse(test.response, true)
 			if test.err != nil {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), test.err.Error())
@@ -424,7 +424,7 @@ func TestConstructionParseResponse(t *testing.T) {
 
 	for name, test := range unsignedTest {
 		t.Run(name, func(t *testing.T) {
-			err := asserter.ConstructionParseResponse(false, test.response)
+			err := asserter.ConstructionParseResponse(test.response, false)
 			if test.err != nil {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), test.err.Error())

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -150,7 +150,7 @@ func (f *Fetcher) ConstructionParse(
 		return nil, nil, nil, err
 	}
 
-	if err := f.Asserter.ConstructionParseResponse(signed, response); err != nil {
+	if err := f.Asserter.ConstructionParseResponse(response, signed); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -150,7 +150,7 @@ func (f *Fetcher) ConstructionParse(
 		return nil, nil, nil, err
 	}
 
-	if err := f.Asserter.ConstructionParseResponse(response); err != nil {
+	if err := f.Asserter.ConstructionParseResponse(signed, response); err != nil {
 		return nil, nil, nil, err
 	}
 


### PR DESCRIPTION
Fixes #73 

### Summary
Fixes a bug where `Asserter.ConstructionParseResponse` raises an error if there are no signers, when it shouldn't for unsigned transactions. 
