### PR TITLE
[Fetcher] Initialize with non-primary network

### DIFF
--- a/examples/fetcher/main.go
+++ b/examples/fetcher/main.go
@@ -40,7 +40,7 @@ func main() {
 	// Behind the scenes this makes a call to get the
 	// network status and uses the response to inform
 	// the asserter what are valid responses.
-	primaryNetwork, networkStatus, err := newFetcher.InitializeAsserter(ctx)
+	primaryNetwork, networkStatus, err := newFetcher.InitializeAsserter(ctx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -1,0 +1,196 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	otherNetwork = &types.NetworkIdentifier{
+		Blockchain: "other",
+		Network:    "other",
+	}
+
+	otherNetworkStatus = &types.NetworkStatusResponse{
+		CurrentBlockIdentifier: basicBlock,
+		CurrentBlockTimestamp:  1582834600000,
+		GenesisBlockIdentifier: &types.BlockIdentifier{
+			Index: 10,
+			Hash:  "block 10",
+		},
+	}
+
+	complexNetworkList = &types.NetworkListResponse{
+		NetworkIdentifiers: []*types.NetworkIdentifier{
+			basicNetwork,
+			otherNetwork,
+		},
+	}
+
+	otherNetworkOptions = &types.NetworkOptionsResponse{
+		Version: &types.Version{
+			RosettaVersion: "1.4.0",
+			NodeVersion:    "0.0.1",
+		},
+		Allow: &types.Allow{
+			OperationStatuses: []*types.OperationStatus{
+				{
+					Status:     "OTHER",
+					Successful: true,
+				},
+			},
+			OperationTypes: []string{"input"},
+		},
+	}
+)
+
+func TestInitializeAsserter(t *testing.T) {
+	var tests = map[string]struct {
+		network        *types.NetworkIdentifier
+		networkRequest *types.NetworkRequest // used for both /network/options and /network/status
+		networkList    *types.NetworkListResponse
+		networkStatus  *types.NetworkStatusResponse
+		networkOptions *types.NetworkOptionsResponse
+
+		expectedNetwork *types.NetworkIdentifier
+		expectedStatus  *types.NetworkStatusResponse
+		expectedError   error
+	}{
+		"default network": {
+			networkRequest: &types.NetworkRequest{
+				NetworkIdentifier: basicNetwork,
+			},
+			networkList:     basicNetworkList,
+			networkStatus:   basicNetworkStatus,
+			networkOptions:  basicNetworkOptions,
+			expectedNetwork: basicNetwork,
+			expectedStatus:  basicNetworkStatus,
+		},
+		"specify network": {
+			network: basicNetwork,
+			networkRequest: &types.NetworkRequest{
+				NetworkIdentifier: basicNetwork,
+			},
+			networkList:     basicNetworkList,
+			networkStatus:   basicNetworkStatus,
+			networkOptions:  basicNetworkOptions,
+			expectedNetwork: basicNetwork,
+			expectedStatus:  basicNetworkStatus,
+		},
+		"other network": {
+			network: otherNetwork,
+			networkRequest: &types.NetworkRequest{
+				NetworkIdentifier: otherNetwork,
+			},
+			networkList:     complexNetworkList,
+			networkStatus:   otherNetworkStatus,
+			networkOptions:  otherNetworkOptions,
+			expectedNetwork: otherNetwork,
+			expectedStatus:  otherNetworkStatus,
+		},
+		"no networks": {
+			network: otherNetwork,
+			networkRequest: &types.NetworkRequest{
+				NetworkIdentifier: otherNetwork,
+			},
+			networkList:   &types.NetworkListResponse{},
+			expectedError: ErrNoNetworks,
+		},
+		"missing network": {
+			network: otherNetwork,
+			networkRequest: &types.NetworkRequest{
+				NetworkIdentifier: otherNetwork,
+			},
+			networkList:    basicNetworkList,
+			networkOptions: basicNetworkOptions,
+			expectedError:  ErrNetworkMissing,
+		},
+		"invalid options": {
+			networkRequest: &types.NetworkRequest{
+				NetworkIdentifier: basicNetwork,
+			},
+			networkList:   basicNetworkList,
+			networkStatus: basicNetworkStatus,
+			networkOptions: &types.NetworkOptionsResponse{
+				Allow: &types.Allow{
+					OperationStatuses: []*types.OperationStatus{
+						{
+							Status:     "OTHER",
+							Successful: false,
+						},
+						{
+							Status:     "OTHER",
+							Successful: true,
+						},
+					},
+				},
+			},
+			expectedError: ErrAssertionFailed,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var (
+				assert = assert.New(t)
+				ctx    = context.Background()
+			)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal("POST", r.Method)
+
+				w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+				w.WriteHeader(http.StatusOK)
+
+				switch r.URL.RequestURI() {
+				case "/network/list":
+					fmt.Fprintln(w, types.PrettyPrintStruct(test.networkList))
+				case "/network/status":
+					var networkRequest *types.NetworkRequest
+					assert.NoError(json.NewDecoder(r.Body).Decode(&networkRequest))
+					assert.Equal(test.networkRequest, networkRequest)
+					fmt.Fprintln(w, types.PrettyPrintStruct(test.networkStatus))
+				case "/network/options":
+					var networkRequest *types.NetworkRequest
+					assert.NoError(json.NewDecoder(r.Body).Decode(&networkRequest))
+					assert.Equal(test.networkRequest, networkRequest)
+					fmt.Fprintln(w, types.PrettyPrintStruct(test.networkOptions))
+				}
+			}))
+
+			defer ts.Close()
+
+			f := New(
+				ts.URL,
+				WithRetryElapsedTime(5*time.Second),
+			)
+
+			networkIdentifier, networkStatus, err := f.InitializeAsserter(ctx, test.network)
+			assert.Equal(test.expectedNetwork, networkIdentifier)
+			assert.Equal(test.expectedStatus, networkStatus)
+			assert.True(checkError(err, test.expectedError))
+		})
+	}
+}

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -74,3 +74,24 @@ func checkError(fetcherErr *Error, err error) bool {
 	}
 	return errors.Is(fetcherErr.Err, err)
 }
