### PR TITLE
Make middlewares optional

### DIFF
--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -67,7 +67,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Create the main router handler then apply the logger and Cors
+	// middlewares in sequence.
 	router := NewBlockchainRouter(network, asserter)
+	loggedRouter := server.LoggerMiddleware(router)
+	corsRouter := server.CorsMiddleware(loggedRouter)
 	log.Printf("Listening on port %d\n", serverPort)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", serverPort), router))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", serverPort), corsRouter))
 }

--- a/server/logger.go
+++ b/server/logger.go
@@ -22,18 +22,18 @@ import (
 	"time"
 )
 
-// Logger prints all server requests to stdout.
-func Logger(inner http.Handler, name string) http.Handler {
+// LoggerMiddleware is a simple logger middleware that prints the requests in
+// an ad-hoc fashion to the stdlib's log.
+func LoggerMiddleware(inner http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
 		inner.ServeHTTP(w, r)
 
 		log.Printf(
-			"%s %s %s %s",
+			"%s %s %s",
 			r.Method,
 			r.RequestURI,
-			name,
 			time.Since(start),
 		)
 	})

--- a/server/routers.go
+++ b/server/routers.go
@@ -39,8 +39,13 @@ type Router interface {
 	Routes() Routes
 }
 
-// CorsMiddleware handle CORS and ensures OPTIONS requests are
+// CorsMiddleware handles CORS and ensures OPTIONS requests are
 // handled properly.
+//
+// This may be used to expose a Rosetta server instance to requests made by web
+// apps served over a different domain. Note that his currently allows _all_
+// third party domains so callers might want to adapt this middleware for their
+// own use-cases.
 func CorsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -62,20 +67,15 @@ func NewRouter(routers ...Router) http.Handler {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, api := range routers {
 		for _, route := range api.Routes() {
-			var handler http.Handler
-			handler = route.HandlerFunc
-			handler = Logger(handler, route.Name)
-
 			router.
 				Methods(route.Method).
 				Path(route.Pattern).
 				Name(route.Name).
-				Handler(handler)
+				Handler(route.HandlerFunc)
 		}
 	}
 
-	// use custom middleware because could not get mux handler to work in Chrome
-	return CorsMiddleware(router)
+	return router
 }
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an

--- a/templates/server/logger.mustache
+++ b/templates/server/logger.mustache
@@ -7,18 +7,18 @@ import (
 	"time"
 )
 
-// Logger prints all server requests to stdout.
-func Logger(inner http.Handler, name string) http.Handler {
+// LoggerMiddleware is a simple logger middleware that prints the requests in
+// an ad-hoc fashion to the stdlib's log.
+func LoggerMiddleware(inner http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
 		inner.ServeHTTP(w, r)
 
 		log.Printf(
-			"%s %s %s %s",
+			"%s %s %s",
 			r.Method,
 			r.RequestURI,
-			name,
 			time.Since(start),
 		)
 	})

--- a/templates/server/routers.mustache
+++ b/templates/server/routers.mustache
@@ -20,12 +20,17 @@ type Route struct {
 type Routes []Route
 
 // Router defines the required methods for retrieving api routes
-type Router interface { 
+type Router interface {
 	Routes() Routes
 }
 
-// CorsMiddleware handle CORS and ensures OPTIONS requests are
+// CorsMiddleware handles CORS and ensures OPTIONS requests are
 // handled properly.
+//
+// This may be used to expose a Rosetta server instance to requests made by web
+// apps served over a different domain. Note that his currently allows _all_
+// third party domains so callers might want to adapt this middleware for their
+// own use-cases.
 func CorsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -44,20 +49,15 @@ func NewRouter(routers ...Router) http.Handler {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, api := range routers {
 		for _, route := range api.Routes() {
-			var handler http.Handler
-			handler = route.HandlerFunc
-			handler = Logger(handler, route.Name)
-
 			router.
 				Methods(route.Method).
 				Path(route.Pattern).
 				Name(route.Name).
-				Handler(handler)
+				Handler(route.HandlerFunc)
 		}
 	}
 
-  // use custom middleware because could not get mux handler to work in Chrome
-  return CorsMiddleware(router)
+  return router
 }
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code


### PR DESCRIPTION
This makes the middlewares offered by the server package optional. This
allows full customization by implementations.

Fixes #59 