### PR TITLE
[BUG] Err Handling in statefulsyncer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ lint-examples:
 	golangci-lint run -v -E ${LINT_SETTINGS}
 
 lint: | lint-examples
-	golangci-lint run -v -E ${LINT_SETTINGS},gomnd; \
-	make check-comments;
+	golangci-lint run -v -E ${LINT_SETTINGS},gomnd;
 
 format:
 	gofmt -s -w -l .

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -99,7 +99,7 @@ func (f *Fetcher) AccountBalanceRetry(
 		}
 
 		if err := tryAgain(
-			fmt.Sprintf("account %s", types.PrettyPrintStruct(account)),
+			fmt.Sprintf("account %s", types.PrintStruct(account)),
 			backoffRetries,
 			err,
 		); err != nil {

--- a/fetcher/account_test.go
+++ b/fetcher/account_test.go
@@ -103,7 +103,7 @@ func TestAccountBalanceRetry(t *testing.T) {
 			network:             basicNetwork,
 			account:             basicAccount,
 			errorsBeforeSuccess: 6,
-			expectedError:       context.Canceled,
+			expectedError:       ErrRequestFailed,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 		},

--- a/fetcher/account_test.go
+++ b/fetcher/account_test.go
@@ -63,7 +63,7 @@ func TestAccountBalanceRetry(t *testing.T) {
 		expectedBlock       *types.BlockIdentifier
 		expectedAmounts     []*types.Amount
 		expectedError       error
-		unretriableError    bool
+		retriableError      bool
 
 		fetcherMaxRetries uint64
 		shouldCancel      bool
@@ -82,11 +82,11 @@ func TestAccountBalanceRetry(t *testing.T) {
 			expectedBlock:       basicBlock,
 			expectedAmounts:     basicAmounts,
 			fetcherMaxRetries:   5,
+			retriableError:      true,
 		},
-		"unretriable error": {
+		"non-retriable error": {
 			network:             basicNetwork,
 			account:             basicAccount,
-			unretriableError:    true,
 			errorsBeforeSuccess: 2,
 			fetcherMaxRetries:   5,
 			expectedError:       ErrRequestFailed,
@@ -97,6 +97,7 @@ func TestAccountBalanceRetry(t *testing.T) {
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrExhaustedRetries,
 			fetcherMaxRetries:   1,
+			retriableError:      true,
 		},
 		"cancel context": {
 			network:             basicNetwork,
@@ -136,7 +137,7 @@ func TestAccountBalanceRetry(t *testing.T) {
 					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 					w.WriteHeader(http.StatusInternalServerError)
 					fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
-						Retriable: !test.unretriableError,
+						Retriable: test.retriableError,
 					}))
 					tries++
 					return

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -67,7 +67,14 @@ func (f *Fetcher) fetchChannelTransactions(
 
 		if err != nil {
 			return &Error{
-				Err:       fmt.Errorf("%w: /block/transaction %s", ErrRequestFailed, err.Error()),
+				Err: fmt.Errorf(
+					"%w: /block/transaction %s at block %d:%s %s",
+					ErrRequestFailed,
+					transactionIdentifier.Hash,
+					block.Index,
+					block.Hash,
+					err.Error(),
+				),
 				ClientErr: clientErr,
 			}
 		}
@@ -165,7 +172,12 @@ func (f *Fetcher) UnsafeBlock(
 	})
 	if err != nil {
 		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /block %s", ErrRequestFailed, err.Error()),
+			Err: fmt.Errorf(
+				"%w: /block %s %s",
+				ErrRequestFailed,
+				types.PrintStruct(blockIdentifier),
+				err.Error(),
+			),
 			ClientErr: clientErr,
 		}
 		return nil, fetcherErr

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -112,6 +112,8 @@ func (f *Fetcher) UnsafeTransactions(
 		g.Go(func() error {
 			err := f.fetchChannelTransactions(ctx, network, block, txsToFetch, fetchedTxs)
 			if err != nil {
+				// Only record the first error returned
+				// by fetchChannelTransactions.
 				if fetchErr == nil {
 					fetchErr = err
 				}
@@ -134,6 +136,9 @@ func (f *Fetcher) UnsafeTransactions(
 	}
 
 	if err := g.Wait(); err != nil {
+		// If there exists a fetchErr, that
+		// should be returned over whatever error
+		// is returned to the errGroup.
 		if fetchErr != nil {
 			return nil, fetchErr
 		}

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -250,13 +250,7 @@ func (f *Fetcher) BlockRetry(
 			return nil, fetcherErr
 		}
 
-		var blockFetchErr string
-		if blockIdentifier.Index != nil {
-			blockFetchErr = fmt.Sprintf("block %d", *blockIdentifier.Index)
-		} else {
-			blockFetchErr = fmt.Sprintf("block %s", *blockIdentifier.Hash)
-		}
-
+		blockFetchErr := fmt.Sprintf("block %s", types.PrintStruct(blockIdentifier))
 		if err := tryAgain(blockFetchErr, backoffRetries, err); err != nil {
 			return nil, err
 		}

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -145,7 +145,7 @@ func TestBlockRetry(t *testing.T) {
 			blockIdentifier:     basicBlock,
 			errorsBeforeSuccess: 6,
 			retriableError:      true,
-			expectedError:       context.Canceled,
+			expectedError:       ErrRequestFailed,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 		},

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -38,58 +38,108 @@ var (
 		},
 		Timestamp: 1582833600000,
 	}
+
+	basicTransaction = &types.Transaction{
+		TransactionIdentifier: &types.TransactionIdentifier{
+			Hash: "tx 1",
+		},
+	}
+
+	otherTransactions = []*types.TransactionIdentifier{
+		basicTransaction.TransactionIdentifier,
+	}
+
+	basicBlockWithTransactions = &types.Block{
+		BlockIdentifier: basicBlock,
+		ParentBlockIdentifier: &types.BlockIdentifier{
+			Index: 9,
+			Hash:  "block 9",
+		},
+		Timestamp: 1582833600000,
+		Transactions: []*types.Transaction{
+			basicTransaction,
+		},
+	}
 )
 
 func TestBlockRetry(t *testing.T) {
 	var tests = map[string]struct {
-		network *types.NetworkIdentifier
-		block   *types.BlockIdentifier
+		network                   *types.NetworkIdentifier
+		blockIdentifier           *types.BlockIdentifier
+		containsOtherTransactions bool
+		transaction               *types.Transaction
+		blockResponse             *types.Block
 
-		errorsBeforeSuccess int
-		expectedBlock       *types.Block
-		expectedError       error
-		unretriableError    bool
+		errorsBeforeSuccess            int
+		transactionErrorsBeforeSuccess int
+		expectedBlock                  *types.Block
+		expectedError                  error
+		unretriableError               bool
+		unretriableErrorTransaction    bool
 
 		fetcherMaxRetries uint64
 		shouldCancel      bool
 	}{
 		"omitted block": {
 			network:           basicNetwork,
-			block:             basicBlock,
+			blockIdentifier:   basicBlock,
 			expectedBlock:     nil,
 			fetcherMaxRetries: 0,
 		},
 		"no failures": {
 			network:           basicNetwork,
-			block:             basicBlock,
+			blockIdentifier:   basicBlock,
+			blockResponse:     basicFullBlock,
 			expectedBlock:     basicFullBlock,
 			fetcherMaxRetries: 5,
 		},
+		"retry failures with other transactions": {
+			network:                        basicNetwork,
+			blockIdentifier:                basicBlock,
+			blockResponse:                  basicFullBlock,
+			transaction:                    basicTransaction,
+			containsOtherTransactions:      true,
+			transactionErrorsBeforeSuccess: 2,
+			expectedBlock:                  basicBlockWithTransactions,
+			fetcherMaxRetries:              5,
+		},
 		"retry failures": {
 			network:             basicNetwork,
-			block:               basicBlock,
+			blockIdentifier:     basicBlock,
+			blockResponse:       basicFullBlock,
 			errorsBeforeSuccess: 2,
 			expectedBlock:       basicFullBlock,
 			fetcherMaxRetries:   5,
 		},
 		"unretriable error": {
 			network:             basicNetwork,
-			block:               basicBlock,
+			blockIdentifier:     basicBlock,
 			errorsBeforeSuccess: 2,
 			unretriableError:    true,
 			fetcherMaxRetries:   5,
 			expectedError:       ErrRequestFailed,
 		},
+		"unretriable error with transactions": {
+			network:                        basicNetwork,
+			blockIdentifier:                basicBlock,
+			blockResponse:                  basicFullBlock,
+			transaction:                    basicTransaction,
+			containsOtherTransactions:      true,
+			transactionErrorsBeforeSuccess: 2,
+			unretriableErrorTransaction:    true,
+			expectedError:                  ErrRequestFailed,
+			fetcherMaxRetries:              5,
+		},
 		"exhausted retries": {
 			network:             basicNetwork,
-			block:               basicBlock,
+			blockIdentifier:     basicBlock,
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrExhaustedRetries,
 			fetcherMaxRetries:   1,
 		},
 		"cancel context": {
 			network:             basicNetwork,
-			block:               basicBlock,
+			blockIdentifier:     basicBlock,
 			errorsBeforeSuccess: 6,
 			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
@@ -100,44 +150,76 @@ func TestBlockRetry(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			var (
-				tries       = 0
-				assert      = assert.New(t)
-				ctx, cancel = context.WithCancel(context.Background())
-				endpoint    = "/block"
+				tries            = 0
+				transactionTries = 0
+				assert           = assert.New(t)
+				ctx, cancel      = context.WithCancel(context.Background())
 			)
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal("POST", r.Method)
-				assert.Equal(endpoint, r.URL.RequestURI())
+				if r.URL.RequestURI() == "/block" {
+					expected := &types.BlockRequest{
+						NetworkIdentifier: test.network,
+						BlockIdentifier:   types.ConstructPartialBlockIdentifier(test.blockIdentifier),
+					}
+					var blockRequest *types.BlockRequest
+					assert.NoError(json.NewDecoder(r.Body).Decode(&blockRequest))
+					assert.Equal(expected, blockRequest)
 
-				expected := &types.BlockRequest{
-					NetworkIdentifier: test.network,
-					BlockIdentifier:   types.ConstructPartialBlockIdentifier(test.block),
+					if test.shouldCancel {
+						cancel()
+					}
+
+					if tries < test.errorsBeforeSuccess {
+						w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+						w.WriteHeader(http.StatusInternalServerError)
+						fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
+							Retriable: !test.unretriableError,
+						}))
+						tries++
+						return
+					}
+
+					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+					w.WriteHeader(http.StatusOK)
+					resp := &types.BlockResponse{
+						Block: test.blockResponse,
+					}
+					if test.containsOtherTransactions {
+						resp.OtherTransactions = otherTransactions
+					}
+
+					fmt.Fprintln(w, types.PrettyPrintStruct(resp))
+					return
 				}
-				var blockRequest *types.BlockRequest
-				assert.NoError(json.NewDecoder(r.Body).Decode(&blockRequest))
-				assert.Equal(expected, blockRequest)
 
-				if test.shouldCancel {
-					cancel()
+				assert.Equal("/block/transaction", r.URL.RequestURI())
+
+				expected := &types.BlockTransactionRequest{
+					NetworkIdentifier:     test.network,
+					BlockIdentifier:       test.blockIdentifier,
+					TransactionIdentifier: test.transaction.TransactionIdentifier,
 				}
 
-				if tries < test.errorsBeforeSuccess {
+				var blockTransactionRequest types.BlockTransactionRequest
+				assert.NoError(json.NewDecoder(r.Body).Decode(&blockTransactionRequest))
+				assert.Equal(expected, &blockTransactionRequest)
+
+				if transactionTries < test.transactionErrorsBeforeSuccess {
 					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 					w.WriteHeader(http.StatusInternalServerError)
 					fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
-						Retriable: !test.unretriableError,
+						Retriable: !test.unretriableErrorTransaction,
 					}))
-					tries++
+					transactionTries++
 					return
 				}
 
 				w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprintln(w, types.PrettyPrintStruct(
-					&types.BlockResponse{
-						Block: test.expectedBlock,
-					},
-				))
+				fmt.Fprintln(w, types.PrettyPrintStruct(&types.BlockTransactionResponse{
+					Transaction: test.transaction,
+				}))
 			}))
 
 			defer ts.Close()
@@ -162,7 +244,7 @@ func TestBlockRetry(t *testing.T) {
 			block, blockErr := f.BlockRetry(
 				ctx,
 				test.network,
-				types.ConstructPartialBlockIdentifier(test.block),
+				types.ConstructPartialBlockIdentifier(test.blockIdentifier),
 			)
 			assert.Equal(test.expectedBlock, block)
 			assert.True(checkError(blockErr, test.expectedError))

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -160,7 +160,9 @@ func TestBlockRetry(t *testing.T) {
 				if r.URL.RequestURI() == "/block" {
 					expected := &types.BlockRequest{
 						NetworkIdentifier: test.network,
-						BlockIdentifier:   types.ConstructPartialBlockIdentifier(test.blockIdentifier),
+						BlockIdentifier: types.ConstructPartialBlockIdentifier(
+							test.blockIdentifier,
+						),
 					}
 					var blockRequest *types.BlockRequest
 					assert.NoError(json.NewDecoder(r.Body).Decode(&blockRequest))

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -87,7 +87,7 @@ func (f *Fetcher) NetworkStatusRetry(
 		}
 
 		if err := tryAgain(
-			fmt.Sprintf("network status %s", types.PrettyPrintStruct(network)),
+			fmt.Sprintf("network status %s", types.PrintStruct(network)),
 			backoffRetries,
 			err,
 		); err != nil {
@@ -233,7 +233,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 		}
 
 		if err := tryAgain(
-			fmt.Sprintf("network options %s", types.PrettyPrintStruct(network)),
+			fmt.Sprintf("network options %s", types.PrintStruct(network)),
 			backoffRetries,
 			err,
 		); err != nil {

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -68,7 +68,7 @@ func (f *Fetcher) NetworkStatusRetry(
 		f.maxRetries,
 	)
 
-	for {
+	for ctx.Err() == nil {
 		networkStatus, err := f.NetworkStatus(
 			ctx,
 			network,
@@ -86,29 +86,18 @@ func (f *Fetcher) NetworkStatusRetry(
 			return nil, fetcherErr
 		}
 
-		if ctx.Err() != nil {
-			fetcherErr := &Error{
-				Err:       ctx.Err(),
-				ClientErr: err.ClientErr,
-			}
-			return nil, fetcherErr
-		}
-
-		if !tryAgain(
+		if err := tryAgain(
 			fmt.Sprintf("network status %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			err.Err,
-		) {
-			break
+			err,
+		); err != nil {
+			return nil, err
 		}
 	}
 
 	return nil, &Error{
-		Err: fmt.Errorf(
-			"%w: unable to fetch network status %s",
-			ErrExhaustedRetries,
-			types.PrettyPrintStruct(network),
-		)}
+		Err: ctx.Err(),
+	}
 }
 
 // NetworkList returns the validated response
@@ -153,7 +142,7 @@ func (f *Fetcher) NetworkListRetry(
 		f.maxRetries,
 	)
 
-	for {
+	for ctx.Err() == nil {
 		networkList, err := f.NetworkList(
 			ctx,
 			metadata,
@@ -170,24 +159,14 @@ func (f *Fetcher) NetworkListRetry(
 			return nil, fetcherErr
 		}
 
-		if ctx.Err() != nil {
-			fetcherErr := &Error{
-				Err:       ctx.Err(),
-				ClientErr: err.ClientErr,
-			}
-			return nil, fetcherErr
-		}
-
-		if !tryAgain("NetworkList", backoffRetries, err.Err) {
-			break
+		if err := tryAgain("NetworkList", backoffRetries, err); err != nil {
+			return nil, err
 		}
 	}
 
 	return nil, &Error{
-		Err: fmt.Errorf(
-			"%w: unable to fetch network list",
-			ErrExhaustedRetries,
-		)}
+		Err: ctx.Err(),
+	}
 }
 
 // NetworkOptions returns the validated response
@@ -235,7 +214,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 		f.maxRetries,
 	)
 
-	for {
+	for ctx.Err() == nil {
 		networkOptions, err := f.NetworkOptions(
 			ctx,
 			network,
@@ -253,27 +232,16 @@ func (f *Fetcher) NetworkOptionsRetry(
 			return nil, fetcherErr
 		}
 
-		if ctx.Err() != nil {
-			fetcherErr := &Error{
-				Err:       ctx.Err(),
-				ClientErr: err.ClientErr,
-			}
-			return nil, fetcherErr
-		}
-
-		if !tryAgain(
+		if err := tryAgain(
 			fmt.Sprintf("network options %s", types.PrettyPrintStruct(network)),
 			backoffRetries,
-			err.Err,
-		) {
-			break
+			err,
+		); err != nil {
+			return nil, err
 		}
 	}
 
 	return nil, &Error{
-		Err: fmt.Errorf(
-			"%w: unable to fetch network options %s",
-			ErrExhaustedRetries,
-			types.PrettyPrintStruct(network)),
+		Err: ctx.Err(),
 	}
 }

--- a/fetcher/network_test.go
+++ b/fetcher/network_test.go
@@ -68,6 +68,7 @@ func TestNetworkStatusRetry(t *testing.T) {
 		errorsBeforeSuccess int
 		expectedStatus      *types.NetworkStatusResponse
 		expectedError       error
+		unretriableError    bool
 
 		fetcherMaxRetries uint64
 		shouldCancel      bool
@@ -81,6 +82,13 @@ func TestNetworkStatusRetry(t *testing.T) {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 2,
 			expectedStatus:      basicNetworkStatus,
+			fetcherMaxRetries:   5,
+		},
+		"unretriable failure": {
+			network:             basicNetwork,
+			errorsBeforeSuccess: 2,
+			unretriableError:    true,
+			expectedError:       ErrRequestFailed,
 			fetcherMaxRetries:   5,
 		},
 		"exhausted retries": {
@@ -124,7 +132,9 @@ func TestNetworkStatusRetry(t *testing.T) {
 				if tries < test.errorsBeforeSuccess {
 					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 					w.WriteHeader(http.StatusInternalServerError)
-					fmt.Fprintln(w, "{}")
+					fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
+						Retriable: !test.unretriableError,
+					}))
 					tries++
 					return
 				}
@@ -159,6 +169,7 @@ func TestNetworkListRetry(t *testing.T) {
 		errorsBeforeSuccess int
 		expectedList        *types.NetworkListResponse
 		expectedError       error
+		unretriableError    bool
 
 		fetcherMaxRetries uint64
 		shouldCancel      bool
@@ -179,6 +190,13 @@ func TestNetworkListRetry(t *testing.T) {
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrExhaustedRetries,
 			fetcherMaxRetries:   1,
+		},
+		"unretriable error": {
+			network:             basicNetwork,
+			errorsBeforeSuccess: 2,
+			expectedError:       ErrRequestFailed,
+			unretriableError:    true,
+			fetcherMaxRetries:   5,
 		},
 		"cancel context": {
 			network:             basicNetwork,
@@ -213,7 +231,9 @@ func TestNetworkListRetry(t *testing.T) {
 				if tries < test.errorsBeforeSuccess {
 					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 					w.WriteHeader(http.StatusInternalServerError)
-					fmt.Fprintln(w, "{}")
+					fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
+						Retriable: !test.unretriableError,
+					}))
 					tries++
 					return
 				}
@@ -247,6 +267,7 @@ func TestNetworkOptionsRetry(t *testing.T) {
 		errorsBeforeSuccess int
 		expectedOptions     *types.NetworkOptionsResponse
 		expectedError       error
+		unretriableError    bool
 
 		fetcherMaxRetries uint64
 		shouldCancel      bool
@@ -267,6 +288,13 @@ func TestNetworkOptionsRetry(t *testing.T) {
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrExhaustedRetries,
 			fetcherMaxRetries:   1,
+		},
+		"unretriable error": {
+			network:             basicNetwork,
+			errorsBeforeSuccess: 2,
+			expectedError:       ErrRequestFailed,
+			unretriableError:    true,
+			fetcherMaxRetries:   5,
 		},
 		"cancel context": {
 			network:             basicNetwork,
@@ -303,7 +331,9 @@ func TestNetworkOptionsRetry(t *testing.T) {
 				if tries < test.errorsBeforeSuccess {
 					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 					w.WriteHeader(http.StatusInternalServerError)
-					fmt.Fprintln(w, "{}")
+					fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
+						Retriable: !test.unretriableError,
+					}))
 					tries++
 					return
 				}

--- a/fetcher/network_test.go
+++ b/fetcher/network_test.go
@@ -68,7 +68,7 @@ func TestNetworkStatusRetry(t *testing.T) {
 		errorsBeforeSuccess int
 		expectedStatus      *types.NetworkStatusResponse
 		expectedError       error
-		unretriableError    bool
+		retriableError      bool
 
 		fetcherMaxRetries uint64
 		shouldCancel      bool
@@ -83,11 +83,11 @@ func TestNetworkStatusRetry(t *testing.T) {
 			errorsBeforeSuccess: 2,
 			expectedStatus:      basicNetworkStatus,
 			fetcherMaxRetries:   5,
+			retriableError:      true,
 		},
-		"unretriable failure": {
+		"non-retriable failure": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 2,
-			unretriableError:    true,
 			expectedError:       ErrRequestFailed,
 			fetcherMaxRetries:   5,
 		},
@@ -96,6 +96,7 @@ func TestNetworkStatusRetry(t *testing.T) {
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrExhaustedRetries,
 			fetcherMaxRetries:   1,
+			retriableError:      true,
 		},
 		"cancel context": {
 			network:             basicNetwork,
@@ -103,6 +104,7 @@ func TestNetworkStatusRetry(t *testing.T) {
 			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
+			retriableError:      true,
 		},
 	}
 
@@ -133,7 +135,7 @@ func TestNetworkStatusRetry(t *testing.T) {
 					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 					w.WriteHeader(http.StatusInternalServerError)
 					fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
-						Retriable: !test.unretriableError,
+						Retriable: test.retriableError,
 					}))
 					tries++
 					return
@@ -169,7 +171,7 @@ func TestNetworkListRetry(t *testing.T) {
 		errorsBeforeSuccess int
 		expectedList        *types.NetworkListResponse
 		expectedError       error
-		unretriableError    bool
+		retriableError      bool
 
 		fetcherMaxRetries uint64
 		shouldCancel      bool
@@ -184,18 +186,19 @@ func TestNetworkListRetry(t *testing.T) {
 			errorsBeforeSuccess: 2,
 			expectedList:        basicNetworkList,
 			fetcherMaxRetries:   5,
+			retriableError:      true,
 		},
 		"exhausted retries": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrExhaustedRetries,
 			fetcherMaxRetries:   1,
+			retriableError:      true,
 		},
 		"unretriable error": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrRequestFailed,
-			unretriableError:    true,
 			fetcherMaxRetries:   5,
 		},
 		"cancel context": {
@@ -204,6 +207,7 @@ func TestNetworkListRetry(t *testing.T) {
 			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
+			retriableError:      true,
 		},
 	}
 
@@ -232,7 +236,7 @@ func TestNetworkListRetry(t *testing.T) {
 					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 					w.WriteHeader(http.StatusInternalServerError)
 					fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
-						Retriable: !test.unretriableError,
+						Retriable: test.retriableError,
 					}))
 					tries++
 					return
@@ -267,7 +271,7 @@ func TestNetworkOptionsRetry(t *testing.T) {
 		errorsBeforeSuccess int
 		expectedOptions     *types.NetworkOptionsResponse
 		expectedError       error
-		unretriableError    bool
+		retriableError      bool
 
 		fetcherMaxRetries uint64
 		shouldCancel      bool
@@ -282,18 +286,19 @@ func TestNetworkOptionsRetry(t *testing.T) {
 			errorsBeforeSuccess: 2,
 			expectedOptions:     basicNetworkOptions,
 			fetcherMaxRetries:   5,
+			retriableError:      true,
 		},
 		"exhausted retries": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrExhaustedRetries,
 			fetcherMaxRetries:   1,
+			retriableError:      true,
 		},
-		"unretriable error": {
+		"non-retriable error": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrRequestFailed,
-			unretriableError:    true,
 			fetcherMaxRetries:   5,
 		},
 		"cancel context": {
@@ -302,6 +307,7 @@ func TestNetworkOptionsRetry(t *testing.T) {
 			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
+			retriableError:      true,
 		},
 	}
 
@@ -332,7 +338,7 @@ func TestNetworkOptionsRetry(t *testing.T) {
 					w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 					w.WriteHeader(http.StatusInternalServerError)
 					fmt.Fprintln(w, types.PrettyPrintStruct(&types.Error{
-						Retriable: !test.unretriableError,
+						Retriable: test.retriableError,
 					}))
 					tries++
 					return

--- a/fetcher/network_test.go
+++ b/fetcher/network_test.go
@@ -101,7 +101,7 @@ func TestNetworkStatusRetry(t *testing.T) {
 		"cancel context": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 6,
-			expectedError:       context.Canceled,
+			expectedError:       ErrRequestFailed,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 			retriableError:      true,
@@ -204,7 +204,7 @@ func TestNetworkListRetry(t *testing.T) {
 		"cancel context": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 6,
-			expectedError:       context.Canceled,
+			expectedError:       ErrRequestFailed,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 			retriableError:      true,
@@ -304,7 +304,7 @@ func TestNetworkOptionsRetry(t *testing.T) {
 		"cancel context": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 6,
-			expectedError:       context.Canceled,
+			expectedError:       ErrRequestFailed,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 			retriableError:      true,

--- a/fetcher/network_test.go
+++ b/fetcher/network_test.go
@@ -195,7 +195,7 @@ func TestNetworkListRetry(t *testing.T) {
 			fetcherMaxRetries:   1,
 			retriableError:      true,
 		},
-		"unretriable error": {
+		"non-retriable error": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 2,
 			expectedError:       ErrRequestFailed,

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -54,7 +54,12 @@ func tryAgain(fetchMsg string, thisBackoff backoff.BackOff, err *Error) *Error {
 		}
 	}
 
-	log.Printf("%s: retrying fetch for %s after %fs\n", types.PrintStruct(err.ClientErr), fetchMsg, nextBackoff.Seconds())
+	errMessage := err.Err.Error()
+	if err.ClientErr != nil {
+		errMessage = types.PrintStruct(err.ClientErr)
+	}
+
+	log.Printf("%s: retrying fetch for %s after %fs\n", errMessage, fetchMsg, nextBackoff.Seconds())
 	time.Sleep(nextBackoff)
 
 	return nil

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -39,7 +39,8 @@ func backoffRetries(
 // tryAgain handles a backoff and prints error messages depending
 // on the fetchMsg.
 func tryAgain(fetchMsg string, thisBackoff backoff.BackOff, err *Error) *Error {
-	if err.ClientErr != nil && !err.ClientErr.Retriable {
+	// Only retry if an error is explicitly retriable.
+	if err.ClientErr == nil || !err.ClientErr.Retriable {
 		return err
 	}
 

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -20,6 +20,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/coinbase/rosetta-sdk-go/types"
+
 	"github.com/cenkalti/backoff"
 )
 
@@ -52,7 +54,7 @@ func tryAgain(fetchMsg string, thisBackoff backoff.BackOff, err *Error) *Error {
 		}
 	}
 
-	log.Printf("retrying fetch for %s after %fs\n", fetchMsg, nextBackoff.Seconds())
+	log.Printf("%s: retrying fetch for %s after %fs\n", types.PrintStruct(err.ClientErr), fetchMsg, nextBackoff.Seconds())
 	time.Sleep(nextBackoff)
 
 	return nil

--- a/statefulsyncer/stateful_syncer.go
+++ b/statefulsyncer/stateful_syncer.go
@@ -174,7 +174,11 @@ func (s *StatefulSyncer) NetworkStatus(
 	network *types.NetworkIdentifier,
 ) (*types.NetworkStatusResponse, error) {
 	networkStatus, fetchErr := s.fetcher.NetworkStatusRetry(ctx, network, nil)
-	return networkStatus, fetchErr.Err
+	if fetchErr != nil {
+		return nil, fetchErr.Err
+	}
+
+	return networkStatus, nil
 }
 
 // Block is called by the syncer to fetch a block.
@@ -184,5 +188,8 @@ func (s *StatefulSyncer) Block(
 	block *types.PartialBlockIdentifier,
 ) (*types.Block, error) {
 	blockResponse, fetchErr := s.fetcher.BlockRetry(ctx, network, block)
-	return blockResponse, fetchErr.Err
+	if fetchErr != nil {
+		return nil, fetchErr.Err
+	}
+	return blockResponse, nil
 }


### PR DESCRIPTION
Related PR: #99 

This PR fixes a bug in statefulsyncer when `fetchErr` is nil.

### Changes
- [x] Fix `nil` assertion in `statefulsyncer` package
- [x] `fetcher` only retry if `retriable`
- [x] only retry if the error received is explicitly retriable