### PR TITLE
[BUG] Ensure canceling context returns the correct error

### DIFF
--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -79,7 +79,7 @@ func (f *Fetcher) AccountBalanceRetry(
 		f.maxRetries,
 	)
 
-	for ctx.Err() == nil {
+	for {
 		responseBlock, balances, coins, metadata, err := f.AccountBalance(
 			ctx,
 			network,
@@ -88,6 +88,12 @@ func (f *Fetcher) AccountBalanceRetry(
 		)
 		if err == nil {
 			return responseBlock, balances, coins, metadata, nil
+		}
+
+		if ctx.Err() != nil {
+			return nil, nil, nil, nil, &Error{
+				Err: ctx.Err(),
+			}
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
@@ -105,9 +111,5 @@ func (f *Fetcher) AccountBalanceRetry(
 		); err != nil {
 			return nil, nil, nil, nil, err
 		}
-	}
-
-	return nil, nil, nil, nil, &Error{
-		Err: ctx.Err(),
 	}
 }

--- a/fetcher/account_test.go
+++ b/fetcher/account_test.go
@@ -103,7 +103,7 @@ func TestAccountBalanceRetry(t *testing.T) {
 			network:             basicNetwork,
 			account:             basicAccount,
 			errorsBeforeSuccess: 6,
-			expectedError:       ErrRequestFailed,
+			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 		},

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -250,7 +250,7 @@ func (f *Fetcher) BlockRetry(
 		f.maxRetries,
 	)
 
-	for ctx.Err() == nil {
+	for {
 		block, err := f.Block(
 			ctx,
 			network,
@@ -258,6 +258,10 @@ func (f *Fetcher) BlockRetry(
 		)
 		if err == nil {
 			return block, nil
+		}
+
+		if ctx.Err() != nil {
+			return nil, &Error{Err: ctx.Err()}
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
@@ -273,6 +277,4 @@ func (f *Fetcher) BlockRetry(
 			return nil, err
 		}
 	}
-
-	return nil, &Error{Err: ctx.Err()}
 }

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -145,7 +145,7 @@ func TestBlockRetry(t *testing.T) {
 			blockIdentifier:     basicBlock,
 			errorsBeforeSuccess: 6,
 			retriableError:      true,
-			expectedError:       ErrRequestFailed,
+			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 		},

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -68,7 +68,7 @@ func (f *Fetcher) NetworkStatusRetry(
 		f.maxRetries,
 	)
 
-	for ctx.Err() == nil {
+	for {
 		networkStatus, err := f.NetworkStatus(
 			ctx,
 			network,
@@ -76,6 +76,12 @@ func (f *Fetcher) NetworkStatusRetry(
 		)
 		if err == nil {
 			return networkStatus, nil
+		}
+
+		if ctx.Err() != nil {
+			return nil, &Error{
+				Err: ctx.Err(),
+			}
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
@@ -93,10 +99,6 @@ func (f *Fetcher) NetworkStatusRetry(
 		); err != nil {
 			return nil, err
 		}
-	}
-
-	return nil, &Error{
-		Err: ctx.Err(),
 	}
 }
 
@@ -142,13 +144,19 @@ func (f *Fetcher) NetworkListRetry(
 		f.maxRetries,
 	)
 
-	for ctx.Err() == nil {
+	for {
 		networkList, err := f.NetworkList(
 			ctx,
 			metadata,
 		)
 		if err == nil {
 			return networkList, nil
+		}
+
+		if ctx.Err() != nil {
+			return nil, &Error{
+				Err: ctx.Err(),
+			}
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
@@ -162,10 +170,6 @@ func (f *Fetcher) NetworkListRetry(
 		if err := tryAgain("NetworkList", backoffRetries, err); err != nil {
 			return nil, err
 		}
-	}
-
-	return nil, &Error{
-		Err: ctx.Err(),
 	}
 }
 
@@ -214,7 +218,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 		f.maxRetries,
 	)
 
-	for ctx.Err() == nil {
+	for {
 		networkOptions, err := f.NetworkOptions(
 			ctx,
 			network,
@@ -222,6 +226,12 @@ func (f *Fetcher) NetworkOptionsRetry(
 		)
 		if err == nil {
 			return networkOptions, nil
+		}
+
+		if ctx.Err() != nil {
+			return nil, &Error{
+				Err: ctx.Err(),
+			}
 		}
 
 		if errors.Is(err.Err, ErrAssertionFailed) {
@@ -239,9 +249,5 @@ func (f *Fetcher) NetworkOptionsRetry(
 		); err != nil {
 			return nil, err
 		}
-	}
-
-	return nil, &Error{
-		Err: ctx.Err(),
 	}
 }

--- a/fetcher/network_test.go
+++ b/fetcher/network_test.go
@@ -101,7 +101,7 @@ func TestNetworkStatusRetry(t *testing.T) {
 		"cancel context": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 6,
-			expectedError:       ErrRequestFailed,
+			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 			retriableError:      true,
@@ -204,7 +204,7 @@ func TestNetworkListRetry(t *testing.T) {
 		"cancel context": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 6,
-			expectedError:       ErrRequestFailed,
+			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 			retriableError:      true,
@@ -304,7 +304,7 @@ func TestNetworkOptionsRetry(t *testing.T) {
 		"cancel context": {
 			network:             basicNetwork,
 			errorsBeforeSuccess: 6,
-			expectedError:       ErrRequestFailed,
+			expectedError:       context.Canceled,
 			fetcherMaxRetries:   5,
 			shouldCancel:        true,
 			retriableError:      true,


### PR DESCRIPTION
Related PR: #105 

In #105, we introduced a small bug where canceling context doesn't always return a context.Canceled error. This created a flaky test that caused master tests to fail:
https://app.circleci.com/pipelines/github/coinbase/rosetta-sdk-go/586/workflows/1c59e0e3-c228-4718-b784-0d862d32648d/jobs/4204

This PR fixes this issue!