### PR TITLE
HTTP Timeout + Less Verbose Syncer

### DIFF
--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -91,3 +91,10 @@ func WithInsecureTLS() Option {
 		f.rosettaClient.GetConfig().HTTPClient.Transport = customTransport
 	}
 }
+
+// WithTimeout overrides the default HTTP timeout.
+func WithTimeout(timeout time.Duration) Option {
+	return func(f *Fetcher) {
+		f.rosettaClient.GetConfig().HTTPClient.Timeout = timeout
+	}
+}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -295,7 +295,6 @@ func (s *Syncer) Sync(
 				break
 			}
 
-			log.Printf("Syncer at tip (waiting for block %d)\n", s.nextIndex)
 			time.Sleep(defaultSyncSleep)
 			continue
 		}


### PR DESCRIPTION
Related Issue: https://github.com/coinbase/rosetta-cli/issues/64

### Changes
Make `syncer` less verbose at tip and add ability to provide custom timeout for requests.
