### PR TITLE
Add ImportPrivKey function to keys package

### DIFF
--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -115,9 +115,21 @@ func TestImportPrivKey(t *testing.T) {
 	}
 
 	importPrivKeyTests := []importKeyTest{
-		{"aeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebb", types.Edwards25519, ""},
-		{"01ea48249742650907004331e85536f868e2d3959434ba751d8aa230138a9707", types.Edwards25519, ""},
-		{"f1821e051843bce17c1f31023609e9412ae4525d27447fc93afa4a271ee60550", types.Edwards25519, ""},
+		{
+			"aeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebb",
+			types.Edwards25519,
+			"",
+		},
+		{
+			"01ea48249742650907004331e85536f868e2d3959434ba751d8aa230138a9707",
+			types.Edwards25519,
+			"",
+		},
+		{
+			"f1821e051843bce17c1f31023609e9412ae4525d27447fc93afa4a271ee60550",
+			types.Edwards25519,
+			"",
+		},
 		{"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a", types.Secp256k1, ""},
 		{"0e842a16b2d39a4dff5c63688513cb2109e30c3c30bc4eb502cc54f4614493f6", types.Secp256k1, ""},
 		{"42efc44bdf7b2d4d45ddd6ddb727ed498c91e7070914c9ed0d80af680ff42b3e", types.Secp256k1, ""},

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -106,3 +106,29 @@ func TestKeypairValidity(t *testing.T) {
 		assert.Contains(t, err.Error(), test.errMsg)
 	}
 }
+
+func TestImportPrivKey(t *testing.T) {
+	type importKeyTest struct {
+		privKey   string
+		curveType types.CurveType
+		errMsg    string
+	}
+
+	importPrivKeyTests := []importKeyTest{
+		{"aeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebb", types.Edwards25519, ""},
+		{"01ea48249742650907004331e85536f868e2d3959434ba751d8aa230138a9707", types.Edwards25519, ""},
+		{"f1821e051843bce17c1f31023609e9412ae4525d27447fc93afa4a271ee60550", types.Edwards25519, ""},
+		{"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a", types.Secp256k1, ""},
+		{"0e842a16b2d39a4dff5c63688513cb2109e30c3c30bc4eb502cc54f4614493f6", types.Secp256k1, ""},
+		{"42efc44bdf7b2d4d45ddd6ddb727ed498c91e7070914c9ed0d80af680ff42b3e", types.Secp256k1, ""},
+		{"asd", types.Secp256k1, "could not decode privkey"},
+		{"asd", types.Edwards25519, "could not decode privkey"},
+	}
+
+	for _, test := range importPrivKeyTests {
+		_, err := ImportPrivKey(test.privKey, test.curveType)
+		if err != nil {
+			assert.Contains(t, err.Error(), test.errMsg)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
This adds the `ImportPrivKey` function to the keys package, and allows users to pass in a hex-encoded privkey string to get a KeyPair.

This will be used in `rosetta-cli` where users can specify their prefunded addresses' privkeys in hex format in their config files.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
