### PR TITLE
exposing Rosetta types.Error in fetcher

### DIFF
--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -91,7 +91,10 @@ func (f *Fetcher) AccountBalanceRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			return nil, nil, nil, nil, fmt.Errorf("%w: /account/balance not attempting retry", err.Err)
+			return nil, nil, nil, nil, fmt.Errorf(
+				"%w: /account/balance not attempting retry",
+				err.Err,
+			)
 		}
 
 		if ctx.Err() != nil {

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -41,25 +41,25 @@ func (f *Fetcher) AccountBalance(
 		},
 	)
 	if err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err:       fmt.Errorf("%w: /account/balance %s", ErrRequestFailed, err.Error()),
 			ClientErr: clientErr,
 		}
-		return nil, nil, nil, nil, res
+		return nil, nil, nil, nil, fetcherErr
 	}
 
 	if err := asserter.AccountBalanceResponse(
 		block,
 		response,
 	); err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err: fmt.Errorf(
 				"%w: /account/balance %s",
 				ErrAssertionFailed,
 				err.Error(),
 			),
 		}
-		return nil, nil, nil, nil, res
+		return nil, nil, nil, nil, fetcherErr
 	}
 
 	return response.BlockIdentifier, response.Balances, response.Coins, response.Metadata, nil
@@ -91,19 +91,19 @@ func (f *Fetcher) AccountBalanceRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /account/balance not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
 			}
-			return nil, nil, nil, nil, res
+			return nil, nil, nil, nil, fetcherErr
 		}
 
 		if ctx.Err() != nil {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       ctx.Err(),
 				ClientErr: err.ClientErr,
 			}
-			return nil, nil, nil, nil, res
+			return nil, nil, nil, nil, fetcherErr
 		}
 
 		if !tryAgain(

--- a/fetcher/account_test.go
+++ b/fetcher/account_test.go
@@ -17,7 +17,6 @@ package fetcher
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -158,7 +157,7 @@ func TestAccountBalanceRetry(t *testing.T) {
 			assert.Equal(test.expectedBlock, block)
 			assert.Equal(test.expectedAmounts, amounts)
 			assert.Nil(metadata)
-			assert.True(errors.Is(err, test.expectedError))
+			assert.True(checkError(err, test.expectedError))
 		})
 	}
 }

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -140,11 +140,11 @@ func (f *Fetcher) UnsafeBlock(
 		BlockIdentifier:   blockIdentifier,
 	})
 	if err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err:       fmt.Errorf("%w: /block %s", ErrRequestFailed, err.Error()),
 			ClientErr: clientErr,
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	// Exit early if no need to fetch txs
@@ -191,10 +191,10 @@ func (f *Fetcher) Block(
 	}
 
 	if err := f.Asserter.Block(block); err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err: fmt.Errorf("%w: /block %s", ErrAssertionFailed, err.Error()),
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	return block, nil
@@ -227,19 +227,19 @@ func (f *Fetcher) BlockRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /block not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
 			}
-			return nil, res
+			return nil, fetcherErr
 		}
 
 		if ctx.Err() != nil {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       ctx.Err(),
 				ClientErr: err.ClientErr,
 			}
-			return nil, res
+			return nil, fetcherErr
 		}
 
 		var blockFetchErr string

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -17,7 +17,6 @@ package fetcher
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -149,13 +148,13 @@ func TestBlockRetry(t *testing.T) {
 				WithMaxRetries(test.fetcherMaxRetries),
 				WithAsserter(a),
 			)
-			block, err := f.BlockRetry(
+			block, blockErr := f.BlockRetry(
 				ctx,
 				test.network,
 				types.ConstructPartialBlockIdentifier(test.block),
 			)
 			assert.Equal(test.expectedBlock, block)
-			assert.True(errors.Is(err, test.expectedError))
+			assert.True(checkError(blockErr, test.expectedError))
 		})
 	}
 }

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -80,6 +80,13 @@ type Fetcher struct {
 	retryElapsedTime       time.Duration
 }
 
