### PR TITLE
[BUG][Storage] Incorrect handling of coins created and spent in same block

### DIFF
--- a/constructor/executor/job_test.go
+++ b/constructor/executor/job_test.go
@@ -123,7 +123,7 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 	assert.NoError(t, err)
 	defer utils.RemoveTempDir(dir)
 
-	db, err := storage.NewBadgerStorage(ctx, dir, false)
+	db, err := storage.NewBadgerStorage(ctx, dir)
 	assert.NoError(t, err)
 	assert.NotNil(t, db)
 	defer db.Close(ctx)
@@ -431,7 +431,7 @@ func TestJob_Failures(t *testing.T) {
 			assert.NoError(t, err)
 			defer utils.RemoveTempDir(dir)
 
-			db, err := storage.NewBadgerStorage(ctx, dir, false)
+			db, err := storage.NewBadgerStorage(ctx, dir)
 			assert.NoError(t, err)
 			assert.NotNil(t, db)
 			defer db.Close(ctx)

--- a/constructor/executor/worker_test.go
+++ b/constructor/executor/worker_test.go
@@ -141,7 +141,7 @@ func TestFindBalanceWorker(t *testing.T) {
 	assert.NoError(t, err)
 	defer utils.RemoveTempDir(dir)
 
-	db, err := storage.NewBadgerStorage(ctx, dir, false)
+	db, err := storage.NewBadgerStorage(ctx, dir)
 	assert.NoError(t, err)
 	assert.NotNil(t, db)
 	defer db.Close(ctx)

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -238,6 +238,16 @@ func (c *CoinStorage) skipOperation(
 	return false, nil
 }
 
+// updateCoins iterates through the transactions
+// in a block to determine which coins to add
+// and remove from storage.
+//
+// If a coin is created and spent in the same block,
+// it is skipped (i.e. never added/removed from storage).
+//
+// Alternatively, we could add all coins to the database
+// (regardless of whether they are spent in the same block),
+// however, this would put a larger strain on the db.
 func (c *CoinStorage) updateCoins(
 	ctx context.Context,
 	block *types.Block,

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"math/big"
 	"strings"
 
@@ -165,6 +166,8 @@ func (c *CoinStorage) addCoin(
 		return fmt.Errorf("%w: unable to store account coin", err)
 	}
 
+	log.Printf("storing coin %s\n", coin.CoinIdentifier)
+
 	return nil
 }
 
@@ -245,6 +248,8 @@ func (c *CoinStorage) tryRemovingCoin(
 	if err := transaction.Delete(ctx, getCoinAccountCoin(operation.Account, coinIdentifier)); err != nil {
 		return fmt.Errorf("%w: unable to delete coin", err)
 	}
+
+	log.Printf("removing coin %s\n", coinIdentifier)
 
 	return nil
 }

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -238,6 +238,7 @@ func (c *CoinStorage) tryRemovingCoin(
 	}
 
 	if !exists { // this could occur if coin was created before we started syncing
+		fmt.Printf("%s does not exist\n", coinIdentifier)
 		return nil
 	}
 
@@ -260,6 +261,8 @@ func (c *CoinStorage) AddingBlock(
 	block *types.Block,
 	transaction DatabaseTransaction,
 ) (CommitWorker, error) {
+	// TODO: don't do anything for coins added and removed
+	// in same block. This can cause issues on re-org.
 	for _, txn := range block.Transactions {
 		for _, operation := range txn.Operations {
 			if operation.CoinChange == nil {
@@ -298,6 +301,8 @@ func (c *CoinStorage) RemovingBlock(
 	block *types.Block,
 	transaction DatabaseTransaction,
 ) (CommitWorker, error) {
+	// TODO: don't do anything for coins added and removed
+	// in same block. This can cause issues on re-org.
 	for _, txn := range block.Transactions {
 		for _, operation := range txn.Operations {
 			if operation.CoinChange == nil {

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -16,9 +16,7 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"log"
 	"math/big"
 	"strings"
 
@@ -166,33 +164,7 @@ func (c *CoinStorage) addCoin(
 		return fmt.Errorf("%w: unable to store account coin", err)
 	}
 
-	log.Printf("storing coin %s\n", coin.CoinIdentifier)
-
 	return nil
-}
-
-func (c *CoinStorage) tryAddingCoin(
-	ctx context.Context,
-	transaction DatabaseTransaction,
-	operation *types.Operation,
-	action types.CoinAction,
-) error {
-	if operation.CoinChange == nil {
-		return errors.New("coin change cannot be nil")
-	}
-
-	if operation.CoinChange.CoinAction != action {
-		return nil
-	}
-
-	coinIdentifier := operation.CoinChange.CoinIdentifier
-
-	newCoin := &types.Coin{
-		CoinIdentifier: coinIdentifier,
-		Amount:         operation.Amount,
-	}
-
-	return c.addCoin(ctx, operation.Account, newCoin, transaction)
 }
 
 func getAndDecodeCoins(
@@ -215,22 +187,12 @@ func getAndDecodeCoins(
 	return coins, nil
 }
 
-func (c *CoinStorage) tryRemovingCoin(
+func (c *CoinStorage) removeCoin(
 	ctx context.Context,
+	account *types.AccountIdentifier,
+	coinIdentifier *types.CoinIdentifier,
 	transaction DatabaseTransaction,
-	operation *types.Operation,
-	action types.CoinAction,
 ) error {
-	if operation.CoinChange == nil {
-		return errors.New("coin change cannot be nil")
-	}
-
-	if operation.CoinChange.CoinAction != action {
-		return nil
-	}
-
-	coinIdentifier := operation.CoinChange.CoinIdentifier
-
 	_, key := getCoinKey(coinIdentifier)
 	exists, _, err := transaction.Get(ctx, key)
 	if err != nil {
@@ -246,11 +208,81 @@ func (c *CoinStorage) tryRemovingCoin(
 		return fmt.Errorf("%w: unable to delete coin", err)
 	}
 
-	if err := transaction.Delete(ctx, getCoinAccountCoin(operation.Account, coinIdentifier)); err != nil {
+	if err := transaction.Delete(ctx, getCoinAccountCoin(account, coinIdentifier)); err != nil {
 		return fmt.Errorf("%w: unable to delete coin", err)
 	}
 
-	log.Printf("removing coin %s\n", coinIdentifier)
+	return nil
+}
+
+func (c *CoinStorage) updateCoins(
+	ctx context.Context,
+	block *types.Block,
+	addCoinCreated bool,
+	dbTx DatabaseTransaction,
+) error {
+	addCoins := map[string]*types.Operation{}
+	removeCoins := map[string]*types.Operation{}
+
+	for _, txn := range block.Transactions {
+		for _, operation := range txn.Operations {
+			if operation.CoinChange == nil {
+				continue
+			}
+
+			if operation.Amount == nil {
+				continue
+			}
+
+			success, err := c.asserter.OperationSuccessful(operation)
+			if err != nil {
+				return fmt.Errorf("%w: unable to parse operation success", err)
+			}
+
+			if !success {
+				continue
+			}
+
+			coinChange := operation.CoinChange
+			addAction := types.CoinCreated
+			identifier := coinChange.CoinIdentifier.Identifier
+			if !addCoinCreated {
+				addAction = types.CoinSpent
+			}
+
+			if coinChange.CoinAction == addAction {
+				addCoins[identifier] = operation
+				continue
+			}
+
+			removeCoins[identifier] = operation
+		}
+	}
+
+	for identifier, op := range addCoins {
+		if _, ok := removeCoins[identifier]; ok {
+			continue
+		}
+
+		if err := c.addCoin(ctx, op.Account, &types.Coin{
+			CoinIdentifier: op.CoinChange.CoinIdentifier,
+			Amount:         op.Amount,
+		},
+			dbTx,
+		); err != nil {
+			return fmt.Errorf("%w: unable to add coin", err)
+		}
+	}
+
+	for identifier, op := range removeCoins {
+		if _, ok := addCoins[identifier]; ok {
+			continue
+		}
+
+		if err := c.removeCoin(ctx, op.Account, op.CoinChange.CoinIdentifier, dbTx); err != nil {
+			return fmt.Errorf("%w: unable to remove coin", err)
+		}
+	}
 
 	return nil
 }
@@ -261,38 +293,7 @@ func (c *CoinStorage) AddingBlock(
 	block *types.Block,
 	transaction DatabaseTransaction,
 ) (CommitWorker, error) {
-	// TODO: don't do anything for coins added and removed
-	// in same block. This can cause issues on re-org.
-	for _, txn := range block.Transactions {
-		for _, operation := range txn.Operations {
-			if operation.CoinChange == nil {
-				continue
-			}
-
-			if operation.Amount == nil {
-				continue
-			}
-
-			success, err := c.asserter.OperationSuccessful(operation)
-			if err != nil {
-				return nil, fmt.Errorf("%w: unable to parse operation success", err)
-			}
-
-			if !success {
-				continue
-			}
-
-			if err := c.tryAddingCoin(ctx, transaction, operation, types.CoinCreated); err != nil {
-				return nil, fmt.Errorf("%w: unable to add coin", err)
-			}
-
-			if err := c.tryRemovingCoin(ctx, transaction, operation, types.CoinSpent); err != nil {
-				return nil, fmt.Errorf("%w: unable to remove coin", err)
-			}
-		}
-	}
-
-	return nil, nil
+	return nil, c.updateCoins(ctx, block, true, transaction)
 }
 
 // RemovingBlock is called by BlockStorage when removing a block.
@@ -301,40 +302,7 @@ func (c *CoinStorage) RemovingBlock(
 	block *types.Block,
 	transaction DatabaseTransaction,
 ) (CommitWorker, error) {
-	// TODO: don't do anything for coins added and removed
-	// in same block. This can cause issues on re-org.
-	for _, txn := range block.Transactions {
-		for _, operation := range txn.Operations {
-			if operation.CoinChange == nil {
-				continue
-			}
-
-			if operation.Amount == nil {
-				continue
-			}
-
-			success, err := c.asserter.OperationSuccessful(operation)
-			if err != nil {
-				return nil, fmt.Errorf("%w: unable to parse operation success", err)
-			}
-
-			if !success {
-				continue
-			}
-
-			// We add spent coins and remove created coins during a re-org (opposite of
-			// AddingBlock).
-			if err := c.tryAddingCoin(ctx, transaction, operation, types.CoinSpent); err != nil {
-				return nil, fmt.Errorf("%w: unable to add coin", err)
-			}
-
-			if err := c.tryRemovingCoin(ctx, transaction, operation, types.CoinCreated); err != nil {
-				return nil, fmt.Errorf("%w: unable to remove coin", err)
-			}
-		}
-	}
-
-	return nil, nil
+	return nil, c.updateCoins(ctx, block, false, transaction)
 }
 
 // GetCoins returns all unspent coins for a provided *types.AccountIdentifier.

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -549,6 +549,13 @@ func TestCoinStorage(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, tx.Commit(ctx))
 
+		// Error Class: coins created and spent in the same block
+		// during that are orphaned and then added again.
+		//
+		// When adding block here, coin6 will have been created
+		// on the re-org and could be processed before the corresponding
+		// spend on the next tx is processed. This can give
+		// the impression that a duplicate key exists.
 		tx = c.db.NewDatabaseTransaction(ctx, true)
 		commitFunc, err = c.AddingBlock(ctx, coinBlock3, tx)
 		assert.Nil(t, commitFunc)

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -262,6 +262,42 @@ var (
 					},
 				},
 			},
+			{
+				Operations: []*types.Operation{
+					{
+						Account: account3,
+						Status:  successStatus,
+						Amount: &types.Amount{
+							Value:    "12",
+							Currency: currency,
+						},
+						CoinChange: &types.CoinChange{
+							CoinAction: types.CoinCreated,
+							CoinIdentifier: &types.CoinIdentifier{
+								Identifier: "coin6",
+							},
+						},
+					},
+				},
+			},
+			{
+				Operations: []*types.Operation{
+					{
+						Account: account3,
+						Status:  successStatus,
+						Amount: &types.Amount{
+							Value:    "12",
+							Currency: currency,
+						},
+						CoinChange: &types.CoinChange{
+							CoinAction: types.CoinSpent,
+							CoinIdentifier: &types.CoinIdentifier{
+								Identifier: "coin6",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -270,14 +306,14 @@ var (
 			Address: "acc1",
 		},
 		Coins: []*types.Coin{
-			&types.Coin{
+			{
 				CoinIdentifier: &types.CoinIdentifier{Identifier: "accCoin1"},
 				Amount: &types.Amount{
 					Value:    "30",
 					Currency: currency,
 				},
 			},
-			&types.Coin{
+			{
 				CoinIdentifier: &types.CoinIdentifier{Identifier: "accCoin2"},
 				Amount: &types.Amount{
 					Value:    "40",
@@ -292,14 +328,14 @@ var (
 			Address: "acc2",
 		},
 		Coins: []*types.Coin{
-			&types.Coin{
+			{
 				CoinIdentifier: &types.CoinIdentifier{Identifier: "accCoin3"},
 				Amount: &types.Amount{
 					Value:    "10",
 					Currency: currency,
 				},
 			},
-			&types.Coin{
+			{
 				CoinIdentifier: &types.CoinIdentifier{Identifier: "accCoin4"},
 				Amount: &types.Amount{
 					Value:    "20",

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -542,6 +542,42 @@ func TestCoinStorage(t *testing.T) {
 		assert.Equal(t, blockIdentifier, block)
 	})
 
+	t.Run("remove and add complex block", func(t *testing.T) {
+		tx := c.db.NewDatabaseTransaction(ctx, true)
+		commitFunc, err := c.RemovingBlock(ctx, coinBlock3, tx)
+		assert.Nil(t, commitFunc)
+		assert.NoError(t, err)
+		assert.NoError(t, tx.Commit(ctx))
+
+		tx = c.db.NewDatabaseTransaction(ctx, true)
+		commitFunc, err = c.AddingBlock(ctx, coinBlock3, tx)
+		assert.Nil(t, commitFunc)
+		assert.NoError(t, err)
+		assert.NoError(t, tx.Commit(ctx))
+
+		coins, block, err := c.GetCoins(ctx, account)
+		assert.NoError(t, err)
+		assert.Equal(t, []*types.Coin{}, coins)
+		assert.Equal(t, blockIdentifier, block)
+
+		coins, block, err = c.GetCoins(ctx, account3)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, account3Coins, coins)
+		assert.Equal(t, blockIdentifier, block)
+
+		bal, coinIdentifier, block, err := c.GetLargestCoin(ctx, account3, currency)
+		assert.NoError(t, err)
+		assert.Equal(t, big.NewInt(4), bal)
+		assert.Equal(t, &types.CoinIdentifier{Identifier: "coin3"}, coinIdentifier)
+		assert.Equal(t, blockIdentifier, block)
+
+		bal, coinIdentifier, block, err = c.GetLargestCoin(ctx, account3, currency2)
+		assert.NoError(t, err)
+		assert.Equal(t, big.NewInt(6), bal)
+		assert.Equal(t, &types.CoinIdentifier{Identifier: "coin4"}, coinIdentifier)
+		assert.Equal(t, blockIdentifier, block)
+	})
+
 	t.Run("AddCoins after block", func(t *testing.T) {
 		accountCoins := []*AccountCoin{
 			{

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -542,20 +542,13 @@ func TestCoinStorage(t *testing.T) {
 		assert.Equal(t, blockIdentifier, block)
 	})
 
-	t.Run("remove and add complex block", func(t *testing.T) {
+	t.Run("remove block that creates and spends single coin", func(t *testing.T) {
 		tx := c.db.NewDatabaseTransaction(ctx, true)
 		commitFunc, err := c.RemovingBlock(ctx, coinBlock3, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
 		assert.NoError(t, tx.Commit(ctx))
 
-		// Error Class: coins created and spent in the same block
-		// during that are orphaned and then added again.
-		//
-		// When adding block here, coin6 will have been created
-		// on the re-org and could be processed before the corresponding
-		// spend on the next tx is processed. This can give
-		// the impression that a duplicate key exists.
 		tx = c.db.NewDatabaseTransaction(ctx, true)
 		commitFunc, err = c.AddingBlock(ctx, coinBlock3, tx)
 		assert.Nil(t, commitFunc)


### PR DESCRIPTION
When adding/removing a block to/from storage, we iterate over transactions in the order they are represented. If a coin is created and destroyed in the same block and transactions are ordered where the "add coin" op is after the "remove coin" op, we will not remove the newly created coin (coin removal is a no-op if the coin cannot be found).

### Fix
There are 2 ways to fix this bug:
* skip coins that are added/removed in the same block
* process coin additions before removals

I opted for the first fix because it reduces the amount of DB activity when adding blocks without restricting functionality (partially applied coin state is never queried).

### Changes
- [x] Add test to replicate error
- [x] Skip coins created and spent in same block
- [x] add more comments