### PR TITLE
Assert Successful Intent

### DIFF
--- a/parser/intent.go
+++ b/parser/intent.go
@@ -77,8 +77,12 @@ func (p *Parser) ExpectedOperations(
 				continue
 			}
 
-			err := ExpectedOperation(in, obs)
-			if err != nil {
+			// Any error returned here only indicated that intent
+			// does not match observed. For ExpectedOperations,
+			// we don't care about the content of the error, we
+			// just care if it errors so we can evaluate the next
+			// operation for a match.
+			if err := ExpectedOperation(in, obs); err != nil {
 				continue
 			}
 

--- a/parser/intent.go
+++ b/parser/intent.go
@@ -58,7 +58,8 @@ func ExpectedOperation(intent *types.Operation, observed *types.Operation) error
 // ExpectedOperations returns an error if a slice of intended
 // operations differ from observed operations. Optionally,
 // it is possible to error if any extra observed opertions
-// are found.
+// are found or if operations matched are not considered
+// successful.
 func (p *Parser) ExpectedOperations(
 	intent []*types.Operation,
 	observed []*types.Operation,


### PR DESCRIPTION
### Changes
* Modify `ExpectedOperations` to allow for asserting success on matched operations
* Print out all missing matches in `ExpectedOperations` error