+// Error wraps the two possible types of error responses returned
+// by the Rosetta Client
+type Error struct {
+	Err       error        `json:"err"`
+	ClientErr *types.Error `json:"client_err"`
+}
+
 // New constructs a new Fetcher with provided options.
 func New(
 	serverAddress string,

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -175,7 +175,7 @@ func (f *Fetcher) InitializeAsserter(
 		networkOptions,
 	)
 	if assertErr != nil {
-		return nil, nil, err
+		return nil, nil, &Error{Err: assertErr}
 	}
 	f.Asserter = newAsserter
 

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -132,10 +132,10 @@ func (f *Fetcher) InitializeAsserter(
 ) (
 	*types.NetworkIdentifier,
 	*types.NetworkStatusResponse,
-	error,
+	*Error,
 ) {
 	if f.Asserter != nil {
-		return nil, nil, errors.New("asserter already initialized")
+		return nil, nil, &Error{Err: errors.New("asserter already initialized")}
 	}
 
 	// Attempt to fetch network list
@@ -145,7 +145,7 @@ func (f *Fetcher) InitializeAsserter(
 	}
 
 	if len(networkList.NetworkIdentifiers) == 0 {
-		return nil, nil, ErrNoNetworks
+		return nil, nil, &Error{Err: ErrNoNetworks}
 	}
 	primaryNetwork := networkList.NetworkIdentifiers[0]
 
@@ -169,14 +169,15 @@ func (f *Fetcher) InitializeAsserter(
 		return nil, nil, err
 	}
 
-	f.Asserter, err = asserter.NewClientWithResponses(
+	newAsserter, assertErr := asserter.NewClientWithResponses(
 		primaryNetwork,
 		networkStatus,
 		networkOptions,
 	)
-	if err != nil {
+	if assertErr != nil {
 		return nil, nil, err
 	}
+	f.Asserter = newAsserter
 
 	return primaryNetwork, networkStatus, nil
 }

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -36,19 +36,19 @@ func (f *Fetcher) Mempool(
 		},
 	)
 	if err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err:       fmt.Errorf("%w: /mempool %s", ErrRequestFailed, err.Error()),
 			ClientErr: clientErr,
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	mempool := response.TransactionIdentifiers
 	if err := asserter.MempoolTransactions(mempool); err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err: fmt.Errorf("%w: /mempool %s", ErrAssertionFailed, err.Error()),
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	return mempool, nil
@@ -69,19 +69,19 @@ func (f *Fetcher) MempoolTransaction(
 		},
 	)
 	if err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err:       fmt.Errorf("%w: /mempool/transaction %s", ErrRequestFailed, err.Error()),
 			ClientErr: clientErr,
 		}
-		return nil, nil, res
+		return nil, nil, fetcherErr
 	}
 
 	mempoolTransaction := response.Transaction
 	if err := f.Asserter.Transaction(mempoolTransaction); err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err: fmt.Errorf("%w: /mempool/transaction %s", ErrAssertionFailed, err.Error()),
 		}
