### PR TITLE
Support Omitted Blocks

### DIFF
--- a/asserter/account.go
+++ b/asserter/account.go
@@ -42,9 +42,9 @@ func ContainsCurrency(currencies []*types.Currency, currency *types.Currency) bo
 func assertUniqueAmounts(amounts []*types.Amount) error {
 	currencies := make([]*types.Currency, 0)
 	for _, amount := range amounts {
-		// Ensure a currency is used at most once in balance.Amounts
+		// Ensure a currency is used at most once
 		if ContainsCurrency(currencies, amount.Currency) {
-			return fmt.Errorf("currency %+v used in balance multiple times", amount.Currency)
+			return fmt.Errorf("currency %+v used multiple times", amount.Currency)
 		}
 		currencies = append(currencies, amount.Currency)
 

--- a/asserter/account.go
+++ b/asserter/account.go
@@ -35,12 +35,11 @@ func ContainsCurrency(currencies []*types.Currency, currency *types.Currency) bo
 	return false
 }
 
-// assertBalanceAmounts returns an error if a slice
-// of types.Amount returned as an types.AccountIdentifier's
-// balance is invalid. It is considered invalid if the same
+// assertUniqueAmounts returns an error if a slice
+// of types.Amount is invalid. It is considered invalid if the same
 // currency is returned multiple times (these shoould be
 // consolidated) or if a types.Amount is considered invalid.
-func assertBalanceAmounts(amounts []*types.Amount) error {
+func assertUniqueAmounts(amounts []*types.Amount) error {
 	currencies := make([]*types.Currency, 0)
 	for _, amount := range amounts {
 		// Ensure a currency is used at most once in balance.Amounts
@@ -69,7 +68,7 @@ func AccountBalanceResponse(
 		return fmt.Errorf("%w: block identifier is invalid", err)
 	}
 
-	if err := assertBalanceAmounts(response.Balances); err != nil {
+	if err := assertUniqueAmounts(response.Balances); err != nil {
 		return fmt.Errorf("%w: balance amounts are invalid", err)
 	}
 

--- a/asserter/account_test.go
+++ b/asserter/account_test.go
@@ -183,7 +183,7 @@ func TestAccoutBalance(t *testing.T) {
 				validAmount,
 				validAmount,
 			},
-			err: fmt.Errorf("currency %+v used in balance multiple times", validAmount.Currency),
+			err: fmt.Errorf("currency %+v used multiple times", validAmount.Currency),
 		},
 		"valid historical request index": {
 			requestBlock: &types.PartialBlockIdentifier{

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -34,6 +34,10 @@ func ConstructionMetadataResponse(
 		return errors.New("Metadata is nil")
 	}
 
+	if err := assertUniqueAmounts(response.SuggestedFee); err != nil {
+		return fmt.Errorf("%w: duplicate suggested fee currency found", err)
+	}
+
 	return nil
 }
 

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -16,6 +16,7 @@ package asserter
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -34,6 +35,25 @@ func TestConstructionMetadataResponse(t *testing.T) {
 			},
 			err: nil,
 		},
+		"with suggested fee": {
+			response: &types.ConstructionMetadataResponse{
+				Metadata: map[string]interface{}{},
+				SuggestedFee: []*types.Amount{
+					validAmount,
+				},
+			},
+			err: nil,
+		},
+		"with duplicate suggested fee": {
+			response: &types.ConstructionMetadataResponse{
+				Metadata: map[string]interface{}{},
+				SuggestedFee: []*types.Amount{
+					validAmount,
+					validAmount,
+				},
+			},
+			err: fmt.Errorf("currency %+v used multiple times", validAmount.Currency),
+		},
 		"nil response": {
 			err: errors.New("construction metadata response cannot be nil"),
 		},
@@ -46,7 +66,11 @@ func TestConstructionMetadataResponse(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := ConstructionMetadataResponse(test.response)
-			assert.Equal(t, test.err, err)
+			if test.err != nil {
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/asserter/server.go
+++ b/asserter/server.go
@@ -282,6 +282,17 @@ func (a *Asserter) ConstructionPreprocessRequest(
 		return err
 	}
 
+	if err := assertUniqueAmounts(request.MaxFee); err != nil {
+		return fmt.Errorf("%w: duplicate max fee currency found", err)
+	}
+
+	if request.SuggestedFeeMultiplier != nil && *request.SuggestedFeeMultiplier < 0 {
+		return fmt.Errorf(
+			"suggested fee multiplier %f cannot be less than 0",
+			*request.SuggestedFeeMultiplier,
+		)
+	}
+
 	return nil
 }
 

--- a/asserter/server_test.go
+++ b/asserter/server_test.go
@@ -687,6 +687,8 @@ func TestConstructionDeriveRequest(t *testing.T) {
 }
 
 func TestConstructionPreprocessRequest(t *testing.T) {
+	positiveFeeMultiplier := float64(1.1)
+	negativeFeeMultiplier := float64(-1.1)
 	var tests = map[string]struct {
 		request *types.ConstructionPreprocessRequest
 		err     error
@@ -695,6 +697,35 @@ func TestConstructionPreprocessRequest(t *testing.T) {
 			request: &types.ConstructionPreprocessRequest{
 				NetworkIdentifier: validNetworkIdentifier,
 				Operations:        validOps,
+			},
+			err: nil,
+		},
+		"valid request with suggested fee multiplier": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier:      validNetworkIdentifier,
+				Operations:             validOps,
+				SuggestedFeeMultiplier: &positiveFeeMultiplier,
+			},
+			err: nil,
+		},
+		"valid request with max fee": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        validOps,
+				MaxFee: []*types.Amount{
+					validAmount,
+				},
+			},
+			err: nil,
+		},
+		"valid request with suggested fee multiplier and max fee": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        validOps,
+				MaxFee: []*types.Amount{
+					validAmount,
+				},
+				SuggestedFeeMultiplier: &positiveFeeMultiplier,
 			},
 			err: nil,
 		},
@@ -734,6 +765,25 @@ func TestConstructionPreprocessRequest(t *testing.T) {
 				Operations:        invalidOps,
 			},
 			err: errors.New("must be empty for construction"),
+		},
+		"negaitve suggested fee multiplier": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier:      validNetworkIdentifier,
+				Operations:             validOps,
+				SuggestedFeeMultiplier: &negativeFeeMultiplier,
+			},
+			err: fmt.Errorf("suggested fee multiplier %f cannot be less than 0", negativeFeeMultiplier),
+		},
+		"max fee with duplicate currency": {
+			request: &types.ConstructionPreprocessRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        validOps,
+				MaxFee: []*types.Amount{
+					validAmount,
+					validAmount,
+				},
+			},
+			err: fmt.Errorf("currency %+v used multiple times", validAmount.Currency),
 		},
 	}
 

