### PR TITLE
Add Typed Errors to Syncer and Fetcher

### DIFF
--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -41,14 +41,14 @@ func (f *Fetcher) AccountBalance(
 		},
 	)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, nil, nil, nil, fmt.Errorf("%w: /account/balance %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.AccountBalanceResponse(
 		block,
 		response,
 	); err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, nil, nil, nil, fmt.Errorf("%w: /account/balance %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.BlockIdentifier, response.Balances, response.Coins, response.Metadata, nil
@@ -76,7 +76,7 @@ func (f *Fetcher) AccountBalanceRetry(
 			block,
 		)
 		if errors.Is(err, ErrAssertionFailed) {
-			return nil, nil, nil, nil, fmt.Errorf("%w: not attempting retry", err)
+			return nil, nil, nil, nil, fmt.Errorf("%w: /account/balance not attempting retry", err)
 		}
 
 		if err == nil {

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -16,6 +16,7 @@ package fetcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -40,14 +41,14 @@ func (f *Fetcher) AccountBalance(
 		},
 	)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.AccountBalanceResponse(
 		block,
 		response,
 	); err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.BlockIdentifier, response.Balances, response.Coins, response.Metadata, nil
@@ -74,6 +75,10 @@ func (f *Fetcher) AccountBalanceRetry(
 			account,
 			block,
 		)
+		if errors.Is(err, ErrAssertionFailed) {
+			return nil, nil, nil, nil, fmt.Errorf("%w: not attempting retry", err)
+		}
+
 		if err == nil {
 			return responseBlock, balances, coins, metadata, nil
 		}

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -41,14 +41,22 @@ func (f *Fetcher) AccountBalance(
 		},
 	)
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%w: /account/balance %s", ErrRequestFailed, err.Error())
+		return nil, nil, nil, nil, fmt.Errorf(
+			"%w: /account/balance %s",
+			ErrRequestFailed,
+			err.Error(),
+		)
 	}
 
 	if err := asserter.AccountBalanceResponse(
 		block,
 		response,
 	); err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%w: /account/balance %s", ErrAssertionFailed, err.Error())
+		return nil, nil, nil, nil, fmt.Errorf(
+			"%w: /account/balance %s",
+			ErrAssertionFailed,
+			err.Error(),
+		)
 	}
 
 	return response.BlockIdentifier, response.Balances, response.Coins, response.Metadata, nil

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -66,7 +66,7 @@ func (f *Fetcher) fetchChannelTransactions(
 		)
 
 		if err != nil {
-			return fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+			return fmt.Errorf("%w: /block/transaction %s", ErrRequestFailed, err.Error())
 		}
 
 		select {
@@ -140,7 +140,7 @@ func (f *Fetcher) UnsafeBlock(
 		BlockIdentifier:   blockIdentifier,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /block %s", ErrRequestFailed, err.Error())
 	}
 
 	// Exit early if no need to fetch txs
@@ -155,7 +155,7 @@ func (f *Fetcher) UnsafeBlock(
 		blockResponse.OtherTransactions,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /block/transaction %s", ErrRequestFailed, err.Error())
 	}
 
 	blockResponse.Block.Transactions = append(blockResponse.Block.Transactions, batchFetch...)
@@ -175,7 +175,7 @@ func (f *Fetcher) Block(
 ) (*types.Block, error) {
 	block, err := f.UnsafeBlock(ctx, network, blockIdentifier)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /block %s", ErrRequestFailed, err.Error())
 	}
 
 	// If a block is omitted, it will return a non-error
@@ -185,7 +185,7 @@ func (f *Fetcher) Block(
 	}
 
 	if err := f.Asserter.Block(block); err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, fmt.Errorf("%w: /block %s", ErrAssertionFailed, err.Error())
 	}
 
 	return block, nil
@@ -214,7 +214,7 @@ func (f *Fetcher) BlockRetry(
 			blockIdentifier,
 		)
 		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: not attempting retry", err)
