### PR TITLE
[BUG] ErrGroup Context Cancelation

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -377,7 +377,7 @@ func (s *Syncer) syncRange(
 	// replacing the provided ctx because the context returned
 	// by errgroup.WithContext is canceled as soon as Wait returns.
 	// If this canceled context is passed to a handler or helper,
-	// it can have unintented consequences (some functions
+	// it can have unintended consequences (some functions
 	// return immediately if the context is canceled).
 	//
 	// Source: https://godoc.org/golang.org/x/sync/errgroup

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -353,6 +353,11 @@ func createBlocks(startIndex int64, endIndex int64, add string) []*types.Block {
 	return blocks
 }
 
+func assertNotCanceled(t *testing.T, args mock.Arguments) {
+	err := args.Get(0).(context.Context)
+	assert.NoError(t, err.Err())
+}
+
 func TestSync_NoReorg(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -394,8 +399,7 @@ func TestSync_NoReorg(t *testing.T) {
 			b,
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 		mockHandler.On(
 			"BlockAdded",
@@ -404,8 +408,7 @@ func TestSync_NoReorg(t *testing.T) {
 		).Return(
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 	}
 
@@ -444,8 +447,7 @@ func TestSync_SpecificStart(t *testing.T) {
 			b,
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 		mockHandler.On(
 			"BlockAdded",
@@ -454,8 +456,7 @@ func TestSync_SpecificStart(t *testing.T) {
 		).Return(
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 	}
 
@@ -557,16 +558,14 @@ func TestSync_Reorg(t *testing.T) {
 			b,
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 		mockHandler.On(
 			"BlockAdded",
 			mock.AnythingOfType("*context.cancelCtx"),
 			b,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Return(
 			nil,
 		).Once()
@@ -602,8 +601,7 @@ func TestSync_Reorg(t *testing.T) {
 			thisBlock,
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 		mockHandler.On(
 			"BlockRemoved",
@@ -612,8 +610,7 @@ func TestSync_Reorg(t *testing.T) {
 		).Return(
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 	}
 
@@ -639,8 +636,7 @@ func TestSync_Reorg(t *testing.T) {
 			b,
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 		mockHandler.On(
 			"BlockAdded",
@@ -649,8 +645,7 @@ func TestSync_Reorg(t *testing.T) {
 		).Return(
 			nil,
 		).Run(func(args mock.Arguments) {
-			err := args.Get(0).(context.Context)
-			assert.NoError(t, err.Err())
+			assertNotCanceled(t, args)
 		}).Once()
 	}
 

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -393,14 +393,20 @@ func TestSync_NoReorg(t *testing.T) {
 		).Return(
 			b,
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 		mockHandler.On(
 			"BlockAdded",
 			mock.AnythingOfType("*context.cancelCtx"),
 			b,
 		).Return(
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 	}
 
 	err := syncer.Sync(ctx, -1, 1200)
@@ -437,14 +443,20 @@ func TestSync_SpecificStart(t *testing.T) {
 		).Return(
 			b,
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 		mockHandler.On(
 			"BlockAdded",
 			mock.AnythingOfType("*context.cancelCtx"),
 			b,
 		).Return(
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 	}
 
 	err := syncer.Sync(ctx, 100, 1200)
@@ -529,7 +541,10 @@ func TestSync_Reorg(t *testing.T) {
 			Hash:  "block 0",
 			Index: 0,
 		},
-	}, nil)
+	}, nil).Run(func(args mock.Arguments) {
+		err := args.Get(0).(context.Context)
+		assert.NoError(t, err.Err())
+	})
 
 	blocks := createBlocks(0, 800, "")
 	for _, b := range blocks { // [0, 800]
@@ -541,12 +556,18 @@ func TestSync_Reorg(t *testing.T) {
 		).Return(
 			b,
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 		mockHandler.On(
 			"BlockAdded",
 			mock.AnythingOfType("*context.cancelCtx"),
 			b,
-		).Return(
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Return(
 			nil,
 		).Once()
 	}
@@ -561,7 +582,10 @@ func TestSync_Reorg(t *testing.T) {
 	).Return(
 		newBlocks[11],
 		nil,
-	).Once() // [801]
+	).Run(func(args mock.Arguments) {
+		err := args.Get(0).(context.Context)
+		assert.NoError(t, err.Err())
+	}).Once() // [801]
 
 	// Set parent of reorg start to be last good block
 	newBlocks[0].ParentBlockIdentifier = blocks[789].BlockIdentifier
@@ -577,21 +601,30 @@ func TestSync_Reorg(t *testing.T) {
 		).Return(
 			thisBlock,
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 		mockHandler.On(
 			"BlockRemoved",
 			mock.AnythingOfType("*context.cancelCtx"),
 			blocks[i].BlockIdentifier,
 		).Return(
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 	}
 
 	mockHandler.On(
 		"BlockAdded",
 		mock.AnythingOfType("*context.cancelCtx"),
 		newBlocks[0],
-	).Return(
+	).Run(func(args mock.Arguments) {
+		err := args.Get(0).(context.Context)
+		assert.NoError(t, err.Err())
+	}).Return(
 		nil,
 	).Once() // only fetch this block once
 
@@ -605,14 +638,20 @@ func TestSync_Reorg(t *testing.T) {
 		).Return(
 			b,
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 		mockHandler.On(
 			"BlockAdded",
 			mock.AnythingOfType("*context.cancelCtx"),
 			b,
 		).Return(
 			nil,
-		).Once()
+		).Run(func(args mock.Arguments) {
+			err := args.Get(0).(context.Context)
+			assert.NoError(t, err.Err())
+		}).Once()
 	}
 
 	// Expected Calls to Block


### PR DESCRIPTION
Related PR: https://github.com/coinbase/rosetta-cli/pull/88
Regression introduced in: #89

The context returned by `errgroup.WithContext` is canceled as soon as `g.Wait` returns. If this canceled context is passed to a handler or helper, it can have unintended consequences (some functions return immediately if the context is canceled).

Source: https://godoc.org/golang.org/x/sync/errgroup


### Changes
- [x] Add test to ensure context passed to `syncer` handler/helper is not canceled
- [x] Use a separate context for ErrGroup