### PR TITLE
[BUG] CoinStorage Same Block Duplicate

### DIFF
--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -269,17 +269,17 @@ func (c *CoinStorage) updateCoins(
 
 			coinChange := operation.CoinChange
 			identifier := coinChange.CoinIdentifier.Identifier
-			addAction := types.CoinCreated
-			if !addCoinCreated {
-				addAction = types.CoinSpent
+			coinDict := removeCoins
+			if addCoinCreated && coinChange.CoinAction == types.CoinCreated ||
+				!addCoinCreated && coinChange.CoinAction == types.CoinSpent {
+				coinDict = addCoins
 			}
 
-			if coinChange.CoinAction == addAction {
-				addCoins[identifier] = operation
-				continue
+			if _, ok := coinDict[identifier]; ok {
+				return fmt.Errorf("duplicate coin found %s", identifier)
 			}
 
-			removeCoins[identifier] = operation
+			coinDict[identifier] = operation
 		}
 	}
 

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -301,6 +301,43 @@ var (
 		},
 	}
 
+	coinBlockRepeat = &types.Block{
+		Transactions: []*types.Transaction{
+			{
+				Operations: []*types.Operation{
+					{
+						Account: account,
+						Status:  successStatus,
+						Amount: &types.Amount{
+							Value:    "10",
+							Currency: currency,
+						},
+						CoinChange: &types.CoinChange{
+							CoinAction: types.CoinCreated,
+							CoinIdentifier: &types.CoinIdentifier{
+								Identifier: "coin_repeat",
+							},
+						},
+					},
+					{
+						Account: account,
+						Status:  successStatus,
+						Amount: &types.Amount{
+							Value:    "20",
+							Currency: currency,
+						},
+						CoinChange: &types.CoinChange{
+							CoinAction: types.CoinCreated,
+							CoinIdentifier: &types.CoinIdentifier{
+								Identifier: "coin_repeat",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	accBalance1 = &utils.AccountBalance{
 		Account: &types.AccountIdentifier{
 			Address: "acc1",
@@ -455,6 +492,19 @@ func TestCoinStorage(t *testing.T) {
 	t.Run("add duplicate coin", func(t *testing.T) {
 		tx := c.db.NewDatabaseTransaction(ctx, true)
 		commitFunc, err := c.AddingBlock(ctx, coinBlock, tx)
+		assert.Nil(t, commitFunc)
+		assert.Error(t, err)
+		tx.Discard(ctx)
+
+		coins, block, err := c.GetCoins(ctx, account)
+		assert.NoError(t, err)
+		assert.Equal(t, accountCoins, coins)
+		assert.Equal(t, blockIdentifier, block)
+	})
+
+	t.Run("add duplicate coin in same block", func(t *testing.T) {
+		tx := c.db.NewDatabaseTransaction(ctx, true)
+		commitFunc, err := c.AddingBlock(ctx, coinBlockRepeat, tx)
 		assert.Nil(t, commitFunc)
 		assert.Error(t, err)
 		tx.Discard(ctx)


### PR DESCRIPTION
Related PR: #122 

This PR ensures that an error is thrown if a coin appears twice in the same block.

### Changes
- [x] add test to replicate issue
- [x] throw error if coin appears twice in same block
- [x] fix nit in `constructor/coordinator` tests