### PR TITLE
[Storage] Lookup by CoinIdentifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
       name: default
     steps:
       - *fast-checkout
+      - run: apt-get install -y zstd
       - run: make test-cover
   salus:
     machine: true

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -187,6 +187,7 @@ type BadgerTransaction struct {
 
 	holdsLock bool
 
+	reclaimLock      sync.Mutex
 	buffersToReclaim []*bytes.Buffer
 }
 
@@ -220,12 +221,14 @@ func (b *BadgerTransaction) Commit(context.Context) error {
 	err := b.txn.Commit()
 
 	// Reclaim all allocated buffers for future work.
+	b.reclaimLock.Lock()
 	for _, buf := range b.buffersToReclaim {
 		b.db.pool.Put(buf)
 	}
 
 	// Ensure we don't attempt to reclaim twice.
 	b.buffersToReclaim = nil
+	b.reclaimLock.Unlock()
 
 	// It is possible that we may accidentally call commit twice.
 	// In this case, we only unlock if we hold the lock to avoid a panic.
@@ -247,12 +250,14 @@ func (b *BadgerTransaction) Discard(context.Context) {
 	b.txn.Discard()
 
 	// Reclaim all allocated buffers for future work.
+	b.reclaimLock.Lock()
 	for _, buf := range b.buffersToReclaim {
 		b.db.pool.Put(buf)
 	}
 
 	// Ensure we don't attempt to reclaim twice.
 	b.buffersToReclaim = nil
+	b.reclaimLock.Unlock()
 
 	if b.holdsLock {
 		b.db.writer.Unlock()
@@ -264,12 +269,14 @@ func (b *BadgerTransaction) Set(
 	ctx context.Context,
 	key []byte,
 	value []byte,
+	reclaimValue bool,
 ) error {
-	b.buffersToReclaim = append(
-		b.buffersToReclaim,
-		bytes.NewBuffer(key),
-		bytes.NewBuffer(value),
-	)
+	if reclaimValue {
+		b.buffersToReclaim = append(
+			b.buffersToReclaim,
+			bytes.NewBuffer(value),
+		)
+	}
 
 	return b.txn.Set(key, value)
 }
@@ -297,7 +304,6 @@ func (b *BadgerTransaction) Get(
 
 	b.buffersToReclaim = append(
 		b.buffersToReclaim,
-		bytes.NewBuffer(key),
 		value,
 	)
 	return true, value.Bytes(), nil

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -187,6 +187,13 @@ type BadgerTransaction struct {
 
 	holdsLock bool
 
+	// We MUST wait to reclaim any memory until after
+	// the transaction is committed or discarded.
+	// Source: https://godoc.org/github.com/dgraph-io/badger#Txn.Set
+	//
+	// It is also CRITICALLY IMPORTANT that the same
+	// buffer is not added to the BufferPool multiple
+	// times. This will almost certainly lead to a panic.
 	reclaimLock      sync.Mutex
 	buffersToReclaim []*bytes.Buffer
 }

--- a/storage/badger_storage_test.go
+++ b/storage/badger_storage_test.go
@@ -234,7 +234,7 @@ func TestBadgerTrain_Limit(t *testing.T) {
 	// Load storage with entries in namespace
 	namespace := "bogus"
 	txn := database.NewDatabaseTransaction(ctx, true)
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < 10000; i++ {
 		output, err := reggen.Generate(`[a-z]+`, 50)
 		assert.NoError(t, err)
 		entry := &BogusEntry{
@@ -285,7 +285,7 @@ func TestBadgerTrain_Limit(t *testing.T) {
 	assert.NoError(t, err)
 
 	txn2 := database2.NewDatabaseTransaction(ctx, true)
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < 10000; i++ {
 		output, err := reggen.Generate(`[a-z]+`, 50)
 		assert.NoError(t, err)
 		entry := &BogusEntry{

--- a/storage/badger_storage_test.go
+++ b/storage/badger_storage_test.go
@@ -48,7 +48,7 @@ func TestDatabase(t *testing.T) {
 
 	t.Run("Set key", func(t *testing.T) {
 		txn := database.NewDatabaseTransaction(ctx, true)
-		err := txn.Set(ctx, []byte("hello"), []byte("hola"))
+		err := txn.Set(ctx, []byte("hello"), []byte("hola"), true)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 	})
@@ -68,7 +68,7 @@ func TestDatabase(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			k := []byte(fmt.Sprintf("test/%d", i))
 			v := []byte(fmt.Sprintf("%d", i))
-			err := txn.Set(ctx, k, v)
+			err := txn.Set(ctx, k, v, true)
 			assert.NoError(t, err)
 
 			storedValues = append(storedValues, &ScanItem{
@@ -80,7 +80,7 @@ func TestDatabase(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			k := []byte(fmt.Sprintf("testing/%d", i))
 			v := []byte(fmt.Sprintf("%d", i))
-			err := txn.Set(ctx, k, v)
+			err := txn.Set(ctx, k, v, true)
 			assert.NoError(t, err)
 		}
 
@@ -127,7 +127,7 @@ func TestDatabaseTransaction(t *testing.T) {
 
 	t.Run("Set and get within a transaction", func(t *testing.T) {
 		txn := database.NewDatabaseTransaction(ctx, true)
-		assert.NoError(t, txn.Set(ctx, []byte("hello"), []byte("hola")))
+		assert.NoError(t, txn.Set(ctx, []byte("hello"), []byte("hola"), true))
 
 		// Ensure tx does not affect db
 		txn2 := database.NewDatabaseTransaction(ctx, false)
@@ -149,7 +149,7 @@ func TestDatabaseTransaction(t *testing.T) {
 
 	t.Run("Discard transaction", func(t *testing.T) {
 		txn := database.NewDatabaseTransaction(ctx, true)
-		assert.NoError(t, txn.Set(ctx, []byte("hello"), []byte("world")))
+		assert.NoError(t, txn.Set(ctx, []byte("hello"), []byte("world"), true))
 		txn.Discard(ctx)
 
 		txn2 := database.NewDatabaseTransaction(ctx, false)
@@ -200,7 +200,7 @@ func TestBadgerTrain_NoLimit(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(
 			t,
-			txn.Set(ctx, []byte(fmt.Sprintf("%s/%d", namespace, i)), compressedEntry),
+			txn.Set(ctx, []byte(fmt.Sprintf("%s/%d", namespace, i)), compressedEntry, true),
 		)
 	}
 	assert.NoError(t, txn.Commit(ctx))
@@ -245,7 +245,7 @@ func TestBadgerTrain_Limit(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(
 			t,
-			txn.Set(ctx, []byte(fmt.Sprintf("%s/%d", namespace, i)), compressedEntry),
+			txn.Set(ctx, []byte(fmt.Sprintf("%s/%d", namespace, i)), compressedEntry, true),
 		)
 	}
 	assert.NoError(t, txn.Commit(ctx))
@@ -296,7 +296,7 @@ func TestBadgerTrain_Limit(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(
 			t,
-			txn2.Set(ctx, []byte(fmt.Sprintf("%s/%d", namespace, i)), compressedEntry),
+			txn2.Set(ctx, []byte(fmt.Sprintf("%s/%d", namespace, i)), compressedEntry, true),
 		)
 	}
 	assert.NoError(t, txn2.Commit(ctx))

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -175,7 +175,7 @@ func (b *BalanceStorage) SetBalance(
 		return err
 	}
 
-	if err := dbTransaction.Set(ctx, key, serialBal); err != nil {
+	if err := dbTransaction.Set(ctx, key, serialBal, true); err != nil {
 		return err
 	}
 
@@ -225,7 +225,7 @@ func (b *BalanceStorage) Reconciled(
 		return fmt.Errorf("%w: unable to encod balance entry", err)
 	}
 
-	if err := dbTransaction.Set(ctx, key, serialBal); err != nil {
+	if err := dbTransaction.Set(ctx, key, serialBal, true); err != nil {
 		return fmt.Errorf("%w: unable to set balance entry", err)
 	}
 
@@ -344,7 +344,11 @@ func (b *BalanceStorage) UpdateBalance(
 		return err
 	}
 
-	return dbTransaction.Set(ctx, key, serialBal)
+	if err := dbTransaction.Set(ctx, key, serialBal, true); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // GetBalance returns all the balances of a types.AccountIdentifier

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -166,7 +166,7 @@ func (b *BalanceStorage) SetBalance(
 ) error {
 	namespace, key := GetBalanceKey(account, amount.Currency)
 
-	serialBal, err := b.db.Compressor().Encode(namespace, &balanceEntry{
+	serialBal, err := b.db.Compressor().Encode(namespace, balanceEntry{
 		Account: account,
 		Amount:  amount,
 		Block:   block,
@@ -332,7 +332,7 @@ func (b *BalanceStorage) UpdateBalance(
 		)
 	}
 
-	serialBal, err := b.db.Compressor().Encode(namespace, &balanceEntry{
+	serialBal, err := b.db.Compressor().Encode(namespace, balanceEntry{
 		Account: change.Account,
 		Amount: &types.Amount{
 			Value:    newVal,

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -169,7 +169,11 @@ func (b *BlockStorage) StoreHeadBlockIdentifier(
 		return err
 	}
 
-	return transaction.Set(ctx, getHeadBlockKey(), buf)
+	if err := transaction.Set(ctx, getHeadBlockKey(), buf, true); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (b *BlockStorage) getBlockResponse(
@@ -294,7 +298,7 @@ func (b *BlockStorage) storeBlock(
 		return fmt.Errorf("%w: unable to encode block", err)
 	}
 
-	if err := storeUniqueKey(ctx, transaction, key, buf); err != nil {
+	if err := storeUniqueKey(ctx, transaction, key, buf, true); err != nil {
 		return fmt.Errorf("%w: unable to store block", err)
 	}
 
@@ -303,6 +307,7 @@ func (b *BlockStorage) storeBlock(
 		transaction,
 		getBlockIndexKey(blockIdentifier.Index),
 		key,
+		false,
 	); err != nil {
 		return fmt.Errorf("%w: unable to store block index", err)
 	}
@@ -530,6 +535,7 @@ func storeUniqueKey(
 	transaction DatabaseTransaction,
 	key []byte,
 	value []byte,
+	reclaimValue bool,
 ) error {
 	exists, _, err := transaction.Get(ctx, key)
 	if err != nil {
@@ -540,7 +546,7 @@ func storeUniqueKey(
 		return fmt.Errorf("%w: duplicate key %s found", ErrDuplicateKey, string(key))
 	}
 
-	return transaction.Set(ctx, key, value)
+	return transaction.Set(ctx, key, value, reclaimValue)
 }
 
 func (b *BlockStorage) storeTransaction(
@@ -583,7 +589,11 @@ func (b *BlockStorage) storeTransaction(
 		return fmt.Errorf("%w: unable to encode transaction data", err)
 	}
 
-	return transaction.Set(ctx, hashKey, encodedResult)
+	if err := transaction.Set(ctx, hashKey, encodedResult, true); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (b *BlockStorage) removeTransaction(
@@ -622,7 +632,11 @@ func (b *BlockStorage) removeTransaction(
 		return fmt.Errorf("%w: unable to encode transaction data", err)
 	}
 
-	return transaction.Set(ctx, hashKey, encodedResult)
+	if err := transaction.Set(ctx, hashKey, encodedResult, true); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // FindTransaction returns the most recent *types.BlockIdentifier containing the

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -328,7 +328,7 @@ func (b *BroadcastStorage) Broadcast(
 		return fmt.Errorf("already broadcasting transaction %s", transactionIdentifier.Hash)
 	}
 
-	bytes, err := b.db.Compressor().Encode(namespace, &Broadcast{
+	bytes, err := b.db.Compressor().Encode(namespace, Broadcast{
 		Identifier:            identifier,
 		NetworkIdentifier:     network,
 		TransactionIdentifier: transactionIdentifier,

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -251,7 +251,7 @@ func (b *BroadcastStorage) AddingBlock(
 				return nil, fmt.Errorf("%w: unable to encode updated broadcast", err)
 			}
 
-			if err := transaction.Set(ctx, key, bytes); err != nil {
+			if err := transaction.Set(ctx, key, bytes, true); err != nil {
 				return nil, fmt.Errorf("%w: unable to update broadcast", err)
 			}
 
@@ -341,7 +341,7 @@ func (b *BroadcastStorage) Broadcast(
 		return fmt.Errorf("%w: unable to encode broadcast", err)
 	}
 
-	if err := dbTx.Set(ctx, broadcastKey, bytes); err != nil {
+	if err := dbTx.Set(ctx, broadcastKey, bytes, true); err != nil {
 		return fmt.Errorf("%w: unable to set broadcast", err)
 	}
 
@@ -393,7 +393,7 @@ func (b *BroadcastStorage) performBroadcast(
 	txn := b.db.NewDatabaseTransaction(ctx, true)
 	defer txn.Discard(ctx)
 
-	if err := txn.Set(ctx, key, bytes); err != nil {
+	if err := txn.Set(ctx, key, bytes, true); err != nil {
 		return fmt.Errorf("%w: unable to update broadcast", err)
 	}
 

--- a/storage/buffer_pool.go
+++ b/storage/buffer_pool.go
@@ -43,6 +43,12 @@ func (p *BufferPool) Put(buffer *bytes.Buffer) {
 	p.pool.Put(buffer)
 }
 
+// PutByteSlice creates a *bytes.Buffer from the provided
+// []byte and stores it in the pool for reuse.
+func (p *BufferPool) PutByteSlice(buffer []byte) {
+	p.Put(bytes.NewBuffer(buffer))
+}
+
 // Get returns a new or reused *bytes.Buffer.
 func (p *BufferPool) Get() *bytes.Buffer {
 	return p.pool.Get().(*bytes.Buffer)

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -28,6 +29,12 @@ import (
 const (
 	coinNamespace        = "coin"
 	coinAccountNamespace = "coin-account"
+)
+
+var (
+	// ErrCoinNotFound is returned when a coin is not found
+	// in CoinStorage.
+	ErrCoinNotFound = errors.New("coin not found")
 )
 
 var _ BlockWorker = (*CoinStorage)(nil)
@@ -87,29 +94,29 @@ func (c *CoinStorage) getAndDecodeCoin(
 	ctx context.Context,
 	transaction DatabaseTransaction,
 	coinIdentifier *types.CoinIdentifier,
-) (bool, *types.Coin, error) {
+) (bool, *types.Coin, *types.AccountIdentifier, error) {
 	namespace, key := getCoinKey(coinIdentifier)
 	exists, val, err := transaction.Get(ctx, key)
 	if err != nil {
-		return false, nil, fmt.Errorf("%w: unable to query for coin", err)
+		return false, nil, nil, fmt.Errorf("%w: unable to query for coin", err)
 	}
 
 	if !exists { // this could occur if coin was created before we started syncing
-		return false, nil, nil
+		return false, nil, nil, nil
 	}
 
-	var coin types.Coin
-	if err := c.db.Compressor().Decode(namespace, val, &coin); err != nil {
-		return false, nil, fmt.Errorf("%w: unable to decode coin", err)
+	var accountCoin AccountCoin
+	if err := c.db.Compressor().Decode(namespace, val, &accountCoin); err != nil {
+		return false, nil, nil, fmt.Errorf("%w: unable to decode coin", err)
 	}
 
-	return true, &coin, nil
+	return true, accountCoin.Coin, accountCoin.Account, nil
 }
 
 // AccountCoin contains an AccountIdentifier and a Coin that it owns
 type AccountCoin struct {
-	Account *types.AccountIdentifier
-	Coin    *types.Coin
+	Account *types.AccountIdentifier `json:"account"`
+	Coin    *types.Coin              `json:"coin"`
 }
 
 // AddCoins takes an array of AccountCoins and saves them to the database.
@@ -122,7 +129,7 @@ func (c *CoinStorage) AddCoins(
 	defer dbTransaction.Discard(ctx)
 
 	for _, accountCoin := range accountCoins {
-		exists, _, err := c.getAndDecodeCoin(ctx, dbTransaction, accountCoin.Coin.CoinIdentifier)
+		exists, _, _, err := c.getAndDecodeCoin(ctx, dbTransaction, accountCoin.Coin.CoinIdentifier)
 		if err != nil {
 			return fmt.Errorf("%w: unable to get coin", err)
 		}
@@ -151,7 +158,10 @@ func (c *CoinStorage) addCoin(
 	transaction DatabaseTransaction,
 ) error {
 	namespace, key := getCoinKey(coin.CoinIdentifier)
-	encodedResult, err := c.db.Compressor().Encode(namespace, coin)
+	encodedResult, err := c.db.Compressor().Encode(namespace, AccountCoin{
+		Account: account,
+		Coin:    coin,
+	})
 	if err != nil {
 		return fmt.Errorf("%w: unable to encode coin data", err)
 	}
@@ -354,7 +364,7 @@ func (c *CoinStorage) GetCoinsTransactional(
 
 	coinArr := []*types.Coin{}
 	for coinIdentifier := range coins {
-		exists, coin, err := c.getAndDecodeCoin(
+		exists, coin, _, err := c.getAndDecodeCoin(
 			ctx,
 			dbTx,
 			&types.CoinIdentifier{Identifier: coinIdentifier},
@@ -382,6 +392,36 @@ func (c *CoinStorage) GetCoins(
 	defer dbTx.Discard(ctx)
 
 	return c.GetCoinsTransactional(ctx, dbTx, accountIdentifier)
+}
+
+// GetCoinTransactional returns a *types.Coin by its identifier in a database
+// transaction.
+func (c *CoinStorage) GetCoinTransactional(
+	ctx context.Context,
+	dbTx DatabaseTransaction,
+	coinIdentifier *types.CoinIdentifier,
+) (*types.Coin, *types.AccountIdentifier, error) {
+	exists, coin, owner, err := c.getAndDecodeCoin(ctx, dbTx, coinIdentifier)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: unable to lookup coin", err)
+	}
+
+	if !exists {
+		return nil, nil, ErrCoinNotFound
+	}
+
+	return coin, owner, nil
+}
+
+// GetCoin returns a *types.Coin by its identifier.
+func (c *CoinStorage) GetCoin(
+	ctx context.Context,
+	coinIdentifier *types.CoinIdentifier,
+) (*types.Coin, *types.AccountIdentifier, error) {
+	dbTx := c.db.NewDatabaseTransaction(ctx, false)
+	defer dbTx.Discard(ctx)
+
+	return c.GetCoinTransactional(ctx, dbTx, coinIdentifier)
 }
 
 // GetLargestCoin returns the largest Coin for a

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -166,11 +166,17 @@ func (c *CoinStorage) addCoin(
 		return fmt.Errorf("%w: unable to encode coin data", err)
 	}
 
-	if err := storeUniqueKey(ctx, transaction, key, encodedResult); err != nil {
+	if err := storeUniqueKey(ctx, transaction, key, encodedResult, true); err != nil {
 		return fmt.Errorf("%w: unable to store coin", err)
 	}
 
-	if err := storeUniqueKey(ctx, transaction, getCoinAccountCoin(account, coin.CoinIdentifier), []byte("")); err != nil {
+	if err := storeUniqueKey(
+		ctx,
+		transaction,
+		getCoinAccountCoin(account, coin.CoinIdentifier),
+		[]byte(""),
+		false,
+	); err != nil {
 		return fmt.Errorf("%w: unable to store account coin", err)
 	}
 

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -424,6 +425,12 @@ func TestCoinStorage(t *testing.T) {
 	c := NewCoinStorage(database, mockHelper, a)
 
 	t.Run("AddCoins before blocks", func(t *testing.T) {
+		// Ensure correct status is thrown when can't get coin
+		coin, owner, err := c.GetCoin(ctx, coins5.CoinIdentifier)
+		assert.True(t, errors.Is(err, ErrCoinNotFound))
+		assert.Nil(t, coin)
+		assert.Nil(t, owner)
+
 		accountCoins := []*AccountCoin{
 			{
 				Account: account4,
@@ -457,10 +464,20 @@ func TestCoinStorage(t *testing.T) {
 		assert.Equal(t, blockIdentifier, block)
 		assert.ElementsMatch(t, coinsGot, []*types.Coin{coins5})
 
+		coin, owner, err = c.GetCoin(ctx, coins5.CoinIdentifier)
+		assert.NoError(t, err)
+		assert.Equal(t, coins5, coin)
+		assert.Equal(t, account5, owner)
+
 		coinsGot, block, err = c.GetCoins(ctx, account4)
 		assert.NoError(t, err)
 		assert.Equal(t, blockIdentifier, block)
 		assert.ElementsMatch(t, coinsGot, []*types.Coin{coins4})
+
+		coin, owner, err = c.GetCoin(ctx, coins4.CoinIdentifier)
+		assert.NoError(t, err)
+		assert.Equal(t, coins4, coin)
+		assert.Equal(t, account4, owner)
 	})
 
 	t.Run("get coins of unset account", func(t *testing.T) {

--- a/storage/compressor.go
+++ b/storage/compressor.go
@@ -120,12 +120,11 @@ func (c *Compressor) Decode(namespace string, input []byte, object interface{}) 
 		return fmt.Errorf("%w: unable to decompress raw bytes", err)
 	}
 
-	buf := bytes.NewBuffer(decompressed)
-	if err := getDecoder(buf).Decode(&object); err != nil {
+	if err := getDecoder(bytes.NewReader(decompressed)).Decode(&object); err != nil {
 		return fmt.Errorf("%w: unable to decode bytes", err)
 	}
 
-	c.pool.Put(buf)
+	c.pool.Put(bytes.NewBuffer(decompressed))
 	return nil
 }
 

--- a/storage/compressor.go
+++ b/storage/compressor.go
@@ -124,7 +124,7 @@ func (c *Compressor) Decode(namespace string, input []byte, object interface{}) 
 		return fmt.Errorf("%w: unable to decode bytes", err)
 	}
 
-	c.pool.Put(bytes.NewBuffer(decompressed))
+	c.pool.PutByteSlice(decompressed)
 	return nil
 }
 

--- a/storage/compressor_test.go
+++ b/storage/compressor_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+)
+
+func runCompressions(c *Compressor, t *testing.T) {
+	for i := int64(0); i < 500; i++ {
+		b := &types.BlockIdentifier{
+			Index: i,
+			Hash:  fmt.Sprintf("block %d", i),
+		}
+
+		bEnc, err := c.Encode("", b)
+		assert.NoError(t, err)
+
+		tx := &types.Transaction{
+			TransactionIdentifier: &types.TransactionIdentifier{Hash: fmt.Sprintf("tx %d", i)},
+		}
+		txEnc, err := c.Encode("", tx)
+		assert.NoError(t, err)
+
+		block := &types.Block{
+			BlockIdentifier:       b,
+			ParentBlockIdentifier: b,
+			Transactions:          []*types.Transaction{tx},
+		}
+		blockEnc, err := c.Encode("", block)
+		assert.NoError(t, err)
+
+		var bDec types.BlockIdentifier
+		assert.NoError(t, c.Decode("", bEnc, &bDec))
+		assert.Equal(t, types.Hash(b), types.Hash(bDec))
+		c.pool.Put(bytes.NewBuffer(bEnc))
+
+		var txDec types.Transaction
+		assert.NoError(t, c.Decode("", txEnc, &txDec))
+		assert.Equal(t, types.Hash(tx), types.Hash(txDec))
+		c.pool.Put(bytes.NewBuffer(txEnc))
+
+		var blockDec types.Block
+		assert.NoError(t, c.Decode("", blockEnc, &blockDec))
+		assert.Equal(t, types.Hash(block), types.Hash(blockDec))
+		c.pool.Put(bytes.NewBuffer(blockEnc))
+	}
+}
+
+func TestCompressor(t *testing.T) {
+	c, err := NewCompressor(nil, NewBufferPool())
+	assert.NoError(t, err)
+
+	g, _ := errgroup.WithContext(context.Background())
+
+	for i := 0; i < 10; i++ {
+		g.Go(func() error {
+			runCompressions(c, t)
+
+			return nil
+		})
+	}
+
+	assert.NoError(t, g.Wait())
+}

--- a/storage/counter_storage.go
+++ b/storage/counter_storage.go
@@ -113,7 +113,7 @@ func (c *CounterStorage) UpdateTransactional(
 
 	newVal := new(big.Int).Add(val, amount)
 
-	if err := dbTx.Set(ctx, getCounterKey(counter), newVal.Bytes()); err != nil {
+	if err := dbTx.Set(ctx, getCounterKey(counter), newVal.Bytes(), false); err != nil {
 		return nil, err
 	}
 

--- a/storage/job_storage.go
+++ b/storage/job_storage.go
@@ -190,7 +190,7 @@ func (j *JobStorage) getNextIdentifier(
 		return "", fmt.Errorf("%w: unable to encode job identifier", err)
 	}
 
-	if err := dbTx.Set(ctx, k, encoded); err != nil {
+	if err := dbTx.Set(ctx, k, encoded, true); err != nil {
 		return "", fmt.Errorf("%w: unable to update job identifier", err)
 	}
 
@@ -208,7 +208,7 @@ func (j *JobStorage) updateIdentifiers(
 		return fmt.Errorf("%w: unable to encode identifiers", err)
 	}
 
-	if err := dbTx.Set(ctx, k, encoded); err != nil {
+	if err := dbTx.Set(ctx, k, encoded, true); err != nil {
 		return fmt.Errorf("%w: unable to set identifiers", err)
 	}
 
@@ -355,7 +355,7 @@ func (j *JobStorage) Update(
 		return "", fmt.Errorf("%w: unable to encode job", err)
 	}
 
-	if err := dbTx.Set(ctx, k, encoded); err != nil {
+	if err := dbTx.Set(ctx, k, encoded, true); err != nil {
 		return "", fmt.Errorf("%w: unable to update job", err)
 	}
 

--- a/storage/key_storage.go
+++ b/storage/key_storage.go
@@ -124,7 +124,7 @@ func (k *KeyStorage) StoreTransactional(
 		return fmt.Errorf("%w: unable to serialize key", err)
 	}
 
-	err = dbTx.Set(ctx, getAddressKey(address), val)
+	err = dbTx.Set(ctx, getAddressKey(address), val, true)
 	if err != nil {
 		return fmt.Errorf("%w: unable to store key", err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -40,7 +40,7 @@ type Database interface {
 // all memory utilized is reclaimed. If you want to persist
 // any data retrieved, make sure to make a copy!
 type DatabaseTransaction interface {
-	Set(context.Context, []byte, []byte) error
+	Set(context.Context, []byte, []byte, bool) error
 	Get(context.Context, []byte) (bool, []byte, error)
 	Delete(context.Context, []byte) error
 


### PR DESCRIPTION
Blocked by (rebased on): https://github.com/coinbase/rosetta-sdk-go/pull/135

This PR makes it possible to lookup Coins by their identifier. This is useful for building indexers on top of the `syncer` package.

### Changes
- [x] Lookup `*types.Coin` by `*types.CoinIdentifier`
- [x] Don't create a pointer when invoking `Encode` (avoid heap allocation)
- [x] Ensure we never put duplicate values into `sync.Pool`
  - As a rule of thumb, only `Put` in the `sync.Pool` if you created the bytes (otherwise very hard to track where duplicate additions could be).
  - Additionally, never `Put` any inputs into the `sync.Pool`. The responsibility to reclaim `bytes` should be on the caller.