-		return nil, nil, res
+		return nil, nil, fetcherErr
 	}
 
 	return mempoolTransaction, response.Metadata, nil

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -75,20 +75,20 @@ func (f *Fetcher) NetworkStatusRetry(
 	)
 
 	for {
-		networkStatus, errRes := f.NetworkStatus(
+		networkStatus, err := f.NetworkStatus(
 			ctx,
 			network,
 			metadata,
 		)
-		if errRes == nil {
+		if err == nil {
 			continue
 		}
 
-		if errors.Is(errRes.err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/status not attempting retry", errRes.err)
+		if errors.Is(err.err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/status not attempting retry", err.err)
 		}
 
-		if errRes.err == nil {
+		if err.err == nil {
 			return networkStatus, nil
 		}
 
@@ -99,7 +99,7 @@ func (f *Fetcher) NetworkStatusRetry(
 		if !tryAgain(
 			fmt.Sprintf("network status %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			errRes.err,
+			err.err,
 		) {
 			break
 		}
@@ -156,19 +156,19 @@ func (f *Fetcher) NetworkListRetry(
 	)
 
 	for {
-		networkList, errRes := f.NetworkList(
+		networkList, err := f.NetworkList(
 			ctx,
 			metadata,
 		)
-		if errRes == nil {
+		if err == nil {
 			continue
 		}
 
-		if errors.Is(errRes.err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/list not attempting retry", errRes.err)
+		if errors.Is(err.err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/list not attempting retry", err.err)
 		}
 
-		if errRes.err == nil {
+		if err.err == nil {
 			return networkList, nil
 		}
 
@@ -176,7 +176,7 @@ func (f *Fetcher) NetworkListRetry(
 			return nil, ctx.Err()
 		}
 
-		if !tryAgain("NetworkList", backoffRetries, errRes.err) {
+		if !tryAgain("NetworkList", backoffRetries, err.err) {
 			break
 		}
 	}
@@ -234,20 +234,20 @@ func (f *Fetcher) NetworkOptionsRetry(
 	)
 
 	for {
-		networkOptions, errRes := f.NetworkOptions(
+		networkOptions, err := f.NetworkOptions(
 			ctx,
 			network,
 			metadata,
 		)
-		if errRes == nil {
+		if err == nil {
 			continue
 		}
 
-		if errors.Is(errRes.err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/options not attempting retry", errRes.err)
+		if errors.Is(err.err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/options not attempting retry", err.err)
 		}
 
-		if errRes.err == nil {
+		if err.err == nil {
 			return networkOptions, nil
 		}
 
@@ -258,7 +258,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 		if !tryAgain(
 			fmt.Sprintf("network options %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			errRes.err,
+			err.err,
 		) {
 			break
 		}

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -62,7 +62,7 @@ func (f *Fetcher) NetworkStatusRetry(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	metadata map[string]interface{},
-) (*types.NetworkStatusResponse, error) {
+) (*types.NetworkStatusResponse, *Error) {
 	backoffRetries := backoffRetries(
 		f.retryElapsedTime,
 		f.maxRetries,
@@ -79,11 +79,19 @@ func (f *Fetcher) NetworkStatusRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/status not attempting retry", err.Err)
+			res := &Error{
+				Err:       fmt.Errorf("%w: /network/status not attempting retry", err.Err),
+				ClientErr: err.ClientErr,
+			}
+			return nil, res
 		}
 
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			res := &Error{
+				Err:       ctx.Err(),
+				ClientErr: err.ClientErr,
+			}
+			return nil, res
 		}
 
 		if !tryAgain(
@@ -95,11 +103,12 @@ func (f *Fetcher) NetworkStatusRetry(
 		}
 	}
 
-	return nil, fmt.Errorf(
-		"%w: unable to fetch network status %s",
-		ErrExhaustedRetries,
-		types.PrettyPrintStruct(network),
-	)
+	return nil, &Error{
+		Err: fmt.Errorf(
+			"%w: unable to fetch network status %s",
+			ErrExhaustedRetries,
+			types.PrettyPrintStruct(network),
+		)}
 }
 
 // NetworkList returns the validated response
@@ -138,7 +147,7 @@ func (f *Fetcher) NetworkList(
 func (f *Fetcher) NetworkListRetry(
 	ctx context.Context,
 	metadata map[string]interface{},
-) (*types.NetworkListResponse, error) {
+) (*types.NetworkListResponse, *Error) {
 	backoffRetries := backoffRetries(
 		f.retryElapsedTime,
 		f.maxRetries,
@@ -154,11 +163,19 @@ func (f *Fetcher) NetworkListRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/list not attempting retry", err.Err)
+			res := &Error{
+				Err:       fmt.Errorf("%w: /network/list not attempting retry", err.Err),
+				ClientErr: err.ClientErr,
+			}
+			return nil, res
 		}
 
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			res := &Error{
+				Err:       ctx.Err(),
+				ClientErr: err.ClientErr,
+			}
+			return nil, res
 		}
 
 		if !tryAgain("NetworkList", backoffRetries, err.Err) {
@@ -166,10 +183,11 @@ func (f *Fetcher) NetworkListRetry(
 		}
 	}
 
-	return nil, fmt.Errorf(
-		"%w: unable to fetch network list",
-		ErrExhaustedRetries,
-	)
+	return nil, &Error{
+		Err: fmt.Errorf(
+			"%w: unable to fetch network list",
+			ErrExhaustedRetries,
+		)}
 }
 
 // NetworkOptions returns the validated response
@@ -211,7 +229,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	metadata map[string]interface{},
-) (*types.NetworkOptionsResponse, error) {
+) (*types.NetworkOptionsResponse, *Error) {
 	backoffRetries := backoffRetries(
 		f.retryElapsedTime,
 		f.maxRetries,
@@ -228,11 +246,19 @@ func (f *Fetcher) NetworkOptionsRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/options not attempting retry", err.Err)
+			res := &Error{
+				Err:       fmt.Errorf("%w: /network/options not attempting retry", err.Err),
+				ClientErr: err.ClientErr,
+			}
+			return nil, res
 		}
 
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			res := &Error{
+				Err:       ctx.Err(),
+				ClientErr: err.ClientErr,
+			}
+			return nil, res
 		}
 
 		if !tryAgain(
@@ -244,9 +270,10 @@ func (f *Fetcher) NetworkOptionsRetry(
 		}
 	}
 
-	return nil, fmt.Errorf(
-		"%w: unable to fetch network options %s",
-		ErrExhaustedRetries,
-		types.PrettyPrintStruct(network),
-	)
+	return nil, &Error{
+		Err: fmt.Errorf(
+			"%w: unable to fetch network options %s",
+			ErrExhaustedRetries,
+			types.PrettyPrintStruct(network)),
+	}
 }

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -24,11 +24,6 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-type Error struct {
-	Err       error        `json:"err"`
-	ClientErr *types.Error `json:"client_err"`
-}
-
 // NetworkStatus returns the validated response
 // from the NetworkStatus method.
 func (f *Fetcher) NetworkStatus(
@@ -53,8 +48,7 @@ func (f *Fetcher) NetworkStatus(
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
 		res := &Error{
-			Err:       fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
-			ClientErr: clientErr,
+			Err: fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
 		}
 		return nil, res
 	}
@@ -131,8 +125,7 @@ func (f *Fetcher) NetworkList(
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
 		res := &Error{
-			Err:       fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
-			ClientErr: clientErr,
+			Err: fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
 		}
 		return nil, res
 	}
@@ -204,8 +197,7 @@ func (f *Fetcher) NetworkOptions(
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {
 		res := &Error{
-			Err:       fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
-			ClientErr: clientErr,
+			Err: fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
 		}
 		return nil, res
 	}

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -25,8 +25,8 @@ import (
 )
 
 type Error struct {
-	err       error
-	clientErr *types.Error
+	Err       error        `json:"err"`
+	ClientErr *types.Error `json:"client_err"`
 }
 
 // NetworkStatus returns the validated response
@@ -45,16 +45,16 @@ func (f *Fetcher) NetworkStatus(
 	)
 	if err != nil {
 		res := &Error{
-			err:       fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error()),
-			clientErr: clientErr,
+			Err:       fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error()),
+			ClientErr: clientErr,
 		}
 		return nil, res
 	}
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
 		res := &Error{
-			err:       fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
-			clientErr: clientErr,
+			Err:       fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
+			ClientErr: clientErr,
 		}
 		return nil, res
 	}
@@ -84,11 +84,11 @@ func (f *Fetcher) NetworkStatusRetry(
 			continue
 		}
 
-		if errors.Is(err.err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/status not attempting retry", err.err)
+		if errors.Is(err.Err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/status not attempting retry", err.Err)
 		}
 
-		if err.err == nil {
+		if err.Err == nil {
 			return networkStatus, nil
 		}
 
@@ -99,7 +99,7 @@ func (f *Fetcher) NetworkStatusRetry(
 		if !tryAgain(
 			fmt.Sprintf("network status %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			err.err,
+			err.Err,
 		) {
 			break
 		}
@@ -127,16 +127,16 @@ func (f *Fetcher) NetworkList(
 
 	if err != nil {
 		res := &Error{
-			err:       fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error()),
-			clientErr: clientErr,
+			Err:       fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error()),
+			ClientErr: clientErr,
 		}
 		return nil, res
 	}
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
 		res := &Error{
-			err:       fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
-			clientErr: clientErr,
+			Err:       fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
+			ClientErr: clientErr,
 		}
 		return nil, res
 	}
@@ -164,11 +164,11 @@ func (f *Fetcher) NetworkListRetry(
 			continue
 		}
 
-		if errors.Is(err.err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/list not attempting retry", err.err)
+		if errors.Is(err.Err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/list not attempting retry", err.Err)
 		}
 
-		if err.err == nil {
+		if err.Err == nil {
 			return networkList, nil
 		}
 
@@ -176,7 +176,7 @@ func (f *Fetcher) NetworkListRetry(
 			return nil, ctx.Err()
 		}
 
-		if !tryAgain("NetworkList", backoffRetries, err.err) {
+		if !tryAgain("NetworkList", backoffRetries, err.Err) {
 			break
 		}
 	}
@@ -204,16 +204,16 @@ func (f *Fetcher) NetworkOptions(
 
 	if err != nil {
 		res := &Error{
-			err:       fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error()),
-			clientErr: clientErr,
+			Err:       fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error()),
+			ClientErr: clientErr,
 		}
 		return nil, res
 	}
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {
 		res := &Error{
-			err:       fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
-			clientErr: clientErr,
+			Err:       fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
+			ClientErr: clientErr,
 		}
 		return nil, res
 	}
@@ -243,11 +243,11 @@ func (f *Fetcher) NetworkOptionsRetry(
 			continue
 		}
 
-		if errors.Is(err.err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/options not attempting retry", err.err)
+		if errors.Is(err.Err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/options not attempting retry", err.Err)
 		}
 
-		if err.err == nil {
+		if err.Err == nil {
 			return networkOptions, nil
 		}
 
@@ -258,7 +258,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 		if !tryAgain(
 			fmt.Sprintf("network options %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			err.err,
+			err.Err,
 		) {
 			break
 		}

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -24,26 +24,39 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
+type ErrorRes struct {
+	goErr		error
+	rosettaErr	*types.Error
+}
+
 // NetworkStatus returns the validated response
 // from the NetworkStatus method.
 func (f *Fetcher) NetworkStatus(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	metadata map[string]interface{},
-) (*types.NetworkStatusResponse, error) {
-	networkStatus, _, err := f.rosettaClient.NetworkAPI.NetworkStatus(
+) (*types.NetworkStatusResponse, *ErrorRes) {
+	networkStatus, rosettaErr, goErr := f.rosettaClient.NetworkAPI.NetworkStatus(
 		ctx,
 		&types.NetworkRequest{
 			NetworkIdentifier: network,
 			Metadata:          metadata,
 		},
 	)
-	if err != nil {
-		return nil, fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error())
+	if goErr != nil {
+		res := &ErrorRes{
+			goErr: fmt.Errorf("%w: /network/status %s", ErrRequestFailed, goErr.Error()),
+			rosettaErr: rosettaErr,
+		}
+		return nil, res
 	}
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
-		return nil, fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error())
+		res := &ErrorRes{
+			goErr: fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
+			rosettaErr: rosettaErr,
+		}
+		return nil, res
 	}
 
 	return networkStatus, nil
@@ -62,16 +75,20 @@ func (f *Fetcher) NetworkStatusRetry(
 	)
 
 	for {
-		networkStatus, err := f.NetworkStatus(
+		networkStatus, errRes := f.NetworkStatus(
 			ctx,
 			network,
 			metadata,
 		)
-		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/status not attempting retry", err)
+		if errRes == nil {
+			continue
 		}
 
-		if err == nil {
+		if errors.Is(errRes.goErr, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/status not attempting retry", errRes.goErr)
+		}
+
+		if errRes.goErr == nil {
 			return networkStatus, nil
 		}
 
@@ -82,7 +99,7 @@ func (f *Fetcher) NetworkStatusRetry(
 		if !tryAgain(
 			fmt.Sprintf("network status %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			err,
+			errRes.goErr,
 		) {
 			break
 		}
@@ -96,23 +113,32 @@ func (f *Fetcher) NetworkStatusRetry(
 }
 
 // NetworkList returns the validated response
-// from the NetworList method.
+// from the NetworkList method.
 func (f *Fetcher) NetworkList(
 	ctx context.Context,
 	metadata map[string]interface{},
-) (*types.NetworkListResponse, error) {
-	networkList, _, err := f.rosettaClient.NetworkAPI.NetworkList(
+) (*types.NetworkListResponse, *ErrorRes) {
+	networkList, rosettaErr, goErr := f.rosettaClient.NetworkAPI.NetworkList(
 		ctx,
 		&types.MetadataRequest{
 			Metadata: metadata,
 		},
 	)
-	if err != nil {
-		return nil, fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error())
+
+	if goErr != nil {
+		res := &ErrorRes{
+			goErr: fmt.Errorf("%w: /network/list %s", ErrRequestFailed, goErr.Error()),
+			rosettaErr: rosettaErr,
+		}
+		return nil, res
 	}
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
-		return nil, fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error())
+		res := &ErrorRes{
+			goErr: fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
+			rosettaErr: rosettaErr,
+		}
+		return nil, res
 	}
 
 	return networkList, nil
@@ -130,15 +156,19 @@ func (f *Fetcher) NetworkListRetry(
 	)
 
 	for {
-		networkList, err := f.NetworkList(
+		networkList, errRes := f.NetworkList(
 			ctx,
 			metadata,
 		)
-		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/list not attempting retry", err)
+		if errRes == nil {
+			continue
 		}
 
-		if err == nil {
+		if errors.Is(errRes.goErr, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/list not attempting retry", errRes.goErr)
+		}
+
+		if errRes.goErr == nil {
 			return networkList, nil
 		}
 
@@ -146,7 +176,7 @@ func (f *Fetcher) NetworkListRetry(
 			return nil, ctx.Err()
 		}
 
-		if !tryAgain("NetworkList", backoffRetries, err) {
+		if !tryAgain("NetworkList", backoffRetries, errRes.goErr) {
 			break
 		}
 	}
@@ -158,28 +188,37 @@ func (f *Fetcher) NetworkListRetry(
 }
 
 // NetworkOptions returns the validated response
-// from the NetworList method.
+// from the NetworkOptions method.
 func (f *Fetcher) NetworkOptions(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	metadata map[string]interface{},
-) (*types.NetworkOptionsResponse, error) {
-	NetworkOptions, _, err := f.rosettaClient.NetworkAPI.NetworkOptions(
+) (*types.NetworkOptionsResponse, *ErrorRes) {
+	networkOptions, rosettaErr, goErr := f.rosettaClient.NetworkAPI.NetworkOptions(
 		ctx,
 		&types.NetworkRequest{
 			NetworkIdentifier: network,
 			Metadata:          metadata,
 		},
 	)
-	if err != nil {
-		return nil, fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error())
+
+	if goErr != nil {
+		res := &ErrorRes{
+			goErr: fmt.Errorf("%w: /network/options %s", ErrRequestFailed, goErr.Error()),
+			rosettaErr: rosettaErr,
+		}
+		return nil, res
 	}
 
-	if err := asserter.NetworkOptionsResponse(NetworkOptions); err != nil {
-		return nil, fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error())
+	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {
+		res := &ErrorRes{
+			goErr: fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
+			rosettaErr: rosettaErr,
+		}
+		return nil, res
 	}
 
-	return NetworkOptions, nil
+	return networkOptions, nil
 }
 
 // NetworkOptionsRetry retrieves the validated NetworkOptions
@@ -195,16 +234,20 @@ func (f *Fetcher) NetworkOptionsRetry(
 	)
 
 	for {
-		networkOptions, err := f.NetworkOptions(
+		networkOptions, errRes := f.NetworkOptions(
 			ctx,
 			network,
 			metadata,
 		)
-		if errors.Is(err, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/options not attempting retry", err)
+		if errRes == nil {
+			continue
 		}
 
-		if err == nil {
+		if errors.Is(errRes.goErr, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/options not attempting retry", errRes.goErr)
+		}
+
+		if errRes.goErr == nil {
 			return networkOptions, nil
 		}
 
@@ -215,7 +258,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 		if !tryAgain(
 			fmt.Sprintf("network options %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			err,
+			errRes.goErr,
 		) {
 			break
 		}

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -25,8 +25,8 @@ import (
 )
 
 type ErrorRes struct {
-	goErr		error
-	rosettaErr	*types.Error
+	goErr      error
+	rosettaErr *types.Error
 }
 
 // NetworkStatus returns the validated response
@@ -45,7 +45,7 @@ func (f *Fetcher) NetworkStatus(
 	)
 	if goErr != nil {
 		res := &ErrorRes{
-			goErr: fmt.Errorf("%w: /network/status %s", ErrRequestFailed, goErr.Error()),
+			goErr:      fmt.Errorf("%w: /network/status %s", ErrRequestFailed, goErr.Error()),
 			rosettaErr: rosettaErr,
 		}
 		return nil, res
@@ -53,7 +53,7 @@ func (f *Fetcher) NetworkStatus(
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
 		res := &ErrorRes{
-			goErr: fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
+			goErr:      fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
 			rosettaErr: rosettaErr,
 		}
 		return nil, res
@@ -127,7 +127,7 @@ func (f *Fetcher) NetworkList(
 
 	if goErr != nil {
 		res := &ErrorRes{
-			goErr: fmt.Errorf("%w: /network/list %s", ErrRequestFailed, goErr.Error()),
+			goErr:      fmt.Errorf("%w: /network/list %s", ErrRequestFailed, goErr.Error()),
 			rosettaErr: rosettaErr,
 		}
 		return nil, res
@@ -135,7 +135,7 @@ func (f *Fetcher) NetworkList(
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
 		res := &ErrorRes{
-			goErr: fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
+			goErr:      fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
 			rosettaErr: rosettaErr,
 		}
 		return nil, res
@@ -204,7 +204,7 @@ func (f *Fetcher) NetworkOptions(
 
 	if goErr != nil {
 		res := &ErrorRes{
-			goErr: fmt.Errorf("%w: /network/options %s", ErrRequestFailed, goErr.Error()),
+			goErr:      fmt.Errorf("%w: /network/options %s", ErrRequestFailed, goErr.Error()),
 			rosettaErr: rosettaErr,
 		}
 		return nil, res
@@ -212,7 +212,7 @@ func (f *Fetcher) NetworkOptions(
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {
 		res := &ErrorRes{
-			goErr: fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
+			goErr:      fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
 			rosettaErr: rosettaErr,
 		}
 		return nil, res

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -25,7 +25,7 @@ import (
 )
 
 type Error struct {
-	err      error
+	err       error
 	clientErr *types.Error
 }
 
@@ -45,7 +45,7 @@ func (f *Fetcher) NetworkStatus(
 	)
 	if err != nil {
 		res := &Error{
-			err:      fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error()),
+			err:       fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error()),
 			clientErr: clientErr,
 		}
 		return nil, res
@@ -53,7 +53,7 @@ func (f *Fetcher) NetworkStatus(
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
 		res := &Error{
-			err:      fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
+			err:       fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
 			clientErr: clientErr,
 		}
 		return nil, res
@@ -127,7 +127,7 @@ func (f *Fetcher) NetworkList(
 
 	if err != nil {
 		res := &Error{
-			err:      fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error()),
+			err:       fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error()),
 			clientErr: clientErr,
 		}
 		return nil, res
@@ -135,7 +135,7 @@ func (f *Fetcher) NetworkList(
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
 		res := &Error{
-			err:      fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
+			err:       fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
 			clientErr: clientErr,
 		}
 		return nil, res
@@ -204,7 +204,7 @@ func (f *Fetcher) NetworkOptions(
 
 	if err != nil {
 		res := &Error{
-			err:      fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error()),
+			err:       fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error()),
 			clientErr: clientErr,
 		}
 		return nil, res
@@ -212,7 +212,7 @@ func (f *Fetcher) NetworkOptions(
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {
 		res := &Error{
-			err:      fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
+			err:       fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
 			clientErr: clientErr,
 		}
 		return nil, res

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -24,9 +24,9 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-type ErrorRes struct {
-	goErr      error
-	rosettaErr *types.Error
+type Error struct {
+	err      error
+	clientErr *types.Error
 }
 
 // NetworkStatus returns the validated response
@@ -35,26 +35,26 @@ func (f *Fetcher) NetworkStatus(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	metadata map[string]interface{},
-) (*types.NetworkStatusResponse, *ErrorRes) {
-	networkStatus, rosettaErr, goErr := f.rosettaClient.NetworkAPI.NetworkStatus(
+) (*types.NetworkStatusResponse, *Error) {
+	networkStatus, clientErr, err := f.rosettaClient.NetworkAPI.NetworkStatus(
 		ctx,
 		&types.NetworkRequest{
 			NetworkIdentifier: network,
 			Metadata:          metadata,
 		},
 	)
-	if goErr != nil {
-		res := &ErrorRes{
-			goErr:      fmt.Errorf("%w: /network/status %s", ErrRequestFailed, goErr.Error()),
-			rosettaErr: rosettaErr,
+	if err != nil {
+		res := &Error{
+			err:      fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error()),
+			clientErr: clientErr,
 		}
 		return nil, res
 	}
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
-		res := &ErrorRes{
-			goErr:      fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
-			rosettaErr: rosettaErr,
+		res := &Error{
+			err:      fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
+			clientErr: clientErr,
 		}
 		return nil, res
 	}
@@ -84,11 +84,11 @@ func (f *Fetcher) NetworkStatusRetry(
 			continue
 		}
 
-		if errors.Is(errRes.goErr, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/status not attempting retry", errRes.goErr)
+		if errors.Is(errRes.err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/status not attempting retry", errRes.err)
 		}
 
-		if errRes.goErr == nil {
+		if errRes.err == nil {
 			return networkStatus, nil
 		}
 
@@ -99,7 +99,7 @@ func (f *Fetcher) NetworkStatusRetry(
 		if !tryAgain(
 			fmt.Sprintf("network status %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			errRes.goErr,
+			errRes.err,
 		) {
 			break
 		}
@@ -117,26 +117,26 @@ func (f *Fetcher) NetworkStatusRetry(
 func (f *Fetcher) NetworkList(
 	ctx context.Context,
 	metadata map[string]interface{},
-) (*types.NetworkListResponse, *ErrorRes) {
-	networkList, rosettaErr, goErr := f.rosettaClient.NetworkAPI.NetworkList(
+) (*types.NetworkListResponse, *Error) {
+	networkList, clientErr, err := f.rosettaClient.NetworkAPI.NetworkList(
 		ctx,
 		&types.MetadataRequest{
 			Metadata: metadata,
 		},
 	)
 
-	if goErr != nil {
-		res := &ErrorRes{
-			goErr:      fmt.Errorf("%w: /network/list %s", ErrRequestFailed, goErr.Error()),
-			rosettaErr: rosettaErr,
+	if err != nil {
+		res := &Error{
+			err:      fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error()),
+			clientErr: clientErr,
 		}
 		return nil, res
 	}
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
-		res := &ErrorRes{
-			goErr:      fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
-			rosettaErr: rosettaErr,
+		res := &Error{
+			err:      fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
+			clientErr: clientErr,
 		}
 		return nil, res
 	}
@@ -164,11 +164,11 @@ func (f *Fetcher) NetworkListRetry(
 			continue
 		}
 
-		if errors.Is(errRes.goErr, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/list not attempting retry", errRes.goErr)
+		if errors.Is(errRes.err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/list not attempting retry", errRes.err)
 		}
 
-		if errRes.goErr == nil {
+		if errRes.err == nil {
 			return networkList, nil
 		}
 
@@ -176,7 +176,7 @@ func (f *Fetcher) NetworkListRetry(
 			return nil, ctx.Err()
 		}
 
-		if !tryAgain("NetworkList", backoffRetries, errRes.goErr) {
+		if !tryAgain("NetworkList", backoffRetries, errRes.err) {
 			break
 		}
 	}
@@ -193,8 +193,8 @@ func (f *Fetcher) NetworkOptions(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 	metadata map[string]interface{},
-) (*types.NetworkOptionsResponse, *ErrorRes) {
-	networkOptions, rosettaErr, goErr := f.rosettaClient.NetworkAPI.NetworkOptions(
+) (*types.NetworkOptionsResponse, *Error) {
+	networkOptions, clientErr, err := f.rosettaClient.NetworkAPI.NetworkOptions(
 		ctx,
 		&types.NetworkRequest{
 			NetworkIdentifier: network,
@@ -202,18 +202,18 @@ func (f *Fetcher) NetworkOptions(
 		},
 	)
 
-	if goErr != nil {
-		res := &ErrorRes{
-			goErr:      fmt.Errorf("%w: /network/options %s", ErrRequestFailed, goErr.Error()),
-			rosettaErr: rosettaErr,
+	if err != nil {
+		res := &Error{
+			err:      fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error()),
+			clientErr: clientErr,
 		}
 		return nil, res
 	}
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {
-		res := &ErrorRes{
-			goErr:      fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
-			rosettaErr: rosettaErr,
+		res := &Error{
+			err:      fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
+			clientErr: clientErr,
 		}
 		return nil, res
 	}
@@ -243,11 +243,11 @@ func (f *Fetcher) NetworkOptionsRetry(
 			continue
 		}
 
-		if errors.Is(errRes.goErr, ErrAssertionFailed) {
-			return nil, fmt.Errorf("%w: /network/options not attempting retry", errRes.goErr)
+		if errors.Is(errRes.err, ErrAssertionFailed) {
+			return nil, fmt.Errorf("%w: /network/options not attempting retry", errRes.err)
 		}
 
-		if errRes.goErr == nil {
+		if errRes.err == nil {
 			return networkOptions, nil
 		}
 
@@ -258,7 +258,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 		if !tryAgain(
 			fmt.Sprintf("network options %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			errRes.goErr,
+			errRes.err,
 		) {
 			break
 		}

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -39,18 +39,18 @@ func (f *Fetcher) NetworkStatus(
 		},
 	)
 	if err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err:       fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error()),
 			ClientErr: clientErr,
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err: fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	return networkStatus, nil
@@ -79,19 +79,19 @@ func (f *Fetcher) NetworkStatusRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/status not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
 			}
-			return nil, res
+			return nil, fetcherErr
 		}
 
 		if ctx.Err() != nil {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       ctx.Err(),
 				ClientErr: err.ClientErr,
 			}
-			return nil, res
+			return nil, fetcherErr
 		}
 
 		if !tryAgain(
@@ -125,18 +125,18 @@ func (f *Fetcher) NetworkList(
 	)
 
 	if err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err:       fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error()),
 			ClientErr: clientErr,
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err: fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	return networkList, nil
@@ -163,19 +163,19 @@ func (f *Fetcher) NetworkListRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/list not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
 			}
-			return nil, res
+			return nil, fetcherErr
 		}
 
 		if ctx.Err() != nil {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       ctx.Err(),
 				ClientErr: err.ClientErr,
 			}
-			return nil, res
+			return nil, fetcherErr
 		}
 
 		if !tryAgain("NetworkList", backoffRetries, err.Err) {
@@ -206,18 +206,18 @@ func (f *Fetcher) NetworkOptions(
 	)
 
 	if err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err:       fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error()),
 			ClientErr: clientErr,
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {
-		res := &Error{
+		fetcherErr := &Error{
 			Err: fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
 		}
-		return nil, res
+		return nil, fetcherErr
 	}
 
 	return networkOptions, nil
@@ -246,19 +246,19 @@ func (f *Fetcher) NetworkOptionsRetry(
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/options not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
 			}
-			return nil, res
+			return nil, fetcherErr
 		}
 
 		if ctx.Err() != nil {
-			res := &Error{
+			fetcherErr := &Error{
 				Err:       ctx.Err(),
 				ClientErr: err.ClientErr,
 			}
-			return nil, res
+			return nil, fetcherErr
 		}
 
 		if !tryAgain(

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -81,15 +81,11 @@ func (f *Fetcher) NetworkStatusRetry(
 			metadata,
 		)
 		if err == nil {
-			continue
+			return networkStatus, nil
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
 			return nil, fmt.Errorf("%w: /network/status not attempting retry", err.Err)
-		}
-
-		if err.Err == nil {
-			return networkStatus, nil
 		}
 
 		if ctx.Err() != nil {
@@ -161,15 +157,11 @@ func (f *Fetcher) NetworkListRetry(
 			metadata,
 		)
 		if err == nil {
-			continue
+			return networkList, nil
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
 			return nil, fmt.Errorf("%w: /network/list not attempting retry", err.Err)
-		}
-
-		if err.Err == nil {
-			return networkList, nil
 		}
 
 		if ctx.Err() != nil {
@@ -240,15 +232,11 @@ func (f *Fetcher) NetworkOptionsRetry(
 			metadata,
 		)
 		if err == nil {
-			continue
+			return networkOptions, nil
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
 			return nil, fmt.Errorf("%w: /network/options not attempting retry", err.Err)
-		}
-
-		if err.Err == nil {
-			return networkOptions, nil
 		}
 
 		if ctx.Err() != nil {

--- a/fetcher/network_test.go
+++ b/fetcher/network_test.go
@@ -17,7 +17,6 @@ package fetcher
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -148,7 +147,7 @@ func TestNetworkStatusRetry(t *testing.T) {
 				nil,
 			)
 			assert.Equal(test.expectedStatus, status)
-			assert.True(errors.Is(err, test.expectedError))
+			assert.True(checkError(err, test.expectedError))
 		})
 	}
 }
@@ -236,7 +235,7 @@ func TestNetworkListRetry(t *testing.T) {
 				nil,
 			)
 			assert.Equal(test.expectedList, list)
-			assert.True(errors.Is(err, test.expectedError))
+			assert.True(checkError(err, test.expectedError))
 		})
 	}
 }
@@ -327,7 +326,7 @@ func TestNetworkOptionsRetry(t *testing.T) {
 				nil,
 			)
 			assert.Equal(test.expectedOptions, options)
-			assert.True(errors.Is(err, test.expectedError))
+			assert.True(checkError(err, test.expectedError))
 		})
 	}
 }

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -57,6 +57,5 @@ func checkError(fetcherErr *Error, err error) bool {
 	if fetcherErr == nil {
 		return err == nil
 	}
-
 	return errors.Is(fetcherErr.Err, err)
 }

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -15,6 +15,7 @@
 package fetcher
 
 import (
+	"errors"
 	"log"
 	"strings"
 	"time"
@@ -48,4 +49,14 @@ func tryAgain(fetchMsg string, thisBackoff backoff.BackOff, err error) bool {
 	time.Sleep(nextBackoff)
 
 	return true
+}
+
+// checkError compares a *fetcher.Error to a simple type error and returns
+// a boolean indicating if they are equivalent
+func checkError(fetcherErr *Error, err error) bool {
+	if fetcherErr == nil {
+		return err == nil
+	}
+
+	return errors.Is(fetcherErr.Err, err)
 }


### PR DESCRIPTION
Fixes # .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In order to allow consumers of the fetcher to parse errors upstream, we need to expose the Rosetta types.Errors being returned from our API calls.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Defined an ErrorRes struct that wraps both the Go error and Rosetta error being returned from API calls, and returning that from the fetcher instead.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
