### PR TITLE
Upgrade to v1.4.3 spec

### DIFF
--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -20,6 +20,24 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
+// ConstructionPreprocessResponse returns an error if
+// the request public keys are not valid AccountIdentifiers.
+func ConstructionPreprocessResponse(
+	response *types.ConstructionPreprocessResponse,
+) error {
+	if response == nil {
+		return ErrConstructionPreprocessResponseIsNil
+	}
+
+	for _, accountIdentifier := range response.RequiredPublicKeys {
+		if err := AccountIdentifier(accountIdentifier); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ConstructionMetadataResponse returns an error if
 // the metadata is not a JSON object.
 func ConstructionMetadataResponse(
@@ -187,7 +205,7 @@ func CurveType(
 	curve types.CurveType,
 ) error {
 	switch curve {
-	case types.Secp256k1, types.Edwards25519:
+	case types.Secp256k1, types.Secp256r1, types.Edwards25519, types.Tweedle:
 		return nil
 	default:
 		return fmt.Errorf("%w: %s", ErrCurveTypeNotSupported, curve)
@@ -268,7 +286,7 @@ func SignatureType(
 	signature types.SignatureType,
 ) error {
 	switch signature {
-	case types.Ecdsa, types.EcdsaRecovery, types.Ed25519:
+	case types.Ecdsa, types.EcdsaRecovery, types.Ed25519, types.Schnorr1, types.SchnorrPoseidon:
 		return nil
 	default:
 		return fmt.Errorf("%w: %s", ErrSignatureTypeNotSupported, signature)

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -24,6 +24,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestConstructionPreprocessResponse(t *testing.T) {
+	var tests = map[string]struct {
+		response *types.ConstructionPreprocessResponse
+		err      error
+	}{
+		"valid response": {
+			response: &types.ConstructionPreprocessResponse{
+				Options: map[string]interface{}{},
+			},
+			err: nil,
+		},
+		"valid response with accounts": {
+			response: &types.ConstructionPreprocessResponse{
+				Options: map[string]interface{}{},
+				RequiredPublicKeys: []*types.AccountIdentifier{
+					{
+						Address: "hello",
+					},
+				},
+			},
+			err: nil,
+		},
+		"invalid response with accounts": {
+			response: &types.ConstructionPreprocessResponse{
+				Options: map[string]interface{}{},
+				RequiredPublicKeys: []*types.AccountIdentifier{
+					{
+						Address: "",
+					},
+				},
+			},
+			err: ErrAccountAddrMissing,
+		},
+		"nil response": {
+			err: ErrConstructionPreprocessResponseIsNil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ConstructionPreprocessResponse(test.response)
+			if test.err != nil {
+				assert.Contains(t, err.Error(), test.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestConstructionMetadataResponse(t *testing.T) {
 	var tests = map[string]struct {
 		response *types.ConstructionMetadataResponse

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -146,6 +146,9 @@ var (
 	/* CONSTRUCTION ERRORS */
 	/////////////////////////
 
+	ErrConstructionPreprocessResponseIsNil = errors.New(
+		"ConstructionPreprocessResponse cannot be nil",
+	)
 	ErrConstructionMetadataResponseIsNil = errors.New(
 		"ConstructionMetadataResponse cannot be nil",
 	)
@@ -199,6 +202,7 @@ var (
 	ErrSignatureTypeNotSupported = errors.New("not a supported SignatureType")
 
 	ConstructionErrs = []error{
+		ErrConstructionPreprocessResponseIsNil,
 		ErrConstructionMetadataResponseIsNil,
 		ErrConstructionMetadataResponseMetadataMissing,
 		ErrTxIdentifierResponseIsNil,

--- a/asserter/server.go
+++ b/asserter/server.go
@@ -163,6 +163,12 @@ func (a *Asserter) ConstructionMetadataRequest(request *types.ConstructionMetada
 		return ErrConstructionMetadataRequestOptionsIsNil
 	}
 
+	for _, publicKey := range request.PublicKeys {
+		if err := PublicKey(publicKey); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -313,6 +319,12 @@ func (a *Asserter) ConstructionPayloadsRequest(request *types.ConstructionPayloa
 
 	if err := a.Operations(request.Operations, true); err != nil {
 		return err
+	}
+
+	for _, publicKey := range request.PublicKeys {
+		if err := PublicKey(publicKey); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/asserter/server_test.go
+++ b/asserter/server_test.go
@@ -471,6 +471,19 @@ func TestConstructionMetadataRequest(t *testing.T) {
 			},
 			err: nil,
 		},
+		"valid request with public keys": {
+			request: &types.ConstructionMetadataRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Options:           map[string]interface{}{},
+				PublicKeys: []*types.PublicKey{
+					{
+						Bytes:     []byte("hello"),
+						CurveType: types.Secp256k1,
+					},
+				},
+			},
+			err: nil,
+		},
 		"invalid request wrong network": {
 			request: &types.ConstructionMetadataRequest{
 				NetworkIdentifier: wrongNetworkIdentifier,
@@ -497,6 +510,18 @@ func TestConstructionMetadataRequest(t *testing.T) {
 				NetworkIdentifier: validNetworkIdentifier,
 			},
 			err: ErrConstructionMetadataRequestOptionsIsNil,
+		},
+		"invalid request with public keys": {
+			request: &types.ConstructionMetadataRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Options:           map[string]interface{}{},
+				PublicKeys: []*types.PublicKey{
+					{
+						CurveType: types.Secp256k1,
+					},
+				},
+			},
+			err: ErrPublicKeyBytesEmpty,
 		},
 	}
 
@@ -852,6 +877,20 @@ func TestConstructionPayloadsRequest(t *testing.T) {
 			},
 			err: nil,
 		},
+		"valid request with public keys": {
+			request: &types.ConstructionPayloadsRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        validOps,
+				Metadata:          map[string]interface{}{"test": "hello"},
+				PublicKeys: []*types.PublicKey{
+					{
+						Bytes:     []byte("hello"),
+						CurveType: types.Secp256k1,
+					},
+				},
+			},
+			err: nil,
+		},
 		"invalid request wrong network": {
 			request: &types.ConstructionPayloadsRequest{
 				NetworkIdentifier: wrongNetworkIdentifier,
@@ -892,6 +931,19 @@ func TestConstructionPayloadsRequest(t *testing.T) {
 				Operations:        invalidOps,
 			},
 			err: ErrOperationStatusNotEmptyForConstruction,
+		},
+		"invalid request with public keys": {
+			request: &types.ConstructionPayloadsRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				Operations:        validOps,
+				Metadata:          map[string]interface{}{"test": "hello"},
+				PublicKeys: []*types.PublicKey{
+					{
+						CurveType: types.Secp256k1,
+					},
+				},
+			},
+			err: ErrPublicKeyBytesEmpty,
 		},
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ var (
 	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
 )
 
-// APIClient manages communication with the Rosetta API v1.4.2
+// APIClient manages communication with the Rosetta API v1.4.3
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,7 +53,7 @@ done
 rm -rf tmp;
 
 # Download spec file from releases
-ROSETTA_SPEC_VERSION=v1.4.2
+ROSETTA_SPEC_VERSION=v1.4.3
 curl -L https://github.com/coinbase/rosetta-specifications/releases/download/${ROSETTA_SPEC_VERSION}/api.json -o api.json;
 
 # Generate client + types code
@@ -121,10 +121,14 @@ sed "${SED_IFLAG[@]}" 's/*CoinAction/CoinAction/g' client/* server/*;
 
 # Fix CurveTypes, SignatureTypes, and CoinActions
 sed "${SED_IFLAG[@]}" 's/SECP256K1/Secp256k1/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/SECP256R1/Secp256r1/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/EDWARDS25519/Edwards25519/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/TWEEDLE/Tweedle/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/ECDSA_RECOVERY/EcdsaRecovery/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/ECDSA/Ecdsa/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/ED25519/Ed25519/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/SCHNORR_1/Schnorr1/g' client/* server/*;
+sed "${SED_IFLAG[@]}" 's/SCHNORR_POSEIDON/SchnorrPoseidon/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/CREATED/CoinCreated/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/SPENT/CoinSpent/g' client/* server/*;
 

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -265,8 +265,12 @@ func (f *Fetcher) ConstructionPreprocess(
 		return nil, fetcherErr
 	}
 
-	// We do not assert the response here because the only object
-	// in the response is optional and unstructured.
+	if err := asserter.ConstructionPreprocessResponse(response); err != nil {
+		fetcherErr := &Error{
+			Err: fmt.Errorf("%w: /construction/preprocess %s", ErrAssertionFailed, err.Error()),
+		}
+		return nil, fetcherErr
+	}
 
 	return response.Options, nil
 }

--- a/types/construction_metadata_request.go
+++ b/types/construction_metadata_request.go
@@ -18,7 +18,9 @@ package types
 
 // ConstructionMetadataRequest A ConstructionMetadataRequest is utilized to get information required
 // to construct a transaction. The Options object used to specify which metadata to return is left
-// purposely unstructured to allow flexibility for implementers.
+// purposely unstructured to allow flexibility for implementers. Optionally, the request can also
+// include an array of PublicKeys associated with the AccountIdentifiers returned in
+// ConstructionPreprocessResponse.
 type ConstructionMetadataRequest struct {
 	NetworkIdentifier *NetworkIdentifier `json:"network_identifier"`
 	// Some blockchains require different metadata for different types of transaction construction
@@ -26,5 +28,6 @@ type ConstructionMetadataRequest struct {
 	// possible types of metadata for construction (which may require multiple node fetches), the
 	// client can populate an options object to limit the metadata returned to only the subset
 	// required.
-	Options map[string]interface{} `json:"options"`
+	Options    map[string]interface{} `json:"options"`
+	PublicKeys []*PublicKey           `json:"public_keys,omitempty"`
 }

--- a/types/construction_parse_response.go
+++ b/types/construction_parse_response.go
@@ -21,7 +21,8 @@ package types
 // `/construction/preprocess` and `/construction/payloads`.
 type ConstructionParseResponse struct {
 	Operations []*Operation `json:"operations"`
-	// All signers of a particular transaction. If the transaction is unsigned, it should be empty.
+	// All signers (addresses) of a particular transaction. If the transaction is unsigned, it
+	// should be empty.
 	Signers  []string               `json:"signers"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/types/construction_payloads_request.go
+++ b/types/construction_payloads_request.go
@@ -18,9 +18,12 @@ package types
 
 // ConstructionPayloadsRequest ConstructionPayloadsRequest is the request to
 // `/construction/payloads`. It contains the network, a slice of operations, and arbitrary metadata
-// that was returned by the call to `/construction/metadata`.
+// that was returned by the call to `/construction/metadata`. Optionally, the request can also
+// include an array of PublicKeys associated with the AccountIdentifiers returned in
+// ConstructionPreprocessResponse.
 type ConstructionPayloadsRequest struct {
 	NetworkIdentifier *NetworkIdentifier     `json:"network_identifier"`
 	Operations        []*Operation           `json:"operations"`
 	Metadata          map[string]interface{} `json:"metadata,omitempty"`
+	PublicKeys        []*PublicKey           `json:"public_keys,omitempty"`
 }

--- a/types/construction_preprocess_response.go
+++ b/types/construction_preprocess_response.go
@@ -16,10 +16,15 @@
 
 package types
 
-// ConstructionPreprocessResponse ConstructionPreprocessResponse contains the request that will be
-// sent directly to `/construction/metadata`. If it is not necessary to make a request to
-// `/construction/metadata`, options should be null.
+// ConstructionPreprocessResponse ConstructionPreprocessResponse contains `options` that will be
+// sent unmodified to `/construction/metadata`. If it is not necessary to make a request to
+// `/construction/metadata`, `options` should be omitted.  Some blockchains require the PublicKey of
+// particular AccountIdentifiers to construct a valid transaction. To fetch these PublicKeys,
+// populate `required_public_keys` with the AccountIdentifiers associated with the desired
+// PublicKeys. If it is not necessary to retrieve any PublicKeys for construction,
+// `required_public_keys` should be omitted.
 type ConstructionPreprocessResponse struct {
 	// The options that will be sent directly to `/construction/metadata` by the caller.
-	Options map[string]interface{} `json:"options,omitempty"`
+	Options            map[string]interface{} `json:"options,omitempty"`
+	RequiredPublicKeys []*AccountIdentifier   `json:"required_public_keys,omitempty"`
 }

--- a/types/curve_type.go
+++ b/types/curve_type.go
@@ -16,13 +16,18 @@
 
 package types
 
-// CurveType CurveType is the type of cryptographic curve associated with a PublicKey.  * secp256k1:
-// SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y
-// (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf)
+// CurveType CurveType is the type of cryptographic curve associated with a PublicKey. * secp256k1:
+// SEC compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * secp256r1: SEC
+// compressed - `33 bytes` (https://secg.org/sec1-v2.pdf#subsubsection.2.3.3) * edwards25519: `y
+// (255-bits) || x-sign-bit (1-bit)` - `32 bytes` (https://ed25519.cr.yp.to/ed25519-20110926.pdf) *
+// tweedle: 1st pk : Fq.t (32 bytes) || 2nd pk : Fq.t (32 bytes)
+// (https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md#marshal-keys)
 type CurveType string
 
 // List of CurveType
 const (
 	Secp256k1    CurveType = "secp256k1"
+	Secp256r1    CurveType = "secp256r1"
 	Edwards25519 CurveType = "edwards25519"
+	Tweedle      CurveType = "tweedle"
 )

--- a/types/signature_type.go
+++ b/types/signature_type.go
@@ -18,12 +18,20 @@ package types
 
 // SignatureType SignatureType is the type of a cryptographic signature. * ecdsa: `r (32-bytes) || s
 // (32-bytes)` - `64 bytes` * ecdsa_recovery: `r (32-bytes) || s (32-bytes) || v (1-byte)` - `65
-// bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes`
+// bytes` * ed25519: `R (32-byte) || s (32-bytes)` - `64 bytes` * schnorr_1: `r (32-bytes) || s
+// (32-bytes)` - `64 bytes`  (schnorr signature implemented by Zilliqa where both `r` and `s` are
+// scalars encoded as `32-bytes` values, most significant byte first.) * schnorr_poseidon: `r
+// (32-bytes) || s (32-bytes)` where s = Hash(1st pk || 2nd pk || r) - `64 bytes`  (schnorr
+// signature w/ Poseidon hash function implemented by O(1) Labs where both `r` and `s` are scalars
+// encoded as `32-bytes` values, least significant byte first.
+// https://github.com/CodaProtocol/signer-reference/blob/master/schnorr.ml )
 type SignatureType string
 
 // List of SignatureType
 const (
-	Ecdsa         SignatureType = "ecdsa"
-	EcdsaRecovery SignatureType = "ecdsa_recovery"
-	Ed25519       SignatureType = "ed25519"
+	Ecdsa           SignatureType = "ecdsa"
+	EcdsaRecovery   SignatureType = "ecdsa_recovery"
+	Ed25519         SignatureType = "ed25519"
+	Schnorr1        SignatureType = "schnorr_1"
+	SchnorrPoseidon SignatureType = "schnorr_poseidon"
 )


### PR DESCRIPTION
Closes #130 

This PR adds support for `v1.4.3` of the Rosetta Specification.

### Changes
- [x] upgrade to v1.4.3 release (https://github.com/coinbase/rosetta-specifications/releases/tag/v1.4.3)
- [x] add new assertions for added fields in `ConstructionPreprocessResponse`, `ConstructionMetadataRequest`, and `ConstructionPayloadsRequest`