### PR TITLE
[CHORE] Update comparison match logic for opposite amounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage.html
 examples/server/server
 examples/client/client
 examples/fetcher/fetcher
+
+.idea/

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -437,15 +437,40 @@ func comparisonMatch(
 		if err := matchIndexValid(matches, amountMatch[1]); err != nil {
 			return fmt.Errorf("%w: opposite amounts comparison error", err)
 		}
-		for _, op := range matches[amountMatch[0]].Operations {
-			for _, otherOp := range matches[amountMatch[1]].Operations {
-				if err := oppositeAmounts(
-					op,
-					otherOp,
-				); err != nil {
-					return fmt.Errorf("%w: amounts not opposites", err)
-				}
+
+		match1Ops := matches[amountMatch[0]].Operations
+		match2Ops := matches[amountMatch[1]].Operations
+
+		if len(match1Ops) != len(match2Ops) {
+			return errors.New("opposite amounts comparison error: unequal length between match amounts")
+		}
+		// continue if nothing to compare
+		if len(match1Ops) == 0 {
+			continue
+		}
+		// check if all operations within the same match slice have the same amount
+		for i := 1; i < len(match1Ops); i++ {
+			if err := equalAmounts([]*types.Operation{
+				match1Ops[i-1],
+				match1Ops[i],
+			}); err != nil {
+				return fmt.Errorf(
+					"%w: opposite amounts comparison error: amounts not equal within the same match amounts array", err)
 			}
+			if err := equalAmounts([]*types.Operation{
+				match2Ops[i-1],
+				match2Ops[i],
+			}); err != nil {
+				return fmt.Errorf(
+					"%w: opposite amounts comparison error: amounts not equal within the same match amounts array", err)
+			}
+		}
+		// check for opposites amount
+		if err := oppositeAmounts(
+			match1Ops[0],
+			match2Ops[0],
+		); err != nil {
+			return fmt.Errorf("%w: amounts not opposites", err)
 		}
 	}
 

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -437,41 +437,45 @@ func comparisonMatch(
 		if err := matchIndexValid(matches, amountMatch[1]); err != nil {
 			return fmt.Errorf("%w: opposite amounts comparison error", err)
 		}
-
-		match0Ops := matches[amountMatch[0]].Operations
-		match1Ops := matches[amountMatch[1]].Operations
-
-		if len(match0Ops) == 0 || len(match1Ops) == 0 {
-			return errors.New("opposite amounts comparison error: no matched operations")
+		if err := validateMatchOperationsForOppositeComparison(amountMatch[0], matches); err != nil {
+			return err
 		}
-		// check if all operations within the same match slice have the same amount
-		if len(match0Ops) > 1 {
-			if err := equalAmounts(match0Ops); err != nil {
-				return fmt.Errorf(
-					"%w: opposite amounts comparison error: amounts not equal within index %d match operations",
-					err,
-					amountMatch[0],
-				)
-			}
-		}
-		if len(match1Ops) > 1 {
-			if err := equalAmounts(match1Ops); err != nil {
-				return fmt.Errorf(
-					"%w: opposite amounts comparison error: amounts not equal within index %d match operations ",
-					err,
-					amountMatch[1],
-				)
-			}
+		if err := validateMatchOperationsForOppositeComparison(amountMatch[1], matches); err != nil {
+			return err
 		}
 		// check for opposites amount
 		if err := oppositeAmounts(
-			match0Ops[0],
-			match1Ops[0],
+			matches[amountMatch[0]].Operations[0],
+			matches[amountMatch[1]].Operations[0],
 		); err != nil {
 			return fmt.Errorf("%w: amounts not opposites", err)
 		}
 	}
 
+	return nil
+}
+
+// validateMatchOperationsForOppositeComparison checks if the matched operations have at least one element and
+// checks if all the operations have the same amount
+func validateMatchOperationsForOppositeComparison(matchIndex int, matches []*Match) error {
+	matchOps := matches[matchIndex].Operations
+
+	if len(matchOps) == 0 {
+		return fmt.Errorf(
+			"opposite amounts comparison error: no matched operations for match index %d",
+			matchIndex,
+		)
+	}
+	// check if all operations within the same match slice have the same amount
+	if len(matchOps) > 1 {
+		if err := equalAmounts(matchOps); err != nil {
+			return fmt.Errorf(
+				"%w: opposite amounts comparison error: amounts not equal within index %d match operations",
+				err,
+				matchIndex,
+			)
+		}
+	}
 	return nil
 }
 

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -437,13 +437,16 @@ func comparisonMatch(
 		if err := matchIndexValid(matches, amountMatch[1]); err != nil {
 			return fmt.Errorf("%w: opposite amounts comparison error", err)
 		}
-		if err := validateMatchOperationsForOppositeComparison(amountMatch[0], matches); err != nil {
+		if err := matchOperationsForOppositeComparisonValid(amountMatch[0], matches); err != nil {
 			return err
 		}
-		if err := validateMatchOperationsForOppositeComparison(amountMatch[1], matches); err != nil {
+		if err := matchOperationsForOppositeComparisonValid(amountMatch[1], matches); err != nil {
 			return err
 		}
-		// check for opposites amount
+
+		// only need to check opposites amount for the very first operation from each
+		// matched operations group since we made sure all amounts within the same
+		// matched operation group are the same
 		if err := oppositeAmounts(
 			matches[amountMatch[0]].Operations[0],
 			matches[amountMatch[1]].Operations[0],
@@ -455,9 +458,10 @@ func comparisonMatch(
 	return nil
 }
 
-// validateMatchOperationsForOppositeComparison checks if the matched operations have at least one element and
+// matchOperationsForOppositeComparisonValid checks if the matched operations have at least one
+// element and
 // checks if all the operations have the same amount
-func validateMatchOperationsForOppositeComparison(matchIndex int, matches []*Match) error {
+func matchOperationsForOppositeComparisonValid(matchIndex int, matches []*Match) error {
 	matchOps := matches[matchIndex].Operations
 
 	if len(matchOps) == 0 {

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -438,37 +438,35 @@ func comparisonMatch(
 			return fmt.Errorf("%w: opposite amounts comparison error", err)
 		}
 
-		match1Ops := matches[amountMatch[0]].Operations
-		match2Ops := matches[amountMatch[1]].Operations
+		match0Ops := matches[amountMatch[0]].Operations
+		match1Ops := matches[amountMatch[1]].Operations
 
-		if len(match1Ops) != len(match2Ops) {
-			return errors.New("opposite amounts comparison error: unequal length between match amounts")
-		}
-		// continue if nothing to compare
-		if len(match1Ops) == 0 {
-			continue
+		if len(match0Ops) == 0 || len(match1Ops) == 0 {
+			return errors.New("opposite amounts comparison error: no matched operations")
 		}
 		// check if all operations within the same match slice have the same amount
-		for i := 1; i < len(match1Ops); i++ {
-			if err := equalAmounts([]*types.Operation{
-				match1Ops[i-1],
-				match1Ops[i],
-			}); err != nil {
+		if len(match0Ops) > 1 {
+			if err := equalAmounts(match0Ops); err != nil {
 				return fmt.Errorf(
-					"%w: opposite amounts comparison error: amounts not equal within the same match amounts array", err)
+					"%w: opposite amounts comparison error: amounts not equal within index %d match operations",
+					err,
+					amountMatch[0],
+				)
 			}
-			if err := equalAmounts([]*types.Operation{
-				match2Ops[i-1],
-				match2Ops[i],
-			}); err != nil {
+		}
+		if len(match1Ops) > 1 {
+			if err := equalAmounts(match1Ops); err != nil {
 				return fmt.Errorf(
-					"%w: opposite amounts comparison error: amounts not equal within the same match amounts array", err)
+					"%w: opposite amounts comparison error: amounts not equal within index %d match operations ",
+					err,
+					amountMatch[1],
+				)
 			}
 		}
 		// check for opposites amount
 		if err := oppositeAmounts(
+			match0Ops[0],
 			match1Ops[0],
-			match2Ops[0],
 		); err != nil {
 			return fmt.Errorf("%w: amounts not opposites", err)
 		}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -89,7 +89,7 @@ func TestNewReconciler(t *testing.T) {
 					},
 				}
 				r.seenAccounts = map[string]struct{}{
-					types.Hash(accountCurrency): struct{}{},
+					types.Hash(accountCurrency): {},
 				}
 
 				return r


### PR DESCRIPTION
Fixes # .

### Motivation
Update comparison match logic for opposite amounts
- Add more validation on match operations
- Improve time complexity of comparison logic from O(N^2) -> O(N)

### Solution
use a single for loop instead of nested to simply things

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
