### PR TITLE
[Replaced] [Storage] Getter memory optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_PACKAGES=./asserter/... ./fetcher/... ./types/... ./client/... ./server/... \
 	./parser/... ./syncer/... ./reconciler/... ./keys/... \
 	./statefulsyncer/... ./storage/... ./utils/... ./constructor/... ./errors/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
-TEST_SCRIPT=go test -failfast -v ${GO_PACKAGES}
+TEST_SCRIPT=go test -failfast ${GO_PACKAGES}
 LINT_SETTINGS=golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam
 
 deps:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_PACKAGES=./asserter/... ./fetcher/... ./types/... ./client/... ./server/... \
 	./parser/... ./syncer/... ./reconciler/... ./keys/... \
 	./statefulsyncer/... ./storage/... ./utils/... ./constructor/... ./errors/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
-TEST_SCRIPT=go test ${GO_PACKAGES}
+TEST_SCRIPT=go test -failfast -v ${GO_PACKAGES}
 LINT_SETTINGS=golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam
 
 deps:

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -859,15 +859,13 @@ func TestFindBalanceWorker(t *testing.T) {
 			// Setup DB
 			dir, err := utils.CreateTempDir()
 			assert.NoError(t, err)
-			defer utils.RemoveTempDir(dir)
 
 			db, err := storage.NewBadgerStorage(ctx, dir)
 			assert.NoError(t, err)
 			assert.NotNil(t, db)
-			defer db.Close(ctx)
 
 			dbTx := db.NewDatabaseTransaction(ctx, true)
-			defer dbTx.Discard(ctx)
+			assert.NotNil(t, dbTx)
 
 			worker := New(test.mockHelper)
 			output, err := worker.FindBalanceWorker(ctx, dbTx, types.PrintStruct(test.input))
@@ -878,6 +876,10 @@ func TestFindBalanceWorker(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, types.PrintStruct(test.output), output)
 			}
