### PR TITLE
[Storage] Optimize Memory usage on Transaction.Get

### DIFF
--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -492,7 +492,7 @@ func (b *BalanceStorage) getAllBalanceEntries(
 	namespace := balanceNamespace
 	txn := b.db.NewDatabaseTransaction(ctx, false)
 	defer txn.Discard(ctx)
-	_, err := txn.LimitedMemoryScan(
+	_, err := txn.Scan(
 		ctx,
 		[]byte(namespace),
 		func(k []byte, v []byte) error {

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -204,7 +204,7 @@ func (b *BalanceStorage) Reconciled(
 	}
 
 	var bal balanceEntry
-	if err := b.db.Compressor().Decode(namespace, balance, &bal); err != nil {
+	if err := b.db.Compressor().Decode(namespace, balance, &bal, true); err != nil {
 		return fmt.Errorf("%w: unable to decode balance entry", err)
 	}
 
@@ -281,7 +281,7 @@ func (b *BalanceStorage) UpdateBalance(
 		// This could happen if balances are bootstrapped and should not be
 		// overridden.
 		var bal balanceEntry
-		err := b.db.Compressor().Decode(namespace, balance, &bal)
+		err := b.db.Compressor().Decode(namespace, balance, &bal, true)
 		if err != nil {
 			return err
 		}
@@ -407,7 +407,7 @@ func (b *BalanceStorage) GetBalanceTransactional(
 	}
 
 	var popBal balanceEntry
-	err = b.db.Compressor().Decode(namespace, bal, &popBal)
+	err = b.db.Compressor().Decode(namespace, bal, &popBal, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -497,7 +497,8 @@ func (b *BalanceStorage) getAllBalanceEntries(
 		[]byte(namespace),
 		func(k []byte, v []byte) error {
 			var deserialBal balanceEntry
-			err := b.db.Compressor().Decode(namespace, v, &deserialBal)
+			// We should not reclaim memory during a scan!!
+			err := b.db.Compressor().Decode(namespace, v, &deserialBal, false)
 			if err != nil {
 				return fmt.Errorf(
 					"%w: unable to parse balance entry for %s",

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -131,7 +131,7 @@ func (b *BlockStorage) GetHeadBlockIdentifierTransactional(
 	}
 
 	var blockIdentifier types.BlockIdentifier
-	err = b.db.Compressor().Decode("", block, &blockIdentifier)
+	err = b.db.Compressor().Decode("", block, &blockIdentifier, true)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (b *BlockStorage) getBlockResponse(
 	}
 
 	var rosettaBlockResponse types.BlockResponse
-	err = b.db.Compressor().Decode(namespace, blockResponse, &rosettaBlockResponse)
+	err = b.db.Compressor().Decode(namespace, blockResponse, &rosettaBlockResponse, true)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +547,7 @@ func (b *BlockStorage) storeTransaction(
 	if !exists {
 		blocks = make(map[string]*blockTransaction)
 	} else {
-		if err := b.db.Compressor().Decode(namespace, val, &blocks); err != nil {
+		if err := b.db.Compressor().Decode(namespace, val, &blocks, true); err != nil {
 			return fmt.Errorf("%w: could not decode transaction hash contents", err)
 		}
 
@@ -595,7 +595,7 @@ func (b *BlockStorage) removeTransaction(
 	}
 
 	var blocks map[string]*blockTransaction
-	if err := b.db.Compressor().Decode(namespace, val, &blocks); err != nil {
+	if err := b.db.Compressor().Decode(namespace, val, &blocks, true); err != nil {
 		return fmt.Errorf("%w: could not decode transaction hash contents", err)
 	}
 
@@ -639,7 +639,7 @@ func (b *BlockStorage) FindTransaction(
 	}
 
 	var blocks map[string]*blockTransaction
-	if err := b.db.Compressor().Decode(namespace, tx, &blocks); err != nil {
+	if err := b.db.Compressor().Decode(namespace, tx, &blocks, true); err != nil {
 		return nil, nil, fmt.Errorf("%w: unable to decode block data for transaction", err)
 	}
 
@@ -673,7 +673,7 @@ func (b *BlockStorage) findBlockTransaction(
 	}
 
 	var blocks map[string]*blockTransaction
-	if err := b.db.Compressor().Decode(namespace, tx, &blocks); err != nil {
+	if err := b.db.Compressor().Decode(namespace, tx, &blocks, true); err != nil {
 		return nil, fmt.Errorf("%w: unable to decode block data for transaction", err)
 	}
 

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -361,7 +361,8 @@ func (b *BroadcastStorage) getAllBroadcasts(
 		[]byte(namespace),
 		func(k []byte, v []byte) error {
 			var broadcast Broadcast
-			if err := b.db.Compressor().Decode(namespace, v, &broadcast); err != nil {
+			// We should not reclaim memory during a scan!!
+			if err := b.db.Compressor().Decode(namespace, v, &broadcast, false); err != nil {
 				return fmt.Errorf("%w: %v", ErrBroadcastDecodeFailed, err)
 			}
 

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -355,19 +355,23 @@ func (b *BroadcastStorage) getAllBroadcasts(
 	dbTx DatabaseTransaction,
 ) ([]*Broadcast, error) {
 	namespace := transactionBroadcastNamespace
-	rawBroadcasts, err := dbTx.Scan(ctx, []byte(namespace), false)
+	broadcasts := []*Broadcast{}
+	_, err := dbTx.Scan(
+		ctx,
+		[]byte(namespace),
+		func(k []byte, v []byte) error {
+			var broadcast Broadcast
+			if err := b.db.Compressor().Decode(namespace, v, &broadcast); err != nil {
+				return fmt.Errorf("%w: %v", ErrBroadcastDecodeFailed, err)
+			}
+
+			broadcasts = append(broadcasts, &broadcast)
+			return nil
+		},
+		false,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrBroadcastScanFailed, err)
-	}
-
-	broadcasts := make([]*Broadcast, len(rawBroadcasts))
-	for i, rawBroadcast := range rawBroadcasts {
-		var broadcast Broadcast
-		if err := b.db.Compressor().Decode(namespace, rawBroadcast.Value, &broadcast); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrBroadcastDecodeFailed, err)
-		}
-
-		broadcasts[i] = &broadcast
 	}
 
 	return broadcasts, nil

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -106,7 +106,7 @@ func (c *CoinStorage) getAndDecodeCoin(
 	}
 
 	var accountCoin AccountCoin
-	if err := c.db.Compressor().Decode(namespace, val, &accountCoin); err != nil {
+	if err := c.db.Compressor().Decode(namespace, val, &accountCoin, true); err != nil {
 		return false, nil, nil, fmt.Errorf("%w: %v", ErrCoinDecodeFailed, err)
 	}
 

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -188,16 +188,20 @@ func getAndDecodeCoins(
 	transaction DatabaseTransaction,
 	accountIdentifier *types.AccountIdentifier,
 ) (map[string]struct{}, error) {
-	items, err := transaction.Scan(ctx, getCoinAccountPrefix(accountIdentifier), false)
+	coins := map[string]struct{}{}
+	_, err := transaction.Scan(
+		ctx,
+		getCoinAccountPrefix(accountIdentifier),
+		func(k []byte, v []byte) error {
+			vals := strings.Split(string(k), "/")
+			coinIdentifier := vals[len(vals)-1]
+			coins[coinIdentifier] = struct{}{}
+			return nil
+		},
+		false,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrAccountCoinQueryFailed, err)
-	}
-
-	coins := map[string]struct{}{}
-	for _, item := range items {
-		vals := strings.Split(string(item.Key), "/")
-		coinIdentifier := vals[len(vals)-1]
-		coins[coinIdentifier] = struct{}{}
 	}
 
 	return coins, nil

--- a/storage/compressor.go
+++ b/storage/compressor.go
@@ -115,7 +115,12 @@ func getDecoder(r io.Reader) *msgpack.Decoder {
 
 // Decode attempts to decompress the object and will use a dict if
 // one exists for the namespace.
-func (c *Compressor) Decode(namespace string, input []byte, object interface{}) error {
+func (c *Compressor) Decode(
+	namespace string,
+	input []byte,
+	object interface{},
+	reclaimInput bool,
+) error {
 	decompressed, err := c.DecodeRaw(namespace, input)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrRawDecompressFailed, err)
@@ -126,6 +131,9 @@ func (c *Compressor) Decode(namespace string, input []byte, object interface{}) 
 	}
 
 	c.pool.PutByteSlice(decompressed)
+	if reclaimInput {
+		c.pool.PutByteSlice(input)
+	}
 	return nil
 }
 

--- a/storage/compressor_test.go
+++ b/storage/compressor_test.go
@@ -15,7 +15,6 @@
 package storage
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -51,19 +50,16 @@ func runCompressions(c *Compressor, t *testing.T) {
 		assert.NoError(t, err)
 
 		var bDec types.BlockIdentifier
-		assert.NoError(t, c.Decode("", bEnc, &bDec))
+		assert.NoError(t, c.Decode("", bEnc, &bDec, true))
 		assert.Equal(t, types.Hash(b), types.Hash(bDec))
-		c.pool.Put(bytes.NewBuffer(bEnc))
 
 		var txDec types.Transaction
-		assert.NoError(t, c.Decode("", txEnc, &txDec))
+		assert.NoError(t, c.Decode("", txEnc, &txDec, true))
 		assert.Equal(t, types.Hash(tx), types.Hash(txDec))
-		c.pool.Put(bytes.NewBuffer(txEnc))
 
 		var blockDec types.Block
-		assert.NoError(t, c.Decode("", blockEnc, &blockDec))
+		assert.NoError(t, c.Decode("", blockEnc, &blockDec, true))
 		assert.Equal(t, types.Hash(block), types.Hash(blockDec))
-		c.pool.Put(bytes.NewBuffer(blockEnc))
 	}
 }
 

--- a/storage/job_storage.go
+++ b/storage/job_storage.go
@@ -84,7 +84,7 @@ func (j *JobStorage) getAllJobs(
 	}
 
 	var identifiers map[string]struct{}
-	err = j.db.Compressor().Decode("", v, &identifiers)
+	err = j.db.Compressor().Decode("", v, &identifiers, true)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 	}
@@ -176,7 +176,7 @@ func (j *JobStorage) getNextIdentifier(
 	// Get existing identifier
 	var nextIdentifier int
 	if exists {
-		err = j.db.Compressor().Decode("", v, &nextIdentifier)
+		err = j.db.Compressor().Decode("", v, &nextIdentifier, true)
 		if err != nil {
 			return "", fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 		}
@@ -228,7 +228,7 @@ func (j *JobStorage) addJob(
 
 	var identifiers map[string]struct{}
 	if exists {
-		err = j.db.Compressor().Decode("", v, &identifiers)
+		err = j.db.Compressor().Decode("", v, &identifiers, true)
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrJobIdentifierDecodeFailed, err)
 		}
@@ -257,7 +257,7 @@ func (j *JobStorage) removeJob(
 		return fmt.Errorf("%w %s from %s", ErrJobIdentifierRemoveFailed, identifier, string(k))
 	}
 
-	err = j.db.Compressor().Decode("", v, &identifiers)
+	err = j.db.Compressor().Decode("", v, &identifiers, true)
 	if err != nil {
 		return fmt.Errorf("%w: unable to decode existing identifier", err)
 	}
@@ -383,7 +383,7 @@ func (j *JobStorage) Get(
 	}
 
 	var output job.Job
-	err = j.db.Compressor().Decode("", v, &output)
+	err = j.db.Compressor().Decode("", v, &output, true)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrJobDecodeFailed, err)
 	}

--- a/storage/key_storage.go
+++ b/storage/key_storage.go
@@ -147,7 +147,7 @@ func (k *KeyStorage) GetTransactional(
 	}
 
 	var kp Key
-	if err := k.db.Compressor().Decode("", rawKey, &kp); err != nil {
+	if err := k.db.Compressor().Decode("", rawKey, &kp, true); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrParseSavedKeyFailed, err)
 	}
 
@@ -176,7 +176,8 @@ func (k *KeyStorage) GetAllAccountsTransactional(
 		[]byte(keyNamespace),
 		func(key []byte, v []byte) error {
 			var kp Key
-			if err := k.db.Compressor().Decode("", v, &kp); err != nil {
+			// We should not reclaim memory during a scan!!
+			if err := k.db.Compressor().Decode("", v, &kp, false); err != nil {
 				return fmt.Errorf("%w: %v", ErrKeyScanFailed, err)
 			}
 

--- a/storage/key_storage_test.go
+++ b/storage/key_storage_test.go
@@ -167,19 +167,19 @@ func TestKeyStorage(t *testing.T) {
 
 		prefundedAccs := []*PrefundedAccount{
 			{
-				PrivateKeyHex: "0e842a16b2d39a4dff5c63688513cb2109e30c3c30bc4eb502cc54f4614493f6",
-				Account:       &types.AccountIdentifier{Address: "add1"},
-				CurveType:     types.Edwards25519,
+				PrivateKeyHex:     "0e842a16b2d39a4dff5c63688513cb2109e30c3c30bc4eb502cc54f4614493f6",
+				AccountIdentifier: &types.AccountIdentifier{Address: "add1"},
+				CurveType:         types.Edwards25519,
 			},
 			{
-				PrivateKeyHex: "42efc44bdf7b2d4d45ddd6ddb727ed498c91e7070914c9ed0d80af680ff42b3e",
-				Account:       &types.AccountIdentifier{Address: "add2"},
-				CurveType:     types.Edwards25519,
+				PrivateKeyHex:     "42efc44bdf7b2d4d45ddd6ddb727ed498c91e7070914c9ed0d80af680ff42b3e",
+				AccountIdentifier: &types.AccountIdentifier{Address: "add2"},
+				CurveType:         types.Edwards25519,
 			},
 			{
-				PrivateKeyHex: "01ea48249742650907004331e85536f868e2d3959434ba751d8aa230138a9707",
-				Account:       &types.AccountIdentifier{Address: "add3"},
-				CurveType:     types.Edwards25519,
+				PrivateKeyHex:     "01ea48249742650907004331e85536f868e2d3959434ba751d8aa230138a9707",
+				AccountIdentifier: &types.AccountIdentifier{Address: "add3"},
+				CurveType:         types.Edwards25519,
 			},
 		}
 
@@ -194,9 +194,9 @@ func TestKeyStorage(t *testing.T) {
 	t.Run("does not import same key twice", func(t *testing.T) {
 		prefundedAccs := []*PrefundedAccount{
 			{
-				PrivateKeyHex: "17d08f5fe8c77af811caa0c9a187e668ce3b74a99acc3f6d976f075fa8e0be55",
-				Account:       &types.AccountIdentifier{Address: "badadd"},
-				CurveType:     types.Edwards25519,
+				PrivateKeyHex:     "17d08f5fe8c77af811caa0c9a187e668ce3b74a99acc3f6d976f075fa8e0be55",
+				AccountIdentifier: &types.AccountIdentifier{Address: "badadd"},
+				CurveType:         types.Edwards25519,
 			},
 		}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,12 +18,6 @@ import (
 	"context"
 )
 
-// ScanItem is returned by a call to Scan.
-type ScanItem struct {
-	Key   []byte
-	Value []byte
-}
-
 // Database is an interface that provides transactional
 // access to a KV store.
 type Database interface {
@@ -45,11 +39,6 @@ type DatabaseTransaction interface {
 	Delete(context.Context, []byte) error
 
 	Scan(
-		context.Context,
-		[]byte,
-		bool, // log entries
-	) ([]*ScanItem, error)
-	LimitedMemoryScan(
 		context.Context,
 		[]byte,
 		func([]byte, []byte) error,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -77,7 +77,7 @@ var (
 // CreateTempDir creates a directory in
 // /tmp for usage within testing.
 func CreateTempDir() (string, error) {
-	storageDir, err := ioutil.TempDir("", "rosetta-cli")
+	storageDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Replaces #140 

We wait to reclaim memory until a `storage.DatabaseTransaction` is committed or discarded. This leads to a large memory overhead when using a large database transaction (ex: getting all the `Coins` in a transaction). This PR changes our logic to instead reclaim memory as soon as the value is read so it can be reused.

### Changes
- [x] Do not reclaim memory on `Transaction.Get`
- [x] Replace `Scan` with `LimitedMemoryScan` (we no longer allow scanning a large number of records into memory)
- [x] Optionally reclaim memory in `Decode` (don't do during a `Scan`)