+			return nil, fmt.Errorf("%w: /block not attempting retry", err)
 		}
 
 		if err == nil {

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -16,6 +16,7 @@ package fetcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -65,7 +66,7 @@ func (f *Fetcher) fetchChannelTransactions(
 		)
 
 		if err != nil {
-			return err
+			return fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 		}
 
 		select {
@@ -139,7 +140,7 @@ func (f *Fetcher) UnsafeBlock(
 		BlockIdentifier:   blockIdentifier,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	// Exit early if no need to fetch txs
@@ -154,7 +155,7 @@ func (f *Fetcher) UnsafeBlock(
 		blockResponse.OtherTransactions,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	blockResponse.Block.Transactions = append(blockResponse.Block.Transactions, batchFetch...)
@@ -174,7 +175,7 @@ func (f *Fetcher) Block(
 ) (*types.Block, error) {
 	block, err := f.UnsafeBlock(ctx, network, blockIdentifier)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	// If a block is omitted, it will return a non-error
@@ -184,7 +185,7 @@ func (f *Fetcher) Block(
 	}
 
 	if err := f.Asserter.Block(block); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return block, nil
@@ -212,6 +213,10 @@ func (f *Fetcher) BlockRetry(
 			network,
 			blockIdentifier,
 		)
+		if errors.Is(err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: not attempting retry", err)
+		}
+
 		if err == nil {
 			return block, nil
 		}

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -16,6 +16,7 @@ package fetcher
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 
@@ -41,11 +42,11 @@ func (f *Fetcher) ConstructionCombine(
 		},
 	)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.ConstructionCombineResponse(response); err != nil {
-		return "", err
+		return "", fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.SignedTransaction, nil
@@ -70,11 +71,11 @@ func (f *Fetcher) ConstructionDerive(
 		},
 	)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.ConstructionDeriveResponse(response); err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.Address, response.Metadata, nil
@@ -94,11 +95,11 @@ func (f *Fetcher) ConstructionHash(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.TransactionIdentifierResponse(response); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.TransactionIdentifier, nil
@@ -118,11 +119,11 @@ func (f *Fetcher) ConstructionMetadata(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.ConstructionMetadataResponse(metadata); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return metadata.Metadata, nil
@@ -147,11 +148,11 @@ func (f *Fetcher) ConstructionParse(
 		},
 	)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := f.Asserter.ConstructionParseResponse(response, signed); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.Operations, response.Signers, response.Metadata, nil
@@ -182,11 +183,11 @@ func (f *Fetcher) ConstructionPayloads(
 		},
 	)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.ConstructionPayloadsResponse(response); err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.UnsignedTransaction, response.Payloads, nil
@@ -213,7 +214,7 @@ func (f *Fetcher) ConstructionPreprocess(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	// We do not assert the response here because the only object
@@ -237,11 +238,11 @@ func (f *Fetcher) ConstructionSubmit(
 		},
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.TransactionIdentifierResponse(submitResponse); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return submitResponse.TransactionIdentifier, submitResponse.Metadata, nil

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -148,11 +148,19 @@ func (f *Fetcher) ConstructionParse(
 		},
 	)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%w: /construction/parse %s", ErrRequestFailed, err.Error())
+		return nil, nil, nil, fmt.Errorf(
+			"%w: /construction/parse %s",
+			ErrRequestFailed,
+			err.Error(),
+		)
 	}
 
 	if err := f.Asserter.ConstructionParseResponse(response, signed); err != nil {
-		return nil, nil, nil, fmt.Errorf("%w: /construction/parse %s", ErrAssertionFailed, err.Error())
+		return nil, nil, nil, fmt.Errorf(
+			"%w: /construction/parse %s",
+			ErrAssertionFailed,
+			err.Error(),
+		)
 	}
 
 	return response.Operations, response.Signers, response.Metadata, nil

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -42,11 +42,11 @@ func (f *Fetcher) ConstructionCombine(
 		},
 	)
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return "", fmt.Errorf("%w: /construction/combine %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.ConstructionCombineResponse(response); err != nil {
-		return "", fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return "", fmt.Errorf("%w: /construction/combine %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.SignedTransaction, nil
@@ -71,11 +71,11 @@ func (f *Fetcher) ConstructionDerive(
 		},
 	)
 	if err != nil {
-		return "", nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return "", nil, fmt.Errorf("%w: /construction/derive %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.ConstructionDeriveResponse(response); err != nil {
-		return "", nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return "", nil, fmt.Errorf("%w: /construction/derive %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.Address, response.Metadata, nil
@@ -95,11 +95,11 @@ func (f *Fetcher) ConstructionHash(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /construction/hash %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.TransactionIdentifierResponse(response); err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, fmt.Errorf("%w: /construction/hash %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.TransactionIdentifier, nil
@@ -119,11 +119,11 @@ func (f *Fetcher) ConstructionMetadata(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /construction/metadata %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.ConstructionMetadataResponse(metadata); err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, fmt.Errorf("%w: /construction/metadata %s", ErrAssertionFailed, err.Error())
 	}
 
 	return metadata.Metadata, nil
@@ -148,11 +148,11 @@ func (f *Fetcher) ConstructionParse(
 		},
 	)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, nil, nil, fmt.Errorf("%w: /construction/parse %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := f.Asserter.ConstructionParseResponse(response, signed); err != nil {
-		return nil, nil, nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, nil, nil, fmt.Errorf("%w: /construction/parse %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.Operations, response.Signers, response.Metadata, nil
@@ -183,11 +183,11 @@ func (f *Fetcher) ConstructionPayloads(
 		},
 	)
 	if err != nil {
-		return "", nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return "", nil, fmt.Errorf("%w: /construction/payloads %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.ConstructionPayloadsResponse(response); err != nil {
-		return "", nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return "", nil, fmt.Errorf("%w: /construction/payloads %s", ErrAssertionFailed, err.Error())
 	}
 
 	return response.UnsignedTransaction, response.Payloads, nil
@@ -214,7 +214,7 @@ func (f *Fetcher) ConstructionPreprocess(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /construction/preprocess %s", ErrRequestFailed, err.Error())
 	}
 
 	// We do not assert the response here because the only object
@@ -238,11 +238,11 @@ func (f *Fetcher) ConstructionSubmit(
 		},
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, nil, fmt.Errorf("%w: /connection/submit %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.TransactionIdentifierResponse(submitResponse); err != nil {
-		return nil, nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, nil, fmt.Errorf("%w: /connection/submit %s", ErrAssertionFailed, err.Error())
 	}
 
 	return submitResponse.TransactionIdentifier, submitResponse.Metadata, nil

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -51,9 +51,20 @@ const (
 )
 
 var (
-	// ErrExhaustedRetries is returned when a fetch with retries
+	// ErrNoNetworks is returned when there are no
+	// networks available for syncing.
+	ErrNoNetworks = errors.New("no networks available")
+
+	// ErrRequestFailed is returned when a request fails.
+	ErrRequestFailed = errors.New("request failed")
+
+	// ErrExhaustedRetries is returned when a request with retries
 	// fails because it was attempted too many times.
 	ErrExhaustedRetries = errors.New("retries exhausted")
+
+	// ErrAssertionFailed is returned when a fetch succeeds
+	// but fails assertion.
+	ErrAssertionFailed = errors.New("assertion failed")
 )
 
 // Fetcher contains all logic to communicate with a Rosetta Server.
@@ -127,7 +138,7 @@ func (f *Fetcher) InitializeAsserter(
 	}
 
 	if len(networkList.NetworkIdentifiers) == 0 {
-		return nil, nil, errors.New("no networks available")
+		return nil, nil, ErrNoNetworks
 	}
 	primaryNetwork := networkList.NetworkIdentifiers[0]
 

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -36,12 +36,12 @@ func (f *Fetcher) Mempool(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /mempool %s", ErrRequestFailed, err.Error())
 	}
 
 	mempool := response.TransactionIdentifiers
 	if err := asserter.MempoolTransactions(mempool); err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, fmt.Errorf("%w: /mempool %s", ErrAssertionFailed, err.Error())
 	}
 
 	return mempool, nil
@@ -62,12 +62,12 @@ func (f *Fetcher) MempoolTransaction(
 		},
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, nil, fmt.Errorf("%w: /mempool/transaction %s", ErrRequestFailed, err.Error())
 	}
 
 	mempoolTransaction := response.Transaction
 	if err := f.Asserter.Transaction(mempoolTransaction); err != nil {
-		return nil, nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, nil, fmt.Errorf("%w: /mempool/transaction %s", ErrAssertionFailed, err.Error())
 	}
 
 	return mempoolTransaction, response.Metadata, nil

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -16,6 +16,7 @@ package fetcher
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 
@@ -35,12 +36,12 @@ func (f *Fetcher) Mempool(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	mempool := response.TransactionIdentifiers
 	if err := asserter.MempoolTransactions(mempool); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return mempool, nil
@@ -61,12 +62,12 @@ func (f *Fetcher) MempoolTransaction(
 		},
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	mempoolTransaction := response.Transaction
 	if err := f.Asserter.Transaction(mempoolTransaction); err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return mempoolTransaction, response.Metadata, nil

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -16,6 +16,7 @@ package fetcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -38,11 +39,11 @@ func (f *Fetcher) NetworkStatus(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return networkStatus, nil
@@ -66,6 +67,10 @@ func (f *Fetcher) NetworkStatusRetry(
 			network,
 			metadata,
 		)
+		if errors.Is(err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: not attempting network status retry", err)
+		}
+
 		if err == nil {
 			return networkStatus, nil
 		}
@@ -103,11 +108,11 @@ func (f *Fetcher) NetworkList(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return networkList, nil
@@ -129,6 +134,10 @@ func (f *Fetcher) NetworkListRetry(
 			ctx,
 			metadata,
 		)
+		if errors.Is(err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: not attempting network status retry", err)
+		}
+
 		if err == nil {
 			return networkList, nil
 		}
@@ -163,11 +172,11 @@ func (f *Fetcher) NetworkOptions(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.NetworkOptionsResponse(NetworkOptions); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
 	}
 
 	return NetworkOptions, nil
@@ -191,6 +200,10 @@ func (f *Fetcher) NetworkOptionsRetry(
 			network,
 			metadata,
 		)
+		if errors.Is(err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: not attempting network status retry", err)
+		}
+
 		if err == nil {
 			return networkOptions, nil
 		}

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -68,7 +68,7 @@ func (f *Fetcher) NetworkStatusRetry(
 			metadata,
 		)
 		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: not attempting network status retry", err)
+			return nil, fmt.Errorf("%w: not attempting retry", err)
 		}
 
 		if err == nil {
@@ -135,7 +135,7 @@ func (f *Fetcher) NetworkListRetry(
 			metadata,
 		)
 		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: not attempting network status retry", err)
+			return nil, fmt.Errorf("%w: not attempting retry", err)
 		}
 
 		if err == nil {
@@ -201,7 +201,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 			metadata,
 		)
 		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: not attempting network status retry", err)
+			return nil, fmt.Errorf("%w: not attempting retry", err)
 		}
 
 		if err == nil {

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -39,11 +39,11 @@ func (f *Fetcher) NetworkStatus(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error())
 	}
 
 	return networkStatus, nil
@@ -68,7 +68,7 @@ func (f *Fetcher) NetworkStatusRetry(
 			metadata,
 		)
 		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: not attempting retry", err)
+			return nil, fmt.Errorf("%w: /network/status not attempting retry", err)
 		}
 
 		if err == nil {
@@ -108,11 +108,11 @@ func (f *Fetcher) NetworkList(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error())
 	}
 
 	return networkList, nil
@@ -135,7 +135,7 @@ func (f *Fetcher) NetworkListRetry(
 			metadata,
 		)
 		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: not attempting retry", err)
+			return nil, fmt.Errorf("%w: /network/list not attempting retry", err)
 		}
 
 		if err == nil {
@@ -172,11 +172,11 @@ func (f *Fetcher) NetworkOptions(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrRequestFailed, err.Error())
+		return nil, fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error())
 	}
 
 	if err := asserter.NetworkOptionsResponse(NetworkOptions); err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrAssertionFailed, err.Error())
+		return nil, fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error())
 	}
 
 	return NetworkOptions, nil
@@ -201,7 +201,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 			metadata,
 		)
 		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: not attempting retry", err)
+			return nil, fmt.Errorf("%w: /network/options not attempting retry", err)
 		}
 
 		if err == nil {

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -312,7 +312,7 @@ func TestProcessBlock(t *testing.T) {
 			ctx,
 			blockSequence[5],
 		)
-		assert.EqualError(t, err, "Got block 5 instead of 3")
+		assert.Contains(t, err.Error(), "got block 5 instead of 3")
 		assert.Equal(t, int64(3), syncer.nextIndex)
 		assert.Equal(t, blockSequence[2].BlockIdentifier, lastBlockIdentifier(syncer))
 		assert.Equal(


### PR DESCRIPTION
Related PR: https://github.com/coinbase/rosetta-cli/pull/103

To better trace the origin of different errors, we define typed errors that can be examined by the caller.

### Changes
- [x] (syncer) `ErrCannotRemoveGenesisBlock`, `ErrOutOfOrder`
- [x] (fetcher) `ErrRequestFailed`, `ErrAssertionFailed`, `ErrNoNetworks`
  - [x] account
  - [x] block
  - [x] construction
  - [x] network
  - [x] mempool