### PR TITLE
[Constructor] Inject Public Keys During Transaction Construction

### DIFF
--- a/constructor/coordinator/coordinator.go
+++ b/constructor/coordinator/coordinator.go
@@ -207,7 +207,11 @@ func (c *Coordinator) createTransaction(
 	for i, accountIdentifier := range requiredPublicKeys {
 		keyPair, err := c.helper.GetKey(ctx, dbTx, accountIdentifier.Address)
 		if err != nil {
-			return nil, "", fmt.Errorf("%w: unable to find key for address %s", err, accountIdentifier.Address)
+			return nil, "", fmt.Errorf(
+				"%w: unable to find key for address %s",
+				err,
+				accountIdentifier.Address,
+			)
 		}
 
 		publicKeys[i] = keyPair.PublicKey
@@ -496,7 +500,11 @@ func (c *Coordinator) Process(
 		var transactionCreated *types.TransactionIdentifier
 		if broadcast != nil {
 			// Construct Transaction
-			transactionIdentifier, networkTransaction, err := c.createTransaction(ctx, dbTx, broadcast)
+			transactionIdentifier, networkTransaction, err := c.createTransaction(
+				ctx,
+				dbTx,
+				broadcast,
+			)
 			if err != nil {
 				return fmt.Errorf("%w: unable to create transaction", err)
 			}

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -546,7 +546,7 @@ func TestProcess(t *testing.T) {
 		map[string]interface{}{
 			"test": "works",
 		},
-	).Return(metadataOptions, nil).Once()
+	).Return(metadataOptions, nil, nil).Once()
 	fetchedMetadata := map[string]interface{}{
 		"tx_meta": "help",
 	}
@@ -555,6 +555,7 @@ func TestProcess(t *testing.T) {
 		ctx,
 		network,
 		metadataOptions,
+		[]*types.PublicKey{},
 	).Return(fetchedMetadata, nil).Once()
 
 	unsignedTx := "unsigned transaction"
@@ -571,6 +572,7 @@ func TestProcess(t *testing.T) {
 		network,
 		ops,
 		fetchedMetadata,
+		[]*types.PublicKey{},
 	).Return(unsignedTx, signingPayloads, nil).Once()
 	helper.On(
 		"Parse",
@@ -950,7 +952,7 @@ func TestProcess_Failed(t *testing.T) {
 		map[string]interface{}{
 			"test": "works",
 		},
-	).Return(metadataOptions, nil).Once()
+	).Return(metadataOptions, nil, nil).Once()
 	fetchedMetadata := map[string]interface{}{
 		"tx_meta": "help",
 	}
@@ -959,6 +961,7 @@ func TestProcess_Failed(t *testing.T) {
 		ctx,
 		network,
 		metadataOptions,
+		[]*types.PublicKey{},
 	).Return(fetchedMetadata, nil).Once()
 
 	unsignedTx := "unsigned transaction"
@@ -975,6 +978,7 @@ func TestProcess_Failed(t *testing.T) {
 		network,
 		ops,
 		fetchedMetadata,
+		[]*types.PublicKey{},
 	).Return(unsignedTx, signingPayloads, nil).Once()
 	helper.On(
 		"Parse",

--- a/constructor/coordinator/types.go
+++ b/constructor/coordinator/types.go
@@ -58,6 +58,14 @@ type Helper interface {
 		*keys.KeyPair,
 	) error
 
+	// GetKey is called to get the *types.KeyPair
+	// associated with an address.
+	GetKey(
+		context.Context,
+		storage.DatabaseTransaction,
+		string, // address
+	) (*keys.KeyPair, error)
+
 	// AllAddresses returns a slice of all known addresses.
 	AllAddresses(
 		context.Context,
@@ -119,7 +127,7 @@ type Helper interface {
 		*types.NetworkIdentifier,
 		[]*types.Operation,
 		map[string]interface{},
-	) (map[string]interface{}, error)
+	) (map[string]interface{}, []*types.AccountIdentifier, error)
 
 	// Metadata calls the /construction/metadata endpoint
 	// using the online node.
@@ -127,6 +135,7 @@ type Helper interface {
 		context.Context,
 		*types.NetworkIdentifier,
 		map[string]interface{},
+		[]*types.PublicKey,
 	) (map[string]interface{}, error)
 
 	// Payloads calls the /construction/payloads endpoint
@@ -136,6 +145,7 @@ type Helper interface {
 		*types.NetworkIdentifier,
 		[]*types.Operation,
 		map[string]interface{},
+		[]*types.PublicKey,
 	) (string, []*types.SigningPayload, error)
 
 	// Parse calls the /construction/parse endpoint

--- a/mocks/constructor/coordinator/helper.go
+++ b/mocks/constructor/coordinator/helper.go
@@ -183,6 +183,29 @@ func (_m *Helper) Derive(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 
 	return r0, r1, r2
 }
 
+// GetKey provides a mock function with given fields: _a0, _a1, _a2
+func (_m *Helper) GetKey(_a0 context.Context, _a1 storage.DatabaseTransaction, _a2 string) (*keys.KeyPair, error) {
+	ret := _m.Called(_a0, _a1, _a2)
+
+	var r0 *keys.KeyPair
+	if rf, ok := ret.Get(0).(func(context.Context, storage.DatabaseTransaction, string) *keys.KeyPair); ok {
+		r0 = rf(_a0, _a1, _a2)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*keys.KeyPair)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, storage.DatabaseTransaction, string) error); ok {
+		r1 = rf(_a0, _a1, _a2)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Hash provides a mock function with given fields: _a0, _a1, _a2
 func (_m *Helper) Hash(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 string) (*types.TransactionIdentifier, error) {
 	ret := _m.Called(_a0, _a1, _a2)
@@ -243,13 +266,13 @@ func (_m *Helper) LockedAddresses(_a0 context.Context, _a1 storage.DatabaseTrans
 	return r0, r1
 }
 
-// Metadata provides a mock function with given fields: _a0, _a1, _a2
-func (_m *Helper) Metadata(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 map[string]interface{}) (map[string]interface{}, error) {
-	ret := _m.Called(_a0, _a1, _a2)
+// Metadata provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *Helper) Metadata(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 map[string]interface{}, _a3 []*types.PublicKey) (map[string]interface{}, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 map[string]interface{}
-	if rf, ok := ret.Get(0).(func(context.Context, *types.NetworkIdentifier, map[string]interface{}) map[string]interface{}); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(context.Context, *types.NetworkIdentifier, map[string]interface{}, []*types.PublicKey) map[string]interface{}); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
@@ -257,8 +280,8 @@ func (_m *Helper) Metadata(_a0 context.Context, _a1 *types.NetworkIdentifier, _a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *types.NetworkIdentifier, map[string]interface{}) error); ok {
-		r1 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(1).(func(context.Context, *types.NetworkIdentifier, map[string]interface{}, []*types.PublicKey) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -307,20 +330,20 @@ func (_m *Helper) Parse(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 b
 	return r0, r1, r2, r3
 }
 
-// Payloads provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *Helper) Payloads(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 []*types.Operation, _a3 map[string]interface{}) (string, []*types.SigningPayload, error) {
-	ret := _m.Called(_a0, _a1, _a2, _a3)
+// Payloads provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4
+func (_m *Helper) Payloads(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 []*types.Operation, _a3 map[string]interface{}, _a4 []*types.PublicKey) (string, []*types.SigningPayload, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}) string); ok {
-		r0 = rf(_a0, _a1, _a2, _a3)
+	if rf, ok := ret.Get(0).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}, []*types.PublicKey) string); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 []*types.SigningPayload
-	if rf, ok := ret.Get(1).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}) []*types.SigningPayload); ok {
-		r1 = rf(_a0, _a1, _a2, _a3)
+	if rf, ok := ret.Get(1).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}, []*types.PublicKey) []*types.SigningPayload); ok {
+		r1 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]*types.SigningPayload)
@@ -328,8 +351,8 @@ func (_m *Helper) Payloads(_a0 context.Context, _a1 *types.NetworkIdentifier, _a
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}) error); ok {
-		r2 = rf(_a0, _a1, _a2, _a3)
+	if rf, ok := ret.Get(2).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}, []*types.PublicKey) error); ok {
+		r2 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -338,7 +361,7 @@ func (_m *Helper) Payloads(_a0 context.Context, _a1 *types.NetworkIdentifier, _a
 }
 
 // Preprocess provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *Helper) Preprocess(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 []*types.Operation, _a3 map[string]interface{}) (map[string]interface{}, error) {
+func (_m *Helper) Preprocess(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 []*types.Operation, _a3 map[string]interface{}) (map[string]interface{}, []*types.AccountIdentifier, error) {
 	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 map[string]interface{}
@@ -350,14 +373,23 @@ func (_m *Helper) Preprocess(_a0 context.Context, _a1 *types.NetworkIdentifier, 
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}) error); ok {
+	var r1 []*types.AccountIdentifier
+	if rf, ok := ret.Get(1).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}) []*types.AccountIdentifier); ok {
 		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]*types.AccountIdentifier)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, *types.NetworkIdentifier, []*types.Operation, map[string]interface{}) error); ok {
+		r2 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // Sign provides a mock function with given fields: _a0, _a1


### PR DESCRIPTION
Related Issue: https://github.com/coinbase/rosetta-cli/issues/112

The [`v1.4.3` release of the Rosetta Specification](https://github.com/coinbase/rosetta-specifications/releases/tag/v1.4.3) allows a Rosetta implementation to request the PublicKeys of any number of AccountIdentifiers for calls to `/construction/metadata` and `/construction/payloads`.

This PR adds support for the `fetcher` to accept PublicKeys in calls to `/construction/metadata` and `/construction/payloads` and for the `constructor` to inject requested public keys automatically.

### Changes
- [x] Update fetcher methods for `ConstructionPreprocess`, `ConstructionMetadata`, and `ConstructionPaylaods`
- [x] Inject `types.PublicKey` during transaction construction in the `coordinator`
- [x] Add transactional key fetching from key storage

### Future PR
* Update rosetta specification to return `AccountIdentifier` in `ConstructionDeriveResponse` and `SigningPayload` (non-breaking by adding field + deprecating)
* Store keys under `AccountIdentifier` instead of address (there may be multiple keys associated with the same `AccountIdentifier.Address`)
* Modify broadcast storage to return locked account identifiers instead of addresses