### PR TITLE
[BUG] Increase Max Table Size for Performance Option

### DIFF
--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -44,6 +44,11 @@ const (
 	// DefaultValueLogFileSize is 100 MB.
 	DefaultValueLogFileSize = 100 << 20
 
+	// PerformanceMaxTableSize is 256 MB. The larger
+	// this value is, the larger database transactions
+	// storage can handle.
+	PerformanceMaxTableSize = 256 << 20
+
 	bytesInMb = 1000000
 
 	logModulo = 5000
@@ -116,6 +121,7 @@ func lowMemoryOptions(dir string) badger.Options {
 func performanceOptions(dir string) badger.Options {
 	opts := badger.DefaultOptions(dir)
 	opts.Logger = nil
+	opts.MaxTableSize = PerformanceMaxTableSize
 
 	return opts
 }


### PR DESCRIPTION
Fixes #125.

### Changes
- [x] Increase MaxTableSize to 256 MB when performance setting is enabled (default is 64 MB).