--- a/client/api_block.go
+++ b/client/api_block.go
@@ -112,14 +112,16 @@ func (a *BlockAPIService) Block(
 // only be used when querying a node for a block does not return all transactions contained within
 // it. All transactions returned by this endpoint must be appended to any transactions returned by
 // the /block method by consumers of this data. Fetching a transaction by hash is considered an
-// Explorer Method (which is classified under the Future Work section). Calling this endpoint
-// requires reference to a BlockIdentifier because transaction parsing can change depending on which
-// block contains the transaction. For example, in Bitcoin it is necessary to know which block
-// contains a transaction to determine the destination of fee payments. Without specifying a block
-// identifier, the node would have to infer which block to use (which could change during a re-org).
-// Implementations that require fetching previous transactions to populate the response (ex:
-// Previous UTXOs in Bitcoin) may find it useful to run a cache within the Rosetta server in the
-// /data directory (on a path that does not conflict with the node).
+// Explorer Method (which is classified under the Future Work section). This method can be used to
+// let consumers to paginate results when the  block trasactions count is too big to be returned in
+// a single BlockResponse. Calling this endpoint requires reference to a BlockIdentifier because
+// transaction parsing can change depending on which block contains the transaction. For example, in
+// Bitcoin it is necessary to know which block contains a transaction to determine the destination
+// of fee payments. Without specifying a block identifier, the node would have to infer which block
+// to use (which could change during a re-org). Implementations that require fetching previous
+// transactions to populate the response (ex: Previous UTXOs in Bitcoin) may find it useful to run a
+// cache within the Rosetta server in the /data directory (on a path that does not conflict with the
+// node).
 func (a *BlockAPIService) BlockTransaction(
 	ctx _context.Context,
 	blockTransactionRequest *types.BlockTransactionRequest,

--- a/client/api_construction.go
+++ b/client/api_construction.go
@@ -244,11 +244,13 @@ func (a *ConstructionAPIService) ConstructionHash(
 
 // ConstructionMetadata Get any information required to construct a transaction for a specific
 // network. Metadata returned here could be a recent hash to use, an account sequence number, or
-// even arbitrary chain state. The request used when calling this endpoint is often created by
-// calling /construction/preprocess in an offline environment. It is important to clarify that this
-// endpoint should not pre-construct any transactions for the client (this should happen in
-// /construction/payloads). This endpoint is left purposely unstructured because of the wide scope
-// of metadata that could be required.
+// even arbitrary chain state. The request used when calling this endpoint is created by calling
+// /construction/preprocess in an offline environment. You should NEVER assume that the request sent
+// to this endpoint will be created by the caller or populated with any custom parameters. This must
+// occur in /construction/preprocess. It is important to clarify that this endpoint should not
+// pre-construct any transactions for the client (this should happen in /construction/payloads).
+// This endpoint is left purposely unstructured because of the wide scope of metadata that could be
+// required.
 func (a *ConstructionAPIService) ConstructionMetadata(
 	ctx _context.Context,
 	constructionMetadataRequest *types.ConstructionMetadataRequest,
@@ -463,8 +465,10 @@ func (a *ConstructionAPIService) ConstructionPayloads(
 
 // ConstructionPreprocess Preprocess is called prior to /construction/payloads to construct a
 // request for any metadata that is needed for transaction construction given (i.e. account nonce).
-// The request returned from this method will be used by the caller (in a different execution
-// environment) to call the /construction/metadata endpoint.
+// The options object returned from this endpoint will be sent to the /construction/metadata
+// endpoint UNMODIFIED by the caller (in an offline execution environment). If your Construction API
+// implementation has configuration options, they MUST be specified in the /construction/preprocess
+// request (in the metadata field).
 func (a *ConstructionAPIService) ConstructionPreprocess(
 	ctx _context.Context,
 	constructionPreprocessRequest *types.ConstructionPreprocessRequest,

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ var (
 	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
 )
 
-// APIClient manages communication with the Rosetta API v1.4.1
+// APIClient manages communication with the Rosetta API v1.4.2
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,8 +53,9 @@ done
 rm -rf tmp;
 
 # Download spec file from releases
-ROSETTA_SPEC_VERSION=v1.4.1
-curl -L https://github.com/coinbase/rosetta-specifications/releases/download/${ROSETTA_SPEC_VERSION}/api.json -o api.json;
+# ROSETTA_SPEC_VERSION=v1.4.1
+# curl -L https://github.com/coinbase/rosetta-specifications/releases/download/${ROSETTA_SPEC_VERSION}/api.json -o api.json;
+cp ../rosetta-specifications/api.json .
 
 # Generate client + types code
 GENERATOR_VERSION=v4.3.0

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,9 +53,8 @@ done
 rm -rf tmp;
 
 # Download spec file from releases
-# ROSETTA_SPEC_VERSION=v1.4.1
-# curl -L https://github.com/coinbase/rosetta-specifications/releases/download/${ROSETTA_SPEC_VERSION}/api.json -o api.json;
-cp ../rosetta-specifications/api.json .
+ROSETTA_SPEC_VERSION=v1.4.2
+curl -L https://github.com/coinbase/rosetta-specifications/releases/download/${ROSETTA_SPEC_VERSION}/api.json -o api.json;
 
 # Generate client + types code
 GENERATOR_VERSION=v4.3.0

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -177,6 +177,12 @@ func (f *Fetcher) Block(
 		return nil, err
 	}
 
+	// If a block is omitted, it will return a non-error
+	// response with block equal to nil.
+	if block == nil {
+		return nil, nil
+	}
+
 	if err := f.Asserter.Block(block); err != nil {
 		return nil, err
 	}

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -53,6 +53,12 @@ func TestBlockRetry(t *testing.T) {
 		fetcherMaxRetries uint64
 		shouldCancel      bool
 	}{
+		"omitted block": {
+			network:           basicNetwork,
+			block:             basicBlock,
+			expectedBlock:     nil,
+			fetcherMaxRetries: 0,
+		},
 		"no failures": {
 			network:           basicNetwork,
 			block:             basicBlock,

--- a/types/block_response.go
+++ b/types/block_response.go
@@ -17,9 +17,14 @@
 package types
 
 // BlockResponse A BlockResponse includes a fully-populated block or a partially-populated block
-// with a list of other transactions to fetch (other_transactions).
+// with a list of other transactions to fetch (other_transactions). As a result of the consensus
+// algorithm of some blockchains, blocks can be omitted (i.e. certain block indexes can be skipped).
+// If a query for one of these omitted indexes is made, the response should not include a `Block`
+// object. It is VERY important to note that blocks MUST still form a canonical, connected chain of
+// blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a
+// block after an omitted block should reference the last non-omitted block.
 type BlockResponse struct {
-	Block *Block `json:"block"`
+	Block *Block `json:"block,omitempty"`
 	// Some blockchains may require additional transactions to be fetched that weren't returned in
 	// the block response (ex: block only returns transaction hashes). For blockchains with a lot of
 	// transactions in each block, this can be very useful as consumers can concurrently fetch all

--- a/types/construction_metadata_response.go
+++ b/types/construction_metadata_response.go
@@ -17,7 +17,11 @@
 package types
 
 // ConstructionMetadataResponse The ConstructionMetadataResponse returns network-specific metadata
-// used for transaction construction.
+// used for transaction construction. Optionally, the implementer can return the suggested fee
+// associated with the transaction being constructed. The caller may use this info to adjust the
+// intent of the transaction or to create a transaction with a different account that can pay the
+// suggested fee. Suggested fee is an array in case fee payment must occur in multiple currencies.
 type ConstructionMetadataResponse struct {
-	Metadata map[string]interface{} `json:"metadata"`
+	Metadata     map[string]interface{} `json:"metadata"`
+	SuggestedFee []*Amount              `json:"suggested_fee,omitempty"`
 }

--- a/types/construction_preprocess_request.go
+++ b/types/construction_preprocess_request.go
@@ -18,9 +18,21 @@ package types
 
 // ConstructionPreprocessRequest ConstructionPreprocessRequest is passed to the
 // `/construction/preprocess` endpoint so that a Rosetta implementation can determine which metadata
-// it needs to request for construction.
+// it needs to request for construction. Metadata provided in this object should NEVER be a product
+// of live data (i.e. the caller must follow some network-specific data fetching strategy outside of
+// the Construction API to populate required Metadata). If live data is required for construction,
+// it MUST be fetched in the call to `/construction/metadata`. The caller can provide a max fee they
+// are willing to pay for a transaction. This is an array in the case fees must be paid in multiple
+// currencies. The caller can also provide a suggested fee multiplier to indicate that the suggested
+// fee should be scaled. This may be used to set higher fees for urgent transactions or to pay lower
+// fees when there is less urgency. It is assumed that providing a very low multiplier (like 0.0001)
+// will never lead to a transaction being created with a fee less than the minimum network fee (if
+// applicable). In the case that the caller provides both a max fee and a suggested fee multiplier,
+// the max fee will set an upper bound on the suggested fee (regardless of the multiplier provided).
 type ConstructionPreprocessRequest struct {
-	NetworkIdentifier *NetworkIdentifier     `json:"network_identifier"`
-	Operations        []*Operation           `json:"operations"`
-	Metadata          map[string]interface{} `json:"metadata,omitempty"`
+	NetworkIdentifier      *NetworkIdentifier     `json:"network_identifier"`
+	Operations             []*Operation           `json:"operations"`
+	Metadata               map[string]interface{} `json:"metadata,omitempty"`
+	MaxFee                 []*Amount              `json:"max_fee,omitempty"`
+	SuggestedFeeMultiplier *float64               `json:"suggested_fee_multiplier,omitempty"`
 }


### PR DESCRIPTION
Blocked by: https://github.com/coinbase/rosetta-specifications/pull/35 and `v1.4.2` release

This PR adds support for syncing omitted blocks and for populating the new suggested fee-related fields that were added in `v1.4.2`.

### Changes
- [x] Update to `v1.4.2`
- [x] Allow nil block in fetcher
- [x] Assert suggested fee, max fee, suggested fee multiplier
- [x] Modify syncer to support index gaps