+
+// CheckNetworkListForNetwork returns a boolean
+// indicating if a *types.NetworkIdentifier is present
+// in the list of supported networks.
+func CheckNetworkListForNetwork(
+	networkList *types.NetworkListResponse,
+	networkIdentifier *types.NetworkIdentifier,
+) (bool, []*types.NetworkIdentifier) {
+	networkMatched := false
+	supportedNetworks := []*types.NetworkIdentifier{}
+	for _, availableNetwork := range networkList.NetworkIdentifiers {
+		if types.Hash(availableNetwork) == types.Hash(networkIdentifier) {
+			networkMatched = true
+			break
+		}
+
+		supportedNetworks = append(supportedNetworks, availableNetwork)
+	}
+
+	return networkMatched, supportedNetworks
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -196,7 +196,10 @@ func CheckNetworkSupported(
 		return nil, fmt.Errorf("%w: unable to fetch network list", fetchErr.Err)
 	}
 
-	networkMatched, supportedNetworks := fetcher.CheckNetworkListForNetwork(networks, networkIdentifier)
+	networkMatched, supportedNetworks := fetcher.CheckNetworkListForNetwork(
+		networks,
+		networkIdentifier,
+	)
 	if !networkMatched {
 		color.Yellow("Supported networks: %s", types.PrettyPrintStruct(supportedNetworks))
 		return nil, fmt.Errorf(

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -189,24 +189,14 @@ type FetcherHelper interface {
 func CheckNetworkSupported(
 	ctx context.Context,
 	networkIdentifier *types.NetworkIdentifier,
-	fetcher FetcherHelper,
+	helper FetcherHelper,
 ) (*types.NetworkStatusResponse, error) {
-	networks, fetchErr := fetcher.NetworkList(ctx, nil)
+	networks, fetchErr := helper.NetworkList(ctx, nil)
 	if fetchErr != nil {
 		return nil, fmt.Errorf("%w: unable to fetch network list", fetchErr.Err)
 	}
 
-	networkMatched := false
-	supportedNetworks := []*types.NetworkIdentifier{}
-	for _, availableNetwork := range networks.NetworkIdentifiers {
-		if types.Hash(availableNetwork) == types.Hash(networkIdentifier) {
-			networkMatched = true
-			break
-		}
-
-		supportedNetworks = append(supportedNetworks, availableNetwork)
-	}
-
+	networkMatched, supportedNetworks := fetcher.CheckNetworkListForNetwork(networks, networkIdentifier)
 	if !networkMatched {
 		color.Yellow("Supported networks: %s", types.PrettyPrintStruct(supportedNetworks))
 		return nil, fmt.Errorf(
@@ -216,7 +206,7 @@ func CheckNetworkSupported(
 		)
 	}
 
-	status, fetchErr := fetcher.NetworkStatusRetry(
+	status, fetchErr := helper.NetworkStatusRetry(
 		ctx,
 		networkIdentifier,
 		nil,


### PR DESCRIPTION
Fixes #96

This PR makes it possible to initialize the `fetcher` with some non-default network. This is useful for Rosetta implementations that support multiple networks.

### Changes
- [x] allow for initializing asserter with a provided network
- [x] add test for fetcher initialization