### PR TITLE
[BUG] Syncer Fetches Invalid Index when endIndex populated

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -144,16 +144,18 @@ func (s *Syncer) nextSyncableRange(
 		return -1, false, errors.New("unable to get current head")
 	}
 
-	if endIndex == -1 {
-		networkStatus, err := s.fetcher.NetworkStatusRetry(
-			ctx,
-			s.network,
-			nil,
-		)
-		if err != nil {
-			return -1, false, fmt.Errorf("%w: unable to get network status", err)
-		}
+	// Always fetch network status to ensure endIndex is not
+	// past tip
+	networkStatus, err := s.fetcher.NetworkStatusRetry(
+		ctx,
+		s.network,
+		nil,
+	)
+	if err != nil {
+		return -1, false, fmt.Errorf("%w: unable to get network status", err)
+	}
 
+	if endIndex == -1 || endIndex > networkStatus.CurrentBlockIdentifier.Index {
 		endIndex = networkStatus.CurrentBlockIdentifier.Index
 	}
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -291,7 +291,7 @@ func (s *Syncer) Sync(
 		}
 
 		if halt {
-			if rangeEnd >= endIndex && endIndex != -1 {
+			if s.nextIndex > endIndex && endIndex != -1 {
 				break
 			}
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -291,7 +291,7 @@ func (s *Syncer) Sync(
 		}
 
 		if halt {
-			if endIndex != -1 {
+			if rangeEnd >= endIndex && endIndex != -1 {
 				break
 			}
 

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -295,12 +295,16 @@ func (s *Syncer) Sync(
 				break
 			}
 
-			log.Printf("Syncer at tip %d...sleeping\n", s.nextIndex)
+			log.Printf("Syncer at tip (waiting for block %d)\n", s.nextIndex)
 			time.Sleep(defaultSyncSleep)
 			continue
 		}
 
-		log.Printf("Syncing %d-%d\n", s.nextIndex, rangeEnd)
+		if s.nextIndex != rangeEnd {
+			log.Printf("Syncing %d-%d\n", s.nextIndex, rangeEnd)
+		} else {
+			log.Printf("Syncing %d\n", s.nextIndex)
+		}
 
 		err = s.syncRange(ctx, rangeEnd)
 		if err != nil {

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -159,7 +159,7 @@ func (s *Syncer) nextSyncableRange(
 		endIndex = networkStatus.CurrentBlockIdentifier.Index
 	}
 
-	if s.nextIndex >= endIndex {
+	if s.nextIndex > endIndex {
 		return -1, true, nil
 	}
 


### PR DESCRIPTION
### Motivation
When calling `syncer.Sync` with an `endIndex != -1`, the `syncer` will attempt to fetch blocks past the `tip` returned by `CurrentBlockIdentifier.Index`.

### Solution
In `nextSyncableRange`, we always fetch the `NetworkStatus` and compare it to the `endIndex` we are attempting to sync to. If we are attempting to get to an `endIndex` greater than `CurrentBlockIdentifier.Index`, we should handle gracefully getting there (as we wait for blocks).