### PR TITLE
[Parser] typed errors overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOVERALLS_CMD=go run github.com/mattn/goveralls
 GOLINT_CMD=go run golang.org/x/lint/golint
 GO_PACKAGES=./asserter/... ./fetcher/... ./types/... ./client/... ./server/... \
 	./parser/... ./syncer/... ./reconciler/... ./keys/... \
-	./statefulsyncer/... ./storage/... ./utils/... ./constructor/...
+	./statefulsyncer/... ./storage/... ./utils/... ./constructor/... ./errors/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
 TEST_SCRIPT=go test ${GO_PACKAGES}
 LINT_SETTINGS=golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -17,7 +17,7 @@ package asserter
 import (
 	"errors"
 
-	"github.com/coinbase/rosetta-sdk-go/utils"
+	utils "github.com/coinbase/rosetta-sdk-go/errors"
 )
 
 // Named error types for Asserter errors

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -14,7 +14,11 @@
 
 package asserter
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/coinbase/rosetta-sdk-go/utils"
+)
 
 // Named error types for Asserter errors
 var (
@@ -375,19 +379,9 @@ func ErrAsserter(err error) (bool, string) {
 	}
 
 	for key, val := range assertErrs {
-		if findError(val, err) {
+		if utils.FindError(val, err) {
 			return true, key
 		}
 	}
 	return false, ""
-}
-
-// findError
-func findError(errorList []error, err error) bool {
-	for _, k := range errorList {
-		if errors.Is(err, k) {
-			return true
-		}
-	}
-	return false
 }

--- a/errors/utils.go
+++ b/errors/utils.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import "errors"
+
+// FindError is used by the Err functions in each package
+// to determine if a particular error was thrown by that component
+func FindError(errorList []error, err error) bool {
+	for _, k := range errorList {
+		if errors.Is(err, k) {
+			return true
+		}
+	}
+	return false
+}

--- a/errors/utils_test.go
+++ b/errors/utils_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrParser(t *testing.T) {
+	err1 := errors.New("error 1")
+	err2 := errors.New("error 2")
+	err3 := errors.New("error 3")
+
+	var tests = map[string]struct {
+		err     error
+		errList []error
+		found   bool
+	}{
+		"intent error": {
+			err:     err1,
+			errList: []error{err1, err2, err3},
+			found:   true,
+		},
+		"match operations error": {
+			err:     errors.New("this is not an error we expect to find"),
+			errList: []error{err1, err2},
+			found:   false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			found := FindError(test.errList, test.err)
+			assert.Equal(t, test.found, found)
+		})
+	}
+}

