### PR TITLE
[Fetcher] Improve Connection Reuse

### DIFF
--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -33,6 +33,13 @@ func (f *Fetcher) AccountBalance(
 	account *types.AccountIdentifier,
 	block *types.PartialBlockIdentifier,
 ) (*types.BlockIdentifier, []*types.Amount, []*types.Coin, map[string]interface{}, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, nil, nil, nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.AccountAPI.AccountBalance(ctx,
 		&types.AccountBalanceRequest{
 			NetworkIdentifier: network,

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -25,6 +25,20 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	// goalRoutineReuse is the minimum number of requests we want to make
+	// on each goroutine created to fetch block transactions.
+	goalRoutineReuse = 6
+
+	// maxRoutines is the maximum number of goroutines we should create
+	// to fetch block transactions.
+	maxRoutines = 32
+
+	// minRoutines is the minimum number of goroutines we should create
+	// to fetch block transactions.
+	minRoutines = 1
+)
+
 // addTransactionIdentifiers appends a slice of
 // types.TransactionIdentifiers to a channel.
 // When all types.TransactionIdentifiers are added,
@@ -124,7 +138,17 @@ func (f *Fetcher) UnsafeTransactions(
 		return addTransactionIdentifiers(ctx, txsToFetch, transactionIdentifiers)
 	})
 
-	for i := uint64(0); i < f.transactionConcurrency; i++ {
+	// Calculate the concurrency we wish to use to fetch transactions. If we pick
+	// a high number, we will still be limited by the fetcher connection semaphore.
+	transactionConcurrency := int(float64(len(transactionIdentifiers)) / float64(goalRoutineReuse))
+	if transactionConcurrency > maxRoutines {
+		transactionConcurrency = maxRoutines
+	}
+	if transactionConcurrency < minRoutines {
+		transactionConcurrency = minRoutines
+	}
+
+	for i := 0; i < transactionConcurrency; i++ {
 		g.Go(func() error {
 			err := f.fetchChannelTransactions(ctx, network, block, txsToFetch, fetchedTxs)
 			if err != nil {

--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -33,15 +33,6 @@ func WithClient(client *client.APIClient) Option {
 	}
 }
 
-// WithTransactionConcurrency overrides the default transaction
-// concurrency.
-// TODO: remove
-func WithTransactionConcurrency(concurrency uint64) Option {
-	return func(f *Fetcher) {
-		f.transactionConcurrency = concurrency
-	}
-}
-
 // WithMaxRetries overrides the default number of retries on
 // a request.
 func WithMaxRetries(maxRetries uint64) Option {

--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -15,8 +15,6 @@
 package fetcher
 
 import (
-	"crypto/tls"
-	"net/http"
 	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -76,12 +74,7 @@ func WithAsserter(asserter *asserter.Asserter) Option {
 // attack!!
 func WithInsecureTLS() Option {
 	return func(f *Fetcher) {
-		// See this conversation around why `.Clone()` is used here:
-		// https://github.com/golang/go/issues/26013
-		customTransport := http.DefaultTransport.(*http.Transport).Clone()
-		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
-
-		f.rosettaClient.GetConfig().HTTPClient.Transport = customTransport
+		f.insecureTLS = true
 	}
 }
 

--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -35,6 +35,7 @@ func WithClient(client *client.APIClient) Option {
 
 // WithTransactionConcurrency overrides the default transaction
 // concurrency.
+// TODO: remove
 func WithTransactionConcurrency(concurrency uint64) Option {
 	return func(f *Fetcher) {
 		f.transactionConcurrency = concurrency
@@ -82,5 +83,13 @@ func WithInsecureTLS() Option {
 func WithTimeout(timeout time.Duration) Option {
 	return func(f *Fetcher) {
 		f.rosettaClient.GetConfig().HTTPClient.Timeout = timeout
+	}
+}
+
+// WithMaxConnections limits the number of concurrent
+// requests the fetcher will attempt at once.
+func WithMaxConnections(connections int) Option {
+	return func(f *Fetcher) {
+		f.maxConnections = connections
 	}
 }

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -34,6 +34,13 @@ func (f *Fetcher) ConstructionCombine(
 	unsignedTransaction string,
 	signatures []*types.Signature,
 ) (string, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return "", &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionCombine(ctx,
 		&types.ConstructionCombineRequest{
 			NetworkIdentifier:   network,
@@ -70,6 +77,13 @@ func (f *Fetcher) ConstructionDerive(
 	publicKey *types.PublicKey,
 	metadata map[string]interface{},
 ) (string, map[string]interface{}, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return "", nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionDerive(ctx,
 		&types.ConstructionDeriveRequest{
 			NetworkIdentifier: network,
@@ -102,6 +116,13 @@ func (f *Fetcher) ConstructionHash(
 	network *types.NetworkIdentifier,
 	signedTransaction string,
 ) (*types.TransactionIdentifier, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionHash(ctx,
 		&types.ConstructionHashRequest{
 			NetworkIdentifier: network,
@@ -134,6 +155,13 @@ func (f *Fetcher) ConstructionMetadata(
 	options map[string]interface{},
 	publicKeys []*types.PublicKey,
 ) (map[string]interface{}, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	metadata, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionMetadata(ctx,
 		&types.ConstructionMetadataRequest{
 			NetworkIdentifier: network,
@@ -170,6 +198,13 @@ func (f *Fetcher) ConstructionParse(
 	signed bool,
 	transaction string,
 ) ([]*types.Operation, []string, map[string]interface{}, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, nil, nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionParse(ctx,
 		&types.ConstructionParseRequest{
 			NetworkIdentifier: network,
@@ -213,6 +248,13 @@ func (f *Fetcher) ConstructionPayloads(
 	metadata map[string]interface{},
 	publicKeys []*types.PublicKey,
 ) (string, []*types.SigningPayload, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return "", nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionPayloads(ctx,
 		&types.ConstructionPayloadsRequest{
 			NetworkIdentifier: network,
@@ -253,6 +295,13 @@ func (f *Fetcher) ConstructionPreprocess(
 	operations []*types.Operation,
 	metadata map[string]interface{},
 ) (map[string]interface{}, []*types.AccountIdentifier, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionPreprocess(ctx,
 		&types.ConstructionPreprocessRequest{
 			NetworkIdentifier: network,
@@ -286,6 +335,13 @@ func (f *Fetcher) ConstructionSubmit(
 	network *types.NetworkIdentifier,
 	signedTransaction string,
 ) (*types.TransactionIdentifier, map[string]interface{}, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	submitResponse, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionSubmit(
 		ctx,
 		&types.ConstructionSubmitRequest{

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetcher
+
+import (
+	"errors"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+// Error wraps the two possible types of error responses returned
+// by the Rosetta Client
+type Error struct {
+	Err       error        `json:"err"`
+	ClientErr *types.Error `json:"client_err"`
+}
+
+var (
+	// ErrNoNetworks is returned when there are no
+	// networks available for syncing.
+	ErrNoNetworks = errors.New("no networks available")
+
+	// ErrNetworkMissing is returned during asserter initialization
+	// when the provided *types.NetworkIdentifier is not in the
+	// *types.NetworkListResponse.
+	ErrNetworkMissing = errors.New("network missing")
+
+	// ErrRequestFailed is returned when a request fails.
+	ErrRequestFailed = errors.New("request failed")
+
+	// ErrExhaustedRetries is returned when a request with retries
+	// fails because it was attempted too many times.
+	ErrExhaustedRetries = errors.New("retries exhausted")
+
+	// ErrAssertionFailed is returned when a fetch succeeds
+	// but fails assertion.
+	ErrAssertionFailed = errors.New("assertion failed")
+
+	// ErrCouldNotAcquireSemaphore is returned when acquiring
+	// the connection semaphore returns an error.
+	ErrCouldNotAcquireSemaphore = errors.New("could not acquire semaphore")
+)

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -41,13 +41,6 @@ const (
 	// HTTP requests.
 	DefaultHTTPTimeout = 10 * time.Second
 
-	// DefaultTransactionConcurrency is the default
-	// number of transactions a Fetcher will try to
-	// get concurrently when populating a block (if
-	// transactions are not included in the original
-	// block fetch).
-	DefaultTransactionConcurrency = 8
-
 	// DefaultUserAgent is the default userAgent
 	// to populate on requests to a Rosetta server.
 	DefaultUserAgent = "rosetta-sdk-go"
@@ -67,56 +60,22 @@ const (
 	semaphoreRequestWeight = int64(1)
 )
 
-var (
-	// ErrNoNetworks is returned when there are no
-	// networks available for syncing.
-	ErrNoNetworks = errors.New("no networks available")
-
-	// ErrNetworkMissing is returned during asserter initialization
-	// when the provided *types.NetworkIdentifier is not in the
-	// *types.NetworkListResponse.
-	ErrNetworkMissing = errors.New("network missing")
-
-	// ErrRequestFailed is returned when a request fails.
-	ErrRequestFailed = errors.New("request failed")
-
-	// ErrExhaustedRetries is returned when a request with retries
-	// fails because it was attempted too many times.
-	ErrExhaustedRetries = errors.New("retries exhausted")
-
-	// ErrAssertionFailed is returned when a fetch succeeds
-	// but fails assertion.
-	ErrAssertionFailed = errors.New("assertion failed")
-
-	// ErrCouldNotAcquireSemaphore is returned when acquiring
-	// the connection semaphore returns an error.
-	ErrCouldNotAcquireSemaphore = errors.New("could not acquire semaphore")
-)
-
 // Fetcher contains all logic to communicate with a Rosetta Server.
 type Fetcher struct {
 	// Asserter is a public variable because
 	// it can be used to determine if a retrieved
 	// types.Operation is successful and should
 	// be applied.
-	Asserter               *asserter.Asserter
-	rosettaClient          *client.APIClient
-	maxConnections         int
-	transactionConcurrency uint64
-	maxRetries             uint64
-	retryElapsedTime       time.Duration
-	insecureTLS            bool
+	Asserter         *asserter.Asserter
+	rosettaClient    *client.APIClient
+	maxConnections   int
+	maxRetries       uint64
+	retryElapsedTime time.Duration
+	insecureTLS      bool
 
 	// connectionSemaphore is used to limit the
 	// number of concurrent requests we make.
 	connectionSemaphore *semaphore.Weighted
-}
-
-// Error wraps the two possible types of error responses returned
-// by the Rosetta Client
-type Error struct {
-	Err       error        `json:"err"`
-	ClientErr *types.Error `json:"client_err"`
 }
 
 // New constructs a new Fetcher with provided options.
@@ -134,11 +93,10 @@ func New(
 	client := client.NewAPIClient(clientCfg)
 
 	f := &Fetcher{
-		rosettaClient:          client,
-		maxConnections:         DefaultMaxConnections,
-		transactionConcurrency: DefaultTransactionConcurrency,
-		maxRetries:             DefaultRetries,
-		retryElapsedTime:       DefaultElapsedTime,
+		rosettaClient:    client,
+		maxConnections:   DefaultMaxConnections,
+		maxRetries:       DefaultRetries,
+		retryElapsedTime: DefaultElapsedTime,
 	}
 
 	// Override defaults with any provided options

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -29,6 +29,13 @@ func (f *Fetcher) Mempool(
 	ctx context.Context,
 	network *types.NetworkIdentifier,
 ) ([]*types.TransactionIdentifier, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.MempoolAPI.Mempool(
 		ctx,
 		&types.NetworkRequest{
@@ -61,6 +68,13 @@ func (f *Fetcher) MempoolTransaction(
 	network *types.NetworkIdentifier,
 	transaction *types.TransactionIdentifier,
 ) (*types.Transaction, map[string]interface{}, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	response, clientErr, err := f.rosettaClient.MempoolAPI.MempoolTransaction(
 		ctx,
 		&types.MempoolTransactionRequest{

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -31,6 +31,13 @@ func (f *Fetcher) NetworkStatus(
 	network *types.NetworkIdentifier,
 	metadata map[string]interface{},
 ) (*types.NetworkStatusResponse, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	networkStatus, clientErr, err := f.rosettaClient.NetworkAPI.NetworkStatus(
 		ctx,
 		&types.NetworkRequest{
@@ -108,6 +115,13 @@ func (f *Fetcher) NetworkList(
 	ctx context.Context,
 	metadata map[string]interface{},
 ) (*types.NetworkListResponse, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	networkList, clientErr, err := f.rosettaClient.NetworkAPI.NetworkList(
 		ctx,
 		&types.MetadataRequest{
@@ -180,6 +194,13 @@ func (f *Fetcher) NetworkOptions(
 	network *types.NetworkIdentifier,
 	metadata map[string]interface{},
 ) (*types.NetworkOptionsResponse, *Error) {
+	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
+		return nil, &Error{
+			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
+		}
+	}
+	defer f.connectionSemaphore.Release(semaphoreRequestWeight)
+
 	networkOptions, clientErr, err := f.rosettaClient.NetworkAPI.NetworkOptions(
 		ctx,
 		&types.NetworkRequest{

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -326,6 +326,7 @@ func (b *BadgerTransaction) Delete(ctx context.Context, key []byte) error {
 func (b *BadgerTransaction) Scan(
 	ctx context.Context,
 	prefix []byte,
+	logEntries bool,
 ) ([]*ScanItem, error) {
 	entries := 0
 	values := []*ScanItem{}
@@ -353,7 +354,7 @@ func (b *BadgerTransaction) Scan(
 		)
 
 		entries++
-		if entries%logModulo == 0 {
+		if logEntries && entries%logModulo == 0 {
 			log.Printf("scanned %d entries for %s\n", entries, string(prefix))
 		}
 	}
@@ -367,6 +368,7 @@ func (b *BadgerTransaction) LimitedMemoryScan(
 	ctx context.Context,
 	prefix []byte,
 	worker func([]byte, []byte) error,
+	logEntries bool,
 ) (int, error) {
 	entries := 0
 	opts := badger.DefaultIteratorOptions
@@ -388,7 +390,7 @@ func (b *BadgerTransaction) LimitedMemoryScan(
 		}
 
 		entries++
-		if entries%logModulo == 0 {
+		if logEntries && entries%logModulo == 0 {
 			log.Printf("scanned %d entries for %s\n", entries, string(prefix))
 		}
 	}
@@ -489,6 +491,7 @@ func recompress(
 
 			return nil
 		},
+		true,
 	)
 	if err != nil {
 		return -1, -1, fmt.Errorf("%w: unable to recompress", err)
@@ -567,6 +570,7 @@ func BadgerTrain(
 
 			return nil
 		},
+		true,
 	)
 	if err != nil && !errors.Is(err, errMaxEntries) {
 		return -1, -1, fmt.Errorf("%w: unable to scan for %s", err, namespace)

--- a/storage/badger_storage_test.go
+++ b/storage/badger_storage_test.go
@@ -84,7 +84,7 @@ func TestDatabase(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		values, err := txn.Scan(ctx, []byte("test/"))
+		values, err := txn.Scan(ctx, []byte("test/"), false)
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, storedValues, values)
 
@@ -106,6 +106,7 @@ func TestDatabase(t *testing.T) {
 
 				return nil
 			},
+			false,
 		)
 		assert.NoError(t, err)
 		assert.Equal(t, 100, numValues)

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -519,6 +519,7 @@ func (b *BalanceStorage) getAllBalanceEntries(
 			handler(deserialBal)
 			return nil
 		},
+		false,
 	)
 	if err != nil {
 		return fmt.Errorf("%w: database scan failed", err)

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -242,27 +242,27 @@ func (b *BalanceStorage) ReconciliationCoverage(
 	ctx context.Context,
 	minimumIndex int64,
 ) (float64, error) {
-	balances, err := b.getAllBalanceEntries(ctx)
+	seen := 0
+	validCoverage := 0
+	err := b.getAllBalanceEntries(ctx, func(entry balanceEntry) {
+		seen++
+		if entry.LastReconciled == nil {
+			return
+		}
+
+		if entry.LastReconciled.Index >= minimumIndex {
+			validCoverage++
+		}
+	})
 	if err != nil {
 		return -1, fmt.Errorf("%w: unable to get all balance entries", err)
 	}
 
-	if len(balances) == 0 {
+	if seen == 0 {
 		return 0, nil
 	}
 
-	validCoverage := 0
-	for _, b := range balances {
-		if b.LastReconciled == nil {
-			continue
-		}
-
-		if b.LastReconciled.Index >= minimumIndex {
-			validCoverage++
-		}
-	}
-
-	return float64(validCoverage) / float64(len(balances)), nil
+	return float64(validCoverage) / float64(seen), nil
 }
 
 // UpdateBalance updates a types.AccountIdentifer
@@ -495,8 +495,10 @@ func (b *BalanceStorage) BootstrapBalances(
 	return nil
 }
 
-func (b *BalanceStorage) getAllBalanceEntries(ctx context.Context) ([]*balanceEntry, error) {
-	balances := []*balanceEntry{}
+func (b *BalanceStorage) getAllBalanceEntries(
+	ctx context.Context,
+	handler func(balanceEntry),
+) error {
 	namespace := balanceNamespace
 	txn := b.db.NewDatabaseTransaction(ctx, false)
 	defer txn.Discard(ctx)
@@ -514,16 +516,15 @@ func (b *BalanceStorage) getAllBalanceEntries(ctx context.Context) ([]*balanceEn
 				)
 			}
 
-			balances = append(balances, &deserialBal)
-
+			handler(deserialBal)
 			return nil
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("%w: database scan failed", err)
+		return fmt.Errorf("%w: database scan failed", err)
 	}
 
-	return balances, nil
+	return nil
 }
 
 // GetAllAccountCurrency scans the db for all balances and returns a slice
@@ -534,8 +535,10 @@ func (b *BalanceStorage) GetAllAccountCurrency(
 ) ([]*reconciler.AccountCurrency, error) {
 	log.Println("Loading previously seen accounts (this could take a while)...")
 
-	balances, err := b.getAllBalanceEntries(ctx)
-	if err != nil {
+	balances := []*balanceEntry{}
+	if err := b.getAllBalanceEntries(ctx, func(entry balanceEntry) {
+		balances = append(balances, &entry)
+	}); err != nil {
 		return nil, fmt.Errorf("%w: unable to get all balance entries", err)
 	}
 

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -353,7 +353,7 @@ func (b *BroadcastStorage) getAllBroadcasts(
 	dbTx DatabaseTransaction,
 ) ([]*Broadcast, error) {
 	namespace := transactionBroadcastNamespace
-	rawBroadcasts, err := dbTx.Scan(ctx, []byte(namespace))
+	rawBroadcasts, err := dbTx.Scan(ctx, []byte(namespace), false)
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to scan for all broadcasts", err)
 	}

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -188,7 +188,7 @@ func getAndDecodeCoins(
 	transaction DatabaseTransaction,
 	accountIdentifier *types.AccountIdentifier,
 ) (map[string]struct{}, error) {
-	items, err := transaction.Scan(ctx, getCoinAccountPrefix(accountIdentifier))
+	items, err := transaction.Scan(ctx, getCoinAccountPrefix(accountIdentifier), false)
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to query coins for account", err)
 	}

--- a/storage/key_storage.go
+++ b/storage/key_storage.go
@@ -189,7 +189,7 @@ func (k *KeyStorage) GetAllAddressesTransactional(
 	ctx context.Context,
 	dbTx DatabaseTransaction,
 ) ([]string, error) {
-	rawKeys, err := dbTx.Scan(ctx, []byte(keyNamespace))
+	rawKeys, err := dbTx.Scan(ctx, []byte(keyNamespace), false)
 	if err != nil {
 		return nil, fmt.Errorf("%w database scan for keys failed", err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -44,11 +44,16 @@ type DatabaseTransaction interface {
 	Get(context.Context, []byte) (bool, []byte, error)
 	Delete(context.Context, []byte) error
 
-	Scan(ctx context.Context, prefix []byte) ([]*ScanItem, error)
+	Scan(
+		context.Context,
+		[]byte,
+		bool, // log entries
+	) ([]*ScanItem, error)
 	LimitedMemoryScan(
 		context.Context,
 		[]byte,
 		func([]byte, []byte) error,
+		bool, // log entries
 	) (int, error)
 
 	Commit(context.Context) error


### PR DESCRIPTION
Blocked by (rebased on): #136

When using the `fetcher` concurrently, it is sometimes possible to surpass the port allocation on the OS. After some research, I determined this was due to not effectively reusing connections. Based on the info in [this thread](https://stackoverflow.com/questions/37774624/go-http-get-concurrency-and-connection-reset-by-peer), I have tuned `IdleConnTimeout`, `MaxIdleConns`, and `MaxIdleConnsPerHost` accordingly.

### Changes
- [x] increase `MaxIdleConns`
- [x] increase `IdleConnTimeout`
- [x] max total connections in fetcher (enforced by semaphore in autogen client) -> default to `120` as most systems have a default max of `128`
- [x] remove `TransactionConcurrency` and set automatically as some % of transactions to fetch (having multiple toggles here is confusing)
- [x] (unrelated) optimize address scan for reconciliation coverage check