+
+			dbTx.Discard(ctx)
+			db.Close(ctx)
+			utils.RemoveTempDir(dir)
 
 			test.mockHelper.AssertExpectations(t)
 		})

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1299,6 +1299,7 @@ func TestJob_Failures(t *testing.T) {
 			defer db.Close(ctx)
 
 			dbTx := db.NewDatabaseTransaction(ctx, true)
+			defer dbTx.Discard(ctx)
 
 			assert.False(t, j.CheckComplete())
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/zstd v1.4.5
 	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/dgraph-io/badger/v2 v2.2007.1
+	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/ethereum/go-ethereum v1.9.20

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/decred/dcrd/lru v1.0.0 h1:Kbsb1SFDsIlaupWPwsPp+dkxiBY1frcS07PCPgotKz8
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/dgraph-io/badger/v2 v2.2007.1 h1:t36VcBCpo4SsmAD5M8wVv1ieVzcALyGfaJ92z4ccULM=
 github.com/dgraph-io/badger/v2 v2.2007.1/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
+github.com/dgraph-io/badger/v2 v2.2007.2 h1:EjjK0KqwaFMlPin1ajhP943VPENHJdEz1KLIegjaI3k=
+github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.0.3 h1:jh22xisGBjrEVnRZ1DVTpBVQm0Xndu8sMl0CWDzSIBI=
 github.com/dgraph-io/ristretto v0.0.3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -39,8 +39,8 @@ const (
 	// DefaultBlockCacheSize is 0 MB.
 	DefaultBlockCacheSize = 0
 
-	// DefaultIndexCacheSize is 500 MB.
-	DefaultIndexCacheSize = 500 << 20
+	// DefaultIndexCacheSize is 2 GB.
+	DefaultIndexCacheSize = 2000 << 20
 
 	// DefaultMaxTableSize is 256 MB. The larger
 	// this value is, the larger database transactions
@@ -53,7 +53,7 @@ const (
 	// Default GC settings for reclaiming
 	// space in value logs.
 	defaultGCInterval     = 1 * time.Minute
-	defualtGCDiscardRatio = 0.2
+	defualtGCDiscardRatio = 0.1
 	defaultGCSleep        = 10 * time.Second
 )
 
@@ -83,9 +83,6 @@ func defaultBadgerOptions(dir string) badger.Options {
 	// transactions (which are capped at 20% of MaxTableSize).
 	opts.MaxTableSize = DefaultMaxTableSize
 
-	// LoadBloomsOnOpen=false greatly improves the db startup speed.
-	opts.LoadBloomsOnOpen = false
-
 	// To allow writes at a faster speed, we create a new memtable as soon as
 	// an existing memtable is filled up. This option determines how many
 	// memtables should be kept in memory.
@@ -100,10 +97,6 @@ func defaultBadgerOptions(dir string) badger.Options {
 	// it uses much less memory than RAM but is much faster than
 	// FileIO.
 	opts.TableLoadingMode = options.MemoryMap
-
-	// ValueLogLoadingMode ensures we don't load large value logs into
-	// memory.
-	opts.ValueLogLoadingMode = options.FileIO
 
 	// This option will have a significant effect the memory. If the level is kept
 	// in-memory, read are faster but the tables will be kept in memory. By default,
@@ -132,6 +125,13 @@ func defaultBadgerOptions(dir string) badger.Options {
 // Inspired by: https://github.com/dgraph-io/badger/issues/1304
 func lowMemoryOptions(dir string) badger.Options {
 	opts := defaultBadgerOptions(dir)
+
+	// LoadBloomsOnOpen=false greatly improves the db startup speed.
+	opts.LoadBloomsOnOpen = false
+
+	// ValueLogLoadingMode ensures we don't load large value logs into
+	// memory.
+	opts.ValueLogLoadingMode = options.FileIO
 
 	// Don't load tables into memory.
 	opts.TableLoadingMode = options.FileIO

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"
@@ -48,6 +49,12 @@ const (
 
 	bytesInMb = 1000000
 	logModulo = 5000
+
+	// Default GC settings for reclaiming
+	// space in value logs.
+	defaultGCInterval     = 1 * time.Minute
+	defualtGCDiscardRatio = 0.2
+	defaultGCSleep        = 10 * time.Second
 )
 
 // BadgerStorage is a wrapper around Badger DB
@@ -144,19 +151,59 @@ func NewBadgerStorage(ctx context.Context, dir string, options ...BadgerOption) 
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrDatabaseOpenFailed, err)
 	}
+	b.db = db
 
-	pool := NewBufferPool()
+	b.pool = NewBufferPool()
 
-	compressor, err := NewCompressor(b.compressorEntries, pool)
+	compressor, err := NewCompressor(b.compressorEntries, b.pool)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrCompressorLoadFailed, err)
 	}
+	b.compressor = compressor
 
-	return &BadgerStorage{
-		db:         db,
-		pool:       pool,
-		compressor: compressor,
-	}, nil
+	// Start periodic ValueGC goroutine (up to user of BadgerDB to call
+	// periodically to reclaim value logs on-disk).
+	go b.periodicGC(ctx)
+
+	return b, nil
+}
+
+// periodicGC attempts to reclaim storage every
+// defaultGCInterval.
+//
+// Inspired by:
+// https://github.com/ipfs/go-ds-badger/blob/a69f1020ba3954680900097e0c9d0181b88930ad/datastore.go#L173-L199
+func (b *BadgerStorage) periodicGC(ctx context.Context) {
+	// We start the timeout with the default sleep to aggressively check
+	// for space to reclaim on startup.
+	gcTimeout := time.NewTimer(defaultGCSleep)
+	defer gcTimeout.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-gcTimeout.C:
+			err := b.db.RunValueLogGC(defualtGCDiscardRatio)
+			switch err {
+			case badger.ErrNoRewrite, badger.ErrRejected:
+				// No rewrite means we've fully garbage collected.
+				// Rejected means someone else is running a GC
+				// or we're closing.
+				gcTimeout.Reset(defaultGCInterval)
+			case nil:
+				// Nil error means that we've successfully garbage
+				// collected. We should sleep instead of waiting
+				// the full GC collection interval to see if there
+				// is anything else to collect.
+				gcTimeout.Reset(defaultGCSleep)
+			default:
+				// Not much we can do on a random error but log it and continue.
+				log.Printf("error during a GC cycle: %s\n", err.Error())
+				gcTimeout.Reset(defaultGCInterval)
+			}
+		}
+	}
 }
 
 // Close closes the database to prevent corruption.

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -198,6 +198,7 @@ func (b *BadgerStorage) periodicGC(ctx context.Context) {
 			return
 		case <-gcTimeout.C:
 			b.closer.Lock()
+			start := time.Now()
 			err := b.db.RunValueLogGC(defualtGCDiscardRatio)
 			switch err {
 			case badger.ErrNoRewrite, badger.ErrRejected:
@@ -210,6 +211,7 @@ func (b *BadgerStorage) periodicGC(ctx context.Context) {
 				// collected. We should sleep instead of waiting
 				// the full GC collection interval to see if there
 				// is anything else to collect.
+				log.Printf("successful value log garbage collection (%s)", time.Since(start))
 				gcTimeout.Reset(defaultGCSleep)
 			default:
 				// Not much we can do on a random error but log it and continue.

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -177,7 +177,7 @@ func NewBadgerStorage(ctx context.Context, dir string, options ...BadgerOption) 
 
 	// Start periodic ValueGC goroutine (up to user of BadgerDB to call
 	// periodically to reclaim value logs on-disk).
-	// go b.periodicGC(ctx)
+	go b.periodicGC(ctx)
 
 	return b, nil
 }

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -234,12 +234,12 @@ func (b *BadgerStorage) periodicGC(ctx context.Context) {
 // The caller should defer this in main.
 func (b *BadgerStorage) Close(ctx context.Context) error {
 	b.closer.Lock()
+	close(b.closing)
+	b.closer.Unlock()
+
 	if err := b.db.Close(); err != nil {
 		return fmt.Errorf("%w: %v", ErrDBCloseFailed, err)
 	}
-
-	close(b.closing)
-	b.closer.Unlock()
 
 	return nil
 }

--- a/storage/badger_storage_configuration.go
+++ b/storage/badger_storage_configuration.go
@@ -34,3 +34,11 @@ func WithCompressorEntries(entries []*CompressorEntry) BadgerOption {
 		b.compressorEntries = entries
 	}
 }
+
+// WithIndexCacheSize override the DefaultIndexCacheSize
+// setting for the BadgerDB. The size here is in bytes.
+func WithIndexCacheSize(size int64) BadgerOption {
+	return func(b *BadgerStorage) {
+		b.indexCacheSize = size
+	}
+}

--- a/storage/badger_storage_test.go
+++ b/storage/badger_storage_test.go
@@ -31,11 +31,13 @@ func TestDatabase(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	t.Run("No key exists", func(t *testing.T) {
 		txn := database.NewDatabaseTransaction(ctx, false)
@@ -121,11 +123,13 @@ func TestDatabaseTransaction(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	t.Run("Set and get within a transaction", func(t *testing.T) {
 		txn := database.NewDatabaseTransaction(ctx, true)

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -204,7 +204,7 @@ func (b *BalanceStorage) Reconciled(
 	}
 
 	var bal balanceEntry
-	if err := b.db.Compressor().Decode(namespace, balance, &bal); err != nil {
+	if err := b.db.Compressor().Decode(namespace, balance, &bal, true); err != nil {
 		return fmt.Errorf("%w: unable to decode balance entry", err)
 	}
 
@@ -281,7 +281,7 @@ func (b *BalanceStorage) UpdateBalance(
 		// This could happen if balances are bootstrapped and should not be
 		// overridden.
 		var bal balanceEntry
-		err := b.db.Compressor().Decode(namespace, balance, &bal)
+		err := b.db.Compressor().Decode(namespace, balance, &bal, true)
 		if err != nil {
 			return err
 		}
@@ -407,7 +407,7 @@ func (b *BalanceStorage) GetBalanceTransactional(
 	}
 
 	var popBal balanceEntry
-	err = b.db.Compressor().Decode(namespace, bal, &popBal)
+	err = b.db.Compressor().Decode(namespace, bal, &popBal, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -492,12 +492,12 @@ func (b *BalanceStorage) getAllBalanceEntries(
 	namespace := balanceNamespace
 	txn := b.db.NewDatabaseTransaction(ctx, false)
 	defer txn.Discard(ctx)
-	_, err := txn.LimitedMemoryScan(
+	_, err := txn.Scan(
 		ctx,
 		[]byte(namespace),
 		func(k []byte, v []byte) error {
 			var deserialBal balanceEntry
-			err := b.db.Compressor().Decode(namespace, v, &deserialBal)
+			err := b.db.Compressor().Decode(namespace, v, &deserialBal, false)
 			if err != nil {
 				return fmt.Errorf(
 					"%w: unable to parse balance entry for %s",

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -295,7 +295,6 @@ func TestBalance(t *testing.T) {
 
 		// Get balance during transaction
 		readTx := storage.db.NewDatabaseTransaction(ctx, false)
-		defer readTx.Discard(ctx)
 		retrievedAmount, block, err := storage.GetBalanceTransactional(
 			ctx,
 			readTx,
@@ -306,6 +305,7 @@ func TestBalance(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, result, retrievedAmount)
 		assert.Equal(t, newBlock2, block)
+		readTx.Discard(ctx)
 
 		txn.Discard(ctx)
 	})

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -143,11 +143,13 @@ func TestBalance(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBalanceStorage(database)
 	storage.Initialize(mockHelper, nil)
@@ -528,11 +530,13 @@ func TestSetBalanceImported(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBalanceStorage(database)
 	storage.Initialize(mockHelper, nil)
@@ -583,11 +587,13 @@ func TestBootstrapBalances(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBalanceStorage(database)
 	bootstrapBalancesFile := path.Join(newDir, "balances.csv")
@@ -765,11 +771,13 @@ func TestBalanceReconciliation(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBalanceStorage(database)
 	storage.Initialize(mockHelper, nil)

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -131,7 +131,7 @@ func (b *BlockStorage) GetHeadBlockIdentifierTransactional(
 	}
 
 	var blockIdentifier types.BlockIdentifier
-	err = b.db.Compressor().Decode("", block, &blockIdentifier)
+	err = b.db.Compressor().Decode("", block, &blockIdentifier, true)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (b *BlockStorage) getBlockResponse(
 	}
 
 	var rosettaBlockResponse types.BlockResponse
-	err = b.db.Compressor().Decode(namespace, blockResponse, &rosettaBlockResponse)
+	err = b.db.Compressor().Decode(namespace, blockResponse, &rosettaBlockResponse, true)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +547,7 @@ func (b *BlockStorage) storeTransaction(
 	if !exists {
 		blocks = make(map[string]*blockTransaction)
 	} else {
-		if err := b.db.Compressor().Decode(namespace, val, &blocks); err != nil {
+		if err := b.db.Compressor().Decode(namespace, val, &blocks, true); err != nil {
 			return fmt.Errorf("%w: could not decode transaction hash contents", err)
 		}
 
@@ -595,7 +595,7 @@ func (b *BlockStorage) removeTransaction(
 	}
 
 	var blocks map[string]*blockTransaction
-	if err := b.db.Compressor().Decode(namespace, val, &blocks); err != nil {
+	if err := b.db.Compressor().Decode(namespace, val, &blocks, true); err != nil {
 		return fmt.Errorf("%w: could not decode transaction hash contents", err)
 	}
 
@@ -639,7 +639,7 @@ func (b *BlockStorage) FindTransaction(
 	}
 
 	var blocks map[string]*blockTransaction
-	if err := b.db.Compressor().Decode(namespace, tx, &blocks); err != nil {
+	if err := b.db.Compressor().Decode(namespace, tx, &blocks, true); err != nil {
 		return nil, nil, fmt.Errorf("%w: unable to decode block data for transaction", err)
 	}
 
@@ -673,7 +673,7 @@ func (b *BlockStorage) findBlockTransaction(
 	}
 
 	var blocks map[string]*blockTransaction
-	if err := b.db.Compressor().Decode(namespace, tx, &blocks); err != nil {
+	if err := b.db.Compressor().Decode(namespace, tx, &blocks, true); err != nil {
 		return nil, fmt.Errorf("%w: unable to decode block data for transaction", err)
 	}
 

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -41,11 +41,13 @@ func TestHeadBlockIdentifier(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBlockStorage(database)
 
@@ -298,11 +300,13 @@ func TestBlock(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBlockStorage(database)
 
@@ -510,11 +514,13 @@ func TestManyBlocks(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBlockStorage(database)
 
@@ -549,11 +555,13 @@ func TestCreateBlockCache(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBlockStorage(database)
 
@@ -609,11 +617,13 @@ func TestAtTip(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	storage := NewBlockStorage(database)
 	tipDelay := int64(100)

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -355,19 +355,23 @@ func (b *BroadcastStorage) getAllBroadcasts(
 	dbTx DatabaseTransaction,
 ) ([]*Broadcast, error) {
 	namespace := transactionBroadcastNamespace
-	rawBroadcasts, err := dbTx.Scan(ctx, []byte(namespace), false)
+	broadcasts := []*Broadcast{}
+	_, err := dbTx.Scan(
+		ctx,
+		[]byte(namespace),
+		func(k []byte, v []byte) error {
+			var broadcast Broadcast
+			if err := b.db.Compressor().Decode(namespace, v, &broadcast, false); err != nil {
+				return fmt.Errorf("%w: %v", ErrBroadcastDecodeFailed, err)
+			}
+
+			broadcasts = append(broadcasts, &broadcast)
+			return nil
+		},
+		false,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrBroadcastScanFailed, err)
-	}
-
-	broadcasts := make([]*Broadcast, len(rawBroadcasts))
-	for i, rawBroadcast := range rawBroadcasts {
-		var broadcast Broadcast
-		if err := b.db.Compressor().Decode(namespace, rawBroadcast.Value, &broadcast); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrBroadcastDecodeFailed, err)
-		}
-
-		broadcasts[i] = &broadcast
 	}
 
 	return broadcasts, nil

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -389,11 +389,13 @@ func TestCoinStorage(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	a, err := asserter.NewClientWithOptions(
 		&types.NetworkIdentifier{

--- a/storage/compressor.go
+++ b/storage/compressor.go
@@ -115,7 +115,12 @@ func getDecoder(r io.Reader) *msgpack.Decoder {
 
 // Decode attempts to decompress the object and will use a dict if
 // one exists for the namespace.
-func (c *Compressor) Decode(namespace string, input []byte, object interface{}) error {
+func (c *Compressor) Decode(
+	namespace string,
+	input []byte,
+	object interface{},
+	reclaimInput bool,
+) error {
 	decompressed, err := c.DecodeRaw(namespace, input)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrRawDecompressFailed, err)
@@ -126,6 +131,9 @@ func (c *Compressor) Decode(namespace string, input []byte, object interface{}) 
 	}
 
 	c.pool.PutByteSlice(decompressed)
+	if reclaimInput {
+		c.pool.PutByteSlice(input)
+	}
 	return nil
 }
 

--- a/storage/compressor_test.go
+++ b/storage/compressor_test.go
@@ -15,7 +15,6 @@
 package storage
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -51,19 +50,16 @@ func runCompressions(c *Compressor, t *testing.T) {
 		assert.NoError(t, err)
 
 		var bDec types.BlockIdentifier
-		assert.NoError(t, c.Decode("", bEnc, &bDec))
+		assert.NoError(t, c.Decode("", bEnc, &bDec, true))
 		assert.Equal(t, types.Hash(b), types.Hash(bDec))
-		c.pool.Put(bytes.NewBuffer(bEnc))
 
 		var txDec types.Transaction
-		assert.NoError(t, c.Decode("", txEnc, &txDec))
+		assert.NoError(t, c.Decode("", txEnc, &txDec, true))
 		assert.Equal(t, types.Hash(tx), types.Hash(txDec))
-		c.pool.Put(bytes.NewBuffer(txEnc))
 
 		var blockDec types.Block
-		assert.NoError(t, c.Decode("", blockEnc, &blockDec))
+		assert.NoError(t, c.Decode("", blockEnc, &blockDec, true))
 		assert.Equal(t, types.Hash(block), types.Hash(blockDec))
-		c.pool.Put(bytes.NewBuffer(blockEnc))
 	}
 }
 

--- a/storage/counter_storage_test.go
+++ b/storage/counter_storage_test.go
@@ -29,11 +29,13 @@ func TestCounterStorage(t *testing.T) {
 
 	newDir, err := utils.CreateTempDir()
 	assert.NoError(t, err)
-	defer utils.RemoveTempDir(newDir)
 
 	database, err := NewBadgerStorage(ctx, newDir)
 	assert.NoError(t, err)
-	defer database.Close(ctx)
+	defer func() {
+		database.Close(ctx)
+		utils.RemoveTempDir(newDir)
+	}()
 
 	c := NewCounterStorage(database)
 

--- a/storage/job_storage.go
+++ b/storage/job_storage.go
@@ -84,7 +84,7 @@ func (j *JobStorage) getAllJobs(
 	}
 
 	var identifiers map[string]struct{}
-	err = j.db.Compressor().Decode("", v, &identifiers, false)
+	err = j.db.Compressor().Decode("", v, &identifiers, true)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 	}
@@ -176,7 +176,7 @@ func (j *JobStorage) getNextIdentifier(
 	// Get existing identifier
 	var nextIdentifier int
 	if exists {
-		err = j.db.Compressor().Decode("", v, &nextIdentifier, false)
+		err = j.db.Compressor().Decode("", v, &nextIdentifier, true)
 		if err != nil {
 			return "", fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 		}
@@ -228,7 +228,7 @@ func (j *JobStorage) addJob(
 
 	var identifiers map[string]struct{}
 	if exists {
-		err = j.db.Compressor().Decode("", v, &identifiers, false)
+		err = j.db.Compressor().Decode("", v, &identifiers, true)
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 		}
@@ -257,7 +257,7 @@ func (j *JobStorage) removeJob(
 		return fmt.Errorf("%w %s from %s", ErrJobIdentifierRemoveFailed, identifier, string(k))
 	}
 
-	err = j.db.Compressor().Decode("", v, &identifiers, false)
+	err = j.db.Compressor().Decode("", v, &identifiers, true)
 	if err != nil {
 		return fmt.Errorf("%w: unable to decode existing identifier", err)
 	}
@@ -383,7 +383,7 @@ func (j *JobStorage) Get(
 	}
 
 	var output job.Job
-	err = j.db.Compressor().Decode("", v, &output, false)
+	err = j.db.Compressor().Decode("", v, &output, true)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrJobDecodeFailed, err)
 	}

--- a/storage/job_storage.go
+++ b/storage/job_storage.go
@@ -84,7 +84,7 @@ func (j *JobStorage) getAllJobs(
 	}
 
 	var identifiers map[string]struct{}
-	err = j.db.Compressor().Decode("", v, &identifiers, true)
+	err = j.db.Compressor().Decode("", v, &identifiers, false)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 	}
@@ -176,7 +176,7 @@ func (j *JobStorage) getNextIdentifier(
 	// Get existing identifier
 	var nextIdentifier int
 	if exists {
-		err = j.db.Compressor().Decode("", v, &nextIdentifier, true)
+		err = j.db.Compressor().Decode("", v, &nextIdentifier, false)
 		if err != nil {
 			return "", fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 		}
@@ -228,7 +228,7 @@ func (j *JobStorage) addJob(
 
 	var identifiers map[string]struct{}
 	if exists {
-		err = j.db.Compressor().Decode("", v, &identifiers, true)
+		err = j.db.Compressor().Decode("", v, &identifiers, false)
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 		}
@@ -257,7 +257,7 @@ func (j *JobStorage) removeJob(
 		return fmt.Errorf("%w %s from %s", ErrJobIdentifierRemoveFailed, identifier, string(k))
 	}
 
-	err = j.db.Compressor().Decode("", v, &identifiers, true)
+	err = j.db.Compressor().Decode("", v, &identifiers, false)
 	if err != nil {
 		return fmt.Errorf("%w: unable to decode existing identifier", err)
 	}
@@ -383,7 +383,7 @@ func (j *JobStorage) Get(
 	}
 
 	var output job.Job
-	err = j.db.Compressor().Decode("", v, &output, true)
+	err = j.db.Compressor().Decode("", v, &output, false)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrJobDecodeFailed, err)
 	}

--- a/storage/job_storage.go
+++ b/storage/job_storage.go
@@ -84,7 +84,7 @@ func (j *JobStorage) getAllJobs(
 	}
 
 	var identifiers map[string]struct{}
-	err = j.db.Compressor().Decode("", v, &identifiers)
+	err = j.db.Compressor().Decode("", v, &identifiers, true)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 	}
@@ -176,7 +176,7 @@ func (j *JobStorage) getNextIdentifier(
 	// Get existing identifier
 	var nextIdentifier int
 	if exists {
-		err = j.db.Compressor().Decode("", v, &nextIdentifier)
+		err = j.db.Compressor().Decode("", v, &nextIdentifier, true)
 		if err != nil {
 			return "", fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 		}
@@ -228,7 +228,7 @@ func (j *JobStorage) addJob(
 
 	var identifiers map[string]struct{}
 	if exists {
-		err = j.db.Compressor().Decode("", v, &identifiers)
+		err = j.db.Compressor().Decode("", v, &identifiers, true)
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 		}
@@ -257,7 +257,7 @@ func (j *JobStorage) removeJob(
 		return fmt.Errorf("%w %s from %s", ErrJobIdentifierRemoveFailed, identifier, string(k))
 	}
 
-	err = j.db.Compressor().Decode("", v, &identifiers)
+	err = j.db.Compressor().Decode("", v, &identifiers, true)
 	if err != nil {
 		return fmt.Errorf("%w: unable to decode existing identifier", err)
 	}
@@ -383,7 +383,7 @@ func (j *JobStorage) Get(
 	}
 
 	var output job.Job
-	err = j.db.Compressor().Decode("", v, &output)
+	err = j.db.Compressor().Decode("", v, &output, true)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrJobDecodeFailed, err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,12 +18,6 @@ import (
 	"context"
 )
 
-// ScanItem is returned by a call to Scan.
-type ScanItem struct {
-	Key   []byte
-	Value []byte
-}
-
 // Database is an interface that provides transactional
 // access to a KV store.
 type Database interface {
@@ -43,13 +37,7 @@ type DatabaseTransaction interface {
 	Set(context.Context, []byte, []byte, bool) error
 	Get(context.Context, []byte) (bool, []byte, error)
 	Delete(context.Context, []byte) error
-
 	Scan(
-		context.Context,
-		[]byte,
-		bool, // log entries
-	) ([]*ScanItem, error)
-	LimitedMemoryScan(
 		context.Context,
 		[]byte,
 		func([]byte, []byte) error,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -77,7 +77,7 @@ var (
 // CreateTempDir creates a directory in
 // /tmp for usage within testing.
 func CreateTempDir() (string, error) {
-	storageDir, err := ioutil.TempDir("", "rosetta-cli")
+	storageDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
When there are large database transactions (potentially with thousands of reads), we wait to reclaim memory until the transaction is over. We should instead reclaim memory as soon as the value is read so it can be reused.

### Changes (https://github.com/coinbase/rosetta-sdk-go/pull/143)
- [x] Add an argument to Decode indicating if memory should be reclaimed
- [x] Replace `Scan` with `LimitedMemoryScan`

### Changes
Closes #127 
- [x] Run badger garbage collection every minute (limits value log size + could save tons of space) -> https://github.com/dgraph-io/badger/blob/40afeddfc2548276973f812da63064c168ad4667/docs/content/get-started/index.md#garbage-collection
- [x] update badger db and set index cache size: https://github.com/dgraph-io/badger/pull/1473
- [x] Use settings from go-ds-badger (https://github.com/ipfs/go-ds-badger/blob/a69f1020ba3954680900097e0c9d0181b88930ad/datastore.go#L81-L108)
  - [x] value log loading mode
  - [x] compact L0 on close
  - [x] periodic garbage collection: https://github.com/ipfs/go-ds-badger/blob/a69f1020ba3954680900097e0c9d0181b88930ad/datastore.go#L173-L199
- [x] make index cache size configurable