--- a/keys/errors.go
+++ b/keys/errors.go
@@ -24,7 +24,7 @@ var (
 	ErrSignUnsupportedPayloadSignatureType = errors.New(
 		"sign: unexpected payload.SignatureType while signing",
 	)
-	ErrSignUnsupportedSigType = errors.New(
+	ErrSignUnsupportedSignatureType = errors.New(
 		"sign: unexpected Signature type while signing",
 	)
 	ErrSignFailed = errors.New("sign: unable to sign. %w")
@@ -37,3 +37,25 @@ var (
 	)
 	ErrVerifyFailed = errors.New("verify: verify returned false")
 )
+
+// ErrKeys takes an error as an argument and returns
+// whether or not the error is one thrown by the keys package
+func ErrKeys(err error) (bool) {
+	keyErrors := []error{
+		ErrPrivKeyUndecodable,
+		ErrPrivKeyLengthInvalid,
+		ErrSignUnsupportedPayloadSignatureType,
+		ErrSignUnsupportedSignatureType,
+		ErrSignFailed,
+		ErrVerifyUnsupportedPayloadSignatureType,
+		ErrVerifyUnsupportedSignatureType,
+		ErrVerifyFailed,
+	}
+
+	for _, k := range keyErrors {
+		if errors.Is(k, err) {
+			return true
+		}
+	}
+	return false
+}

--- a/keys/errors.go
+++ b/keys/errors.go
@@ -16,6 +16,7 @@ package keys
 
 import (
 	"errors"
+
 	utils "github.com/coinbase/rosetta-sdk-go/errors"
 )
 

--- a/keys/errors.go
+++ b/keys/errors.go
@@ -27,7 +27,7 @@ var (
 	ErrSignUnsupportedSignatureType = errors.New(
 		"sign: unexpected Signature type while signing",
 	)
-	ErrSignFailed = errors.New("sign: unable to sign. %w")
+	ErrSignFailed = errors.New("sign: unable to sign")
 
 	ErrVerifyUnsupportedPayloadSignatureType = errors.New(
 		"verify: unexpected payload.SignatureType while verifying",
@@ -40,7 +40,7 @@ var (
 
 // ErrKeys takes an error as an argument and returns
 // whether or not the error is one thrown by the keys package
-func ErrKeys(err error) (bool) {
+func ErrKeys(err error) bool {
 	keyErrors := []error{
 		ErrPrivKeyUndecodable,
 		ErrPrivKeyLengthInvalid,

--- a/keys/errors.go
+++ b/keys/errors.go
@@ -14,7 +14,10 @@
 
 package keys
 
-import "errors"
+import (
+	"errors"
+	utils "github.com/coinbase/rosetta-sdk-go/errors"
+)
 
 // Named error types for Keys errors
 var (
@@ -52,10 +55,5 @@ func ErrKeys(err error) bool {
 		ErrVerifyFailed,
 	}
 
-	for _, k := range keyErrors {
-		if errors.Is(k, err) {
-			return true
-		}
-	}
-	return false
+	return utils.FindError(keyErrors, err)
 }

--- a/keys/errors_test.go
+++ b/keys/errors_test.go
@@ -1,0 +1,45 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keys
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrKeys(t *testing.T) {
+	var tests = map[string]struct {
+		err    error
+		is     bool
+	}{
+		"is a keys error": {
+			err:    ErrPrivKeyLengthInvalid,
+			is:     true,
+		},
+		"not a keys error": {
+			err:    errors.New("blah"),
+			is:     false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			is := ErrKeys(test.err)
+			assert.Equal(t, test.is, is)
+		})
+	}
+}

--- a/keys/signer_edwards25519.go
+++ b/keys/signer_edwards25519.go
@@ -56,7 +56,7 @@ func (s *SignerEdwards25519) Sign(
 	if sigType != types.Ed25519 {
 		return nil, fmt.Errorf(
 			"%w: expected %v but got %v",
-			ErrSignUnsupportedSigType,
+			ErrSignUnsupportedSignatureType,
 			types.Ed25519,
 			sigType,
 		)

--- a/keys/signer_secp256k1.go
+++ b/keys/signer_secp256k1.go
@@ -71,7 +71,7 @@ func (s *SignerSecp256k1) Sign(
 		}
 		sig = sig[:EcdsaSignatureLen]
 	default:
-		return nil, fmt.Errorf("%w: %s", ErrSignUnsupportedSignatureType, err.Error())
+		return nil, fmt.Errorf("%w: %v", ErrSignUnsupportedSignatureType, err)
 	}
 
 	return &types.Signature{

--- a/keys/signer_secp256k1.go
+++ b/keys/signer_secp256k1.go
@@ -71,7 +71,7 @@ func (s *SignerSecp256k1) Sign(
 		}
 		sig = sig[:EcdsaSignatureLen]
 	default:
-		return nil, fmt.Errorf(ErrSignUnsupportedSigType.Error(), err)
+		return nil, fmt.Errorf(ErrSignUnsupportedSignatureType.Error(), err)
 	}
 
 	return &types.Signature{

--- a/keys/signer_secp256k1.go
+++ b/keys/signer_secp256k1.go
@@ -62,16 +62,16 @@ func (s *SignerSecp256k1) Sign(
 	case types.EcdsaRecovery:
 		sig, err = secp256k1.Sign(payload.Bytes, privKeyBytes)
 		if err != nil {
-			return nil, fmt.Errorf(ErrSignFailed.Error(), err)
+			return nil, fmt.Errorf("%w: %s", ErrSignFailed, err.Error())
 		}
 	case types.Ecdsa:
 		sig, err = secp256k1.Sign(payload.Bytes, privKeyBytes)
 		if err != nil {
-			return nil, fmt.Errorf(ErrSignFailed.Error(), err)
+			return nil, fmt.Errorf("%w: %s", ErrSignFailed, err.Error())
 		}
 		sig = sig[:EcdsaSignatureLen]
 	default:
-		return nil, fmt.Errorf(ErrSignUnsupportedSignatureType.Error(), err)
+		return nil, fmt.Errorf("%w: %s", ErrSignUnsupportedSignatureType, err.Error())
 	}
 
 	return &types.Signature{

--- a/keys/signer_secp256k1_test.go
+++ b/keys/signer_secp256k1_test.go
@@ -52,7 +52,7 @@ func TestSignSecp256k1(t *testing.T) {
 			types.Ed25519,
 			64,
 			true,
-			ErrSignUnsupportedSigType,
+			ErrSignUnsupportedSignatureType,
 		},
 	}
 

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -17,7 +17,7 @@ package parser
 import (
 	"errors"
 
-	"github.com/coinbase/rosetta-sdk-go/utils"
+	utils "github.com/coinbase/rosetta-sdk-go/errors"
 )
 
 // Named error types for Parser errors

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import "errors"
+
+// Named error types for Parser errors
+var (
+	///////////////////
+	/* INTENT ERRORS */
+	///////////////////
+	ErrIntentAccountMismatch = errors.New("intended account did not match observed account")
+	ErrIntentAmountMismatch = errors.New("intended amount did not match observed amount")
+	ErrIntentTypeMismatch = errors.New("intended type did not match observed type")
+
+	ErrUnexpectedOperation = errors.New("found extra operation")
+)

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -21,9 +21,117 @@ var (
 	///////////////////
 	/* INTENT ERRORS */
 	///////////////////
-	ErrIntentAccountMismatch = errors.New("intended account did not match observed account")
-	ErrIntentAmountMismatch = errors.New("intended amount did not match observed amount")
-	ErrIntentTypeMismatch = errors.New("intended type did not match observed type")
+	ErrExpectedOperationAccountMismatch = errors.New(
+		"intended account did not match observed account",
+	)
+	ErrExpectedOperationAmountMismatch = errors.New(
+		"intended amount did not match observed amount",
+	)
+	ErrExpectedOperationTypeMismatch = errors.New(
+		"intended type did not match observed type",
+	)
+	ErrExpectedOperationsUnexpectedOperation = errors.New("found extra operation")
+	ErrExpectedSignerDuplicateSigner         = errors.New("found duplicate signer")
+	ErrExpectedSignerUnexpectedSigner        = errors.New("found unexpected signers")
 
-	ErrUnexpectedOperation = errors.New("found extra operation")
+	IntentErrs = []error{
+		ErrExpectedOperationAccountMismatch,
+		ErrExpectedOperationAmountMismatch,
+		ErrExpectedOperationTypeMismatch,
+		ErrExpectedOperationsUnexpectedOperation,
+		ErrExpectedSignerDuplicateSigner,
+		ErrExpectedSignerUnexpectedSigner,
+	}
+
+	/////////////////////////////
+	/* MATCH OPERATIONS ERRORS */
+	/////////////////////////////
+	ErrAccountMatchAccountMissing           = errors.New("account is missing")
+	ErrAccountMatchSubAccountMissing        = errors.New("SubAccountIdentifier.Address is missing")
+	ErrAccountMatchSubAccountPopulated      = errors.New("SubAccount is populated")
+	ErrAccountMatchUnexpectedSubAccountAddr = errors.New("unexpected SubAccountIdentifier.Address")
+
+	ErrMetadataMatchKeyNotFound       = errors.New("key is not present in metadata")
+	ErrMetadataMatchValueTypeMismatch = errors.New("unexpected value associated with key")
+
+	ErrAmountMatchAmountMissing      = errors.New("amount is missing")
+	ErrAmountMatchAmountPopulated    = errors.New("amount is populated")
+	ErrAmountMatchUnexpectedSign     = errors.New("unexpected amount sign")
+	ErrAmountMatchUnexpectedCurrency = errors.New("unexpected currency")
+
+	ErrCoinActionMatchCoinChangeIsNil      = errors.New("coin change is nil")
+	ErrCoinActionMatchUnexpectedCoinAction = errors.New("unexpected coin action")
+
+	ErrEqualAmountsNoOperations = errors.New("cannot check equality of 0 operations")
+	ErrEqualAmountsNotEqual     = errors.New("amounts are not equal")
+
+	ErrOppositeAmountsSameSign       = errors.New("operations have the same sign")
+	ErrOppositeAmountsAbsValMismatch = errors.New("operation absolute values are not equal")
+
+	ErrEqualAddressesTooManyOperations = errors.New("cannot check equality of <= 1 operations")
+	ErrEqualAddressesAccountIsNil      = errors.New("account is nil")
+	ErrEqualAddressesAddrMismatch      = errors.New("addresses do not match")
+
+	ErrMatchIndexValidIndexOutOfRange = errors.New("match index out of range")
+	ErrMatchIndexValidIndexIsNil      = errors.New("match index is nil")
+
+	ErrMatchOperationsNoOperations          = errors.New("unable to match anything to 0 operations")
+	ErrMatchOperationsDescriptionsMissing   = errors.New("no descriptions to match")
+	ErrMatchOperationsMatchNotFound         = errors.New("unable to find match for operation")
+	ErrMatchOperationsDescriptionNotMatched = errors.New("could not find match for description")
+
+	MatchOpsErrs = []error{
+		ErrAccountMatchAccountMissing,
+		ErrAccountMatchSubAccountMissing,
+		ErrAccountMatchSubAccountPopulated,
+		ErrAccountMatchUnexpectedSubAccountAddr,
+		ErrMetadataMatchKeyNotFound,
+		ErrMetadataMatchValueTypeMismatch,
+		ErrAmountMatchAmountMissing,
+		ErrAmountMatchAmountPopulated,
+		ErrAmountMatchUnexpectedSign,
+		ErrAmountMatchUnexpectedCurrency,
+		ErrCoinActionMatchCoinChangeIsNil,
+		ErrCoinActionMatchUnexpectedCoinAction,
+		ErrEqualAmountsNoOperations,
+		ErrEqualAmountsNotEqual,
+		ErrOppositeAmountsSameSign,
+		ErrOppositeAmountsAbsValMismatch,
+		ErrEqualAddressesTooManyOperations,
+		ErrEqualAddressesAccountIsNil,
+		ErrEqualAddressesAddrMismatch,
+		ErrMatchIndexValidIndexOutOfRange,
+		ErrMatchIndexValidIndexIsNil,
+		ErrMatchOperationsNoOperations,
+		ErrMatchOperationsDescriptionsMissing,
+		ErrMatchOperationsMatchNotFound,
+		ErrMatchOperationsDescriptionNotMatched,
+	}
 )
+
+// ErrParser takes an error as an argument and returns
+// whether or not the error is one thrown by the asserter
+// along with the specific source of the error
+func ErrParser(err error) (bool, string) {
+	parserErrs := map[string][]error{
+		"intent error":           IntentErrs,
+		"match operations error": MatchOpsErrs,
+	}
+
+	for key, val := range parserErrs {
+		if findError(val, err) {
+			return true, key
+		}
+	}
+	return false, ""
+}
+
+// findError
+func findError(errorList []error, err error) bool {
+	for _, k := range errorList {
+		if errors.Is(err, k) {
+			return true
+		}
+	}
+	return false
+}

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -14,7 +14,11 @@
 
 package parser
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/coinbase/rosetta-sdk-go/utils"
+)
 
 // Named error types for Parser errors
 var (
@@ -119,19 +123,9 @@ func ErrParser(err error) (bool, string) {
 	}
 
 	for key, val := range parserErrs {
-		if findError(val, err) {
+		if utils.FindError(val, err) {
 			return true, key
 		}
 	}
 	return false, ""
-}
-
-// findError
-func findError(errorList []error, err error) bool {
-	for _, k := range errorList {
-		if errors.Is(err, k) {
-			return true
-		}
-	}
-	return false
 }

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -68,9 +68,9 @@ var (
 	ErrOppositeAmountsSameSign       = errors.New("operations have the same sign")
 	ErrOppositeAmountsAbsValMismatch = errors.New("operation absolute values are not equal")
 
-	ErrEqualAddressesTooManyOperations = errors.New("cannot check equality of <= 1 operations")
-	ErrEqualAddressesAccountIsNil      = errors.New("account is nil")
-	ErrEqualAddressesAddrMismatch      = errors.New("addresses do not match")
+	ErrEqualAddressesTooFewOperations = errors.New("cannot check equality of <= 1 operations")
+	ErrEqualAddressesAccountIsNil     = errors.New("account is nil")
+	ErrEqualAddressesAddrMismatch     = errors.New("addresses do not match")
 
 	ErrMatchIndexValidIndexOutOfRange = errors.New("match index out of range")
 	ErrMatchIndexValidIndexIsNil      = errors.New("match index is nil")
@@ -97,7 +97,7 @@ var (
 		ErrEqualAmountsNotEqual,
 		ErrOppositeAmountsSameSign,
 		ErrOppositeAmountsAbsValMismatch,
-		ErrEqualAddressesTooManyOperations,
+		ErrEqualAddressesTooFewOperations,
 		ErrEqualAddressesAccountIsNil,
 		ErrEqualAddressesAddrMismatch,
 		ErrMatchIndexValidIndexOutOfRange,

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -34,15 +34,15 @@ var (
 	ErrExpectedOperationTypeMismatch = errors.New(
 		"intended type did not match observed type",
 	)
-	ErrExpectedOperationsUnexpectedOperation = errors.New("found extra operation")
-	ErrExpectedSignerDuplicateSigner         = errors.New("found duplicate signer")
-	ErrExpectedSignerUnexpectedSigner        = errors.New("found unexpected signers")
+	ErrExpectedOperationsExtraOperation = errors.New("found extra operation")
+	ErrExpectedSignerDuplicateSigner    = errors.New("found duplicate signer")
+	ErrExpectedSignerUnexpectedSigner   = errors.New("found unexpected signers")
 
 	IntentErrs = []error{
 		ErrExpectedOperationAccountMismatch,
 		ErrExpectedOperationAmountMismatch,
 		ErrExpectedOperationTypeMismatch,
-		ErrExpectedOperationsUnexpectedOperation,
+		ErrExpectedOperationsExtraOperation,
 		ErrExpectedSignerDuplicateSigner,
 		ErrExpectedSignerUnexpectedSigner,
 	}
@@ -55,8 +55,8 @@ var (
 	ErrAccountMatchSubAccountPopulated      = errors.New("SubAccount is populated")
 	ErrAccountMatchUnexpectedSubAccountAddr = errors.New("unexpected SubAccountIdentifier.Address")
 
-	ErrMetadataMatchKeyNotFound       = errors.New("key is not present in metadata")
-	ErrMetadataMatchValueTypeMismatch = errors.New("unexpected value associated with key")
+	ErrMetadataMatchKeyNotFound      = errors.New("key is not present in metadata")
+	ErrMetadataMatchKeyValueMismatch = errors.New("unexpected value associated with key")
 
 	ErrAmountMatchAmountMissing      = errors.New("amount is missing")
 	ErrAmountMatchAmountPopulated    = errors.New("amount is populated")
@@ -90,7 +90,7 @@ var (
 		ErrAccountMatchSubAccountPopulated,
 		ErrAccountMatchUnexpectedSubAccountAddr,
 		ErrMetadataMatchKeyNotFound,
-		ErrMetadataMatchValueTypeMismatch,
+		ErrMetadataMatchKeyValueMismatch,
 		ErrAmountMatchAmountMissing,
 		ErrAmountMatchAmountPopulated,
 		ErrAmountMatchUnexpectedSign,

--- a/parser/errors_test.go
+++ b/parser/errors_test.go
@@ -12,34 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keys
+package parser
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrKeys(t *testing.T) {
+func TestErrParser(t *testing.T) {
 	var tests = map[string]struct {
-		err error
-		is  bool
+		err    error
+		is     bool
+		source string
 	}{
-		"is a keys error": {
-			err: ErrPrivKeyLengthInvalid,
-			is:  true,
+		"intent error": {
+			err:    ErrExpectedOperationAccountMismatch,
+			is:     true,
+			source: "intent error",
 		},
-		"not a keys error": {
-			err: errors.New("blah"),
-			is:  false,
+		"match operations error": {
+			err:    ErrAccountMatchAccountMissing,
+			is:     true,
+			source: "match operations error",
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			is := ErrKeys(test.err)
+			is, source := ErrParser(test.err)
 			assert.Equal(t, test.is, is)
+			assert.Equal(t, test.source, source)
 		})
 	}
 }

--- a/parser/intent.go
+++ b/parser/intent.go
@@ -29,7 +29,8 @@ import (
 func ExpectedOperation(intent *types.Operation, observed *types.Operation) error {
 	if types.Hash(intent.Account) != types.Hash(observed.Account) {
 		return fmt.Errorf(
-			"intended account %s did not match observed account %s",
+			"%w: expected %s but got %s",
+			ErrIntentAccountMismatch,
 			types.PrettyPrintStruct(intent.Account),
 			types.PrettyPrintStruct(observed.Account),
 		)
@@ -37,7 +38,8 @@ func ExpectedOperation(intent *types.Operation, observed *types.Operation) error
 
 	if types.Hash(intent.Amount) != types.Hash(observed.Amount) {
 		return fmt.Errorf(
-			"intended amount %s did not match observed amount %s",
+			"%w: expected %s but got %s",
+			ErrIntentAmountMismatch,
 			types.PrettyPrintStruct(intent.Amount),
 			types.PrettyPrintStruct(observed.Amount),
 		)
@@ -45,7 +47,8 @@ func ExpectedOperation(intent *types.Operation, observed *types.Operation) error
 
 	if intent.Type != observed.Type {
 		return fmt.Errorf(
-			"intended type %s did not match observed type %s",
+			"%w: expected %s but got %s",
+			ErrIntentTypeMismatch,
 			intent.Type,
 			observed.Type,
 		)
@@ -103,7 +106,8 @@ func (p *Parser) ExpectedOperations(
 
 		if !foundMatch && errExtra {
 			return fmt.Errorf(
-				"found extra operation %s",
+				"%w: %s",
+				ErrUnexpectedOperation,
 				types.PrettyPrintStruct(obs),
 			)
 		}

--- a/parser/intent.go
+++ b/parser/intent.go
@@ -107,7 +107,7 @@ func (p *Parser) ExpectedOperations(
 		if !foundMatch && errExtra {
 			return fmt.Errorf(
 				"%w: %s",
-				ErrExpectedOperationsUnexpectedOperation,
+				ErrExpectedOperationsExtraOperation,
 				types.PrettyPrintStruct(obs),
 			)
 		}

--- a/parser/intent.go
+++ b/parser/intent.go
@@ -30,7 +30,7 @@ func ExpectedOperation(intent *types.Operation, observed *types.Operation) error
 	if types.Hash(intent.Account) != types.Hash(observed.Account) {
 		return fmt.Errorf(
 			"%w: expected %s but got %s",
-			ErrIntentAccountMismatch,
+			ErrExpectedOperationAccountMismatch,
 			types.PrettyPrintStruct(intent.Account),
 			types.PrettyPrintStruct(observed.Account),
 		)
@@ -39,7 +39,7 @@ func ExpectedOperation(intent *types.Operation, observed *types.Operation) error
 	if types.Hash(intent.Amount) != types.Hash(observed.Amount) {
 		return fmt.Errorf(
 			"%w: expected %s but got %s",
-			ErrIntentAmountMismatch,
+			ErrExpectedOperationAmountMismatch,
 			types.PrettyPrintStruct(intent.Amount),
 			types.PrettyPrintStruct(observed.Amount),
 		)
@@ -48,7 +48,7 @@ func ExpectedOperation(intent *types.Operation, observed *types.Operation) error
 	if intent.Type != observed.Type {
 		return fmt.Errorf(
 			"%w: expected %s but got %s",
-			ErrIntentTypeMismatch,
+			ErrExpectedOperationTypeMismatch,
 			intent.Type,
 			observed.Type,
 		)
@@ -107,7 +107,7 @@ func (p *Parser) ExpectedOperations(
 		if !foundMatch && errExtra {
 			return fmt.Errorf(
 				"%w: %s",
-				ErrUnexpectedOperation,
+				ErrExpectedOperationsUnexpectedOperation,
 				types.PrettyPrintStruct(obs),
 			)
 		}
@@ -122,7 +122,7 @@ func (p *Parser) ExpectedOperations(
 
 	if len(missingIntent) > 0 {
 		errString := fmt.Sprintf(
-			"could intent match for %v",
+			"could not intent match %v",
 			missingIntent,
 		)
 
@@ -151,7 +151,7 @@ func ExpectedSigners(intent []*types.SigningPayload, observed []string) error {
 	}
 
 	if err := asserter.StringArray("observed signers", observed); err != nil {
-		return fmt.Errorf("%w: found duplicate signer", err)
+		return fmt.Errorf("%w: %s", ErrExpectedSignerDuplicateSigner, err.Error())
 	}
 
 	// Could exist here if len(intent) != len(observed) but
@@ -170,7 +170,8 @@ func ExpectedSigners(intent []*types.SigningPayload, observed []string) error {
 	for k := range intendedSigners {
 		if _, exists := seenSigners[k]; !exists {
 			return fmt.Errorf(
-				"could not find match for intended signer %s",
+				"%w: %s",
+				ErrExpectedSignerDuplicateSigner,
 				k,
 			)
 		}
@@ -178,7 +179,8 @@ func ExpectedSigners(intent []*types.SigningPayload, observed []string) error {
 
 	if len(unmatched) != 0 {
 		return fmt.Errorf(
-			"found unexpected signers: %s",
+			"%w: %s",
+			ErrExpectedSignerUnexpectedSigner,
 			types.PrettyPrintStruct(unmatched),
 		)
 	}

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -165,7 +165,7 @@ func metadataMatch(reqs []*MetadataDescription, metadata map[string]interface{})
 		if reflect.TypeOf(val).Kind() != req.ValueKind {
 			return fmt.Errorf(
 				"%w: value of %s is not of type %s",
-				ErrMetadataMatchValueTypeMismatch,
+				ErrMetadataMatchKeyValueMismatch,
 				req.Key,
 				req.ValueKind,
 			)

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -402,7 +402,7 @@ func oppositeAmounts(a *types.Operation, b *types.Operation) error {
 // equal addresses.
 func equalAddresses(ops []*types.Operation) error {
 	if len(ops) <= 1 {
-		return fmt.Errorf("%w: got %d operations", ErrEqualAddressesTooManyOperations, len(ops))
+		return fmt.Errorf("%w: got %d operations", ErrEqualAddressesTooFewOperations, len(ops))
 	}
 
 	base := ""

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -378,3 +378,14 @@ func GetAccountBalances(
 
 	return accountBalances, nil
 }
+
+// FindError is used by the Err functions in each package
+// to determine if a particular error was thrown by that component
+func FindError(errorList []error, err error) bool {
+	for _, k := range errorList {
+		if errors.Is(err, k) {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -378,14 +378,3 @@ func GetAccountBalances(
 
 	return accountBalances, nil
 }
-
-// FindError is used by the Err functions in each package
-// to determine if a particular error was thrown by that component
-func FindError(errorList []error, err error) bool {
-	for _, k := range errorList {
-		if errors.Is(err, k) {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
Fixes # .

### Motivation
continuing from this PR: [https://github.com/coinbase/rosetta-sdk-go/pull/102](https://github.com/coinbase/rosetta-sdk-go/pull/102)
and this PR: [https://github.com/coinbase/rosetta-sdk-go/pull/129](https://github.com/coinbase/rosetta-sdk-go/pull/129)

we want to use named errors in the SDK to improve the debugging experience

this PR also includes some minor changes in /keys

### Solution
added errors.go and an ErrParser() function to check if an error was thrown by the parser

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
