### PR TITLE
[Constructor] Suggested Fee Dry Run

### DIFF
--- a/asserter/account.go
+++ b/asserter/account.go
@@ -35,11 +35,11 @@ func ContainsCurrency(currencies []*types.Currency, currency *types.Currency) bo
 	return false
 }
 
-// assertUniqueAmounts returns an error if a slice
+// AssertUniqueAmounts returns an error if a slice
 // of types.Amount is invalid. It is considered invalid if the same
 // currency is returned multiple times (these shoould be
 // consolidated) or if a types.Amount is considered invalid.
-func assertUniqueAmounts(amounts []*types.Amount) error {
+func AssertUniqueAmounts(amounts []*types.Amount) error {
 	currencies := make([]*types.Currency, 0)
 	for _, amount := range amounts {
 		// Ensure a currency is used at most once
@@ -68,7 +68,7 @@ func AccountBalanceResponse(
 		return fmt.Errorf("%w: block identifier is invalid", err)
 	}
 
-	if err := assertUniqueAmounts(response.Balances); err != nil {
+	if err := AssertUniqueAmounts(response.Balances); err != nil {
 		return fmt.Errorf("%w: balance amounts are invalid", err)
 	}
 

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -31,6 +31,23 @@ const (
 	MaxUnixEpoch = 2209017600000
 )
 
+// Currency ensures a *types.Currency is valid.
+func Currency(currency *types.Currency) error {
+	if currency == nil {
+		return ErrAmountCurrencyIsNil
+	}
+
+	if currency.Symbol == "" {
+		return ErrAmountCurrencySymbolEmpty
+	}
+
+	if currency.Decimals < 0 {
+		return ErrAmountCurrencyHasNegDecimals
+	}
+
+	return nil
+}
+
 // Amount ensures a types.Amount has an
 // integer value, specified precision, and symbol.
 func Amount(amount *types.Amount) error {
@@ -43,19 +60,7 @@ func Amount(amount *types.Amount) error {
 		return fmt.Errorf("%w: %s", ErrAmountIsNotInt, amount.Value)
 	}
 
-	if amount.Currency == nil {
-		return ErrAmountCurrencyIsNil
-	}
-
-	if amount.Currency.Symbol == "" {
-		return ErrAmountCurrencySymbolEmpty
-	}
-
-	if amount.Currency.Decimals < 0 {
-		return ErrAmountCurrencyHasNegDecimals
-	}
-
-	return nil
+	return Currency(amount.Currency)
 }
 
 // OperationIdentifier returns an error if index of the

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -51,7 +51,7 @@ func ConstructionMetadataResponse(
 		return ErrConstructionMetadataResponseMetadataMissing
 	}
 
-	if err := assertUniqueAmounts(response.SuggestedFee); err != nil {
+	if err := AssertUniqueAmounts(response.SuggestedFee); err != nil {
 		return fmt.Errorf("%w: duplicate suggested fee currency found", err)
 	}
 

--- a/asserter/server.go
+++ b/asserter/server.go
@@ -287,7 +287,7 @@ func (a *Asserter) ConstructionPreprocessRequest(
 		return err
 	}
 
-	if err := assertUniqueAmounts(request.MaxFee); err != nil {
+	if err := AssertUniqueAmounts(request.MaxFee); err != nil {
 		return fmt.Errorf("%w: duplicate max fee currency found", err)
 	}
 

--- a/constructor/coordinator/coordinator.go
+++ b/constructor/coordinator/coordinator.go
@@ -435,7 +435,7 @@ func (c *Coordinator) invokeHandlersAndBroadcast(
 
 // Process creates and executes jobs
 // until failure.
-func (c *Coordinator) Process(
+func (c *Coordinator) Process( // nolint:gocognit
 	ctx context.Context,
 ) error {
 	for ctx.Err() == nil {

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -1245,3 +1245,235 @@ func TestInitialization_OnlyRequestFundsWorkflows(t *testing.T) {
 	helper.AssertExpectations(t)
 	handler.AssertExpectations(t)
 }
+
+func TestProcess_DryRun(t *testing.T) {
+	ctx := context.Background()
+
+	jobStorage := &mocks.JobStorage{}
+	helper := &mocks.Helper{}
+	handler := &mocks.Handler{}
+	p := defaultParser(t)
+	workflows := []*job.Workflow{
+		{
+			Name:        string(job.RequestFunds),
+			Concurrency: 1,
+		},
+		{
+			Name:        string(job.CreateAccount),
+			Concurrency: 1,
+		},
+		{
+			Name:        "transfer",
+			Concurrency: 1,
+			Scenarios: []*job.Scenario{
+				{
+					Name: "transfer_1",
+					Actions: []*job.Action{
+						{
+							Type:       job.SetVariable,
+							Input:      `{"symbol":"tBTC", "decimals":8}`,
+							OutputPath: "currency",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `{"network":"Testnet3", "blockchain":"Bitcoin"}`,
+							OutputPath: "transfer_1.network",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `"1"`,
+							OutputPath: "transfer_1.confirmation_depth",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `[{"operation_identifier":{"index":0},"type":"Vin","status":"","account":{"address":"sender"},"amount":{"value":"-10","currency":{{currency}}}},{"operation_identifier":{"index":1},"type":"Vout","status":"","account":{"address":"recipient"},"amount":{"value":"5","currency":{{currency}}}}]`, // nolint
+							OutputPath: "transfer_1.operations",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `"true"`,
+							OutputPath: "transfer_1.dry_run",
+						},
+					},
+				},
+				{
+					Name: "transfer_2",
+					Actions: []*job.Action{
+						{
+							Type:       job.SetVariable,
+							Input:      `{"network":"Testnet3", "blockchain":"Bitcoin"}`,
+							OutputPath: "transfer_2.network",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `"1"`,
+							OutputPath: "transfer_2.confirmation_depth",
+						},
+						{
+							Type:       job.FindCurrencyAmount,
+							Input:      `{"currency":{{currency}},"amounts":{{transfer_1.suggested_fee}}}`,
+							OutputPath: "recipient_amount",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `[{"operation_identifier":{"index":0},"type":"Vin","status":"","account":{"address":"sender"},"amount":{"value":"-10","currency":{{currency}}}},{"operation_identifier":{"index":1},"type":"Vout","status":"","account":{"address":"recipient"},"amount":{{recipient_amount}}}]`, // nolint
+							OutputPath: "transfer_2.operations",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c, err := New(
+		jobStorage,
+		helper,
+		handler,
+		p,
+		workflows,
+	)
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
+
+	// Create coordination channels
+	processCanceled := make(chan struct{})
+
+	dir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+
+	db, err := storage.NewBadgerStorage(ctx, dir)
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+
+	helper.On("HeadBlockExists", ctx).Return(true).Once()
+
+	// Attempt to transfer
+	dbTx := db.NewDatabaseTransaction(ctx, false)
+	helper.On("DatabaseTransaction", ctx).Return(dbTx).Once()
+	jobStorage.On("Ready", ctx, dbTx).Return([]*job.Job{}, nil).Once()
+	jobStorage.On("Processing", ctx, dbTx, "transfer").Return([]*job.Job{}, nil).Once()
+	network := &types.NetworkIdentifier{
+		Blockchain: "Bitcoin",
+		Network:    "Testnet3",
+	}
+	currency := &types.Currency{
+		Symbol:   "tBTC",
+		Decimals: 8,
+	}
+	dryRunOps := []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 0,
+			},
+			Type: "Vin",
+			Account: &types.AccountIdentifier{
+				Address: "sender",
+			},
+			Amount: &types.Amount{
+				Value:    "-10",
+				Currency: currency,
+			},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 1,
+			},
+			Type: "Vout",
+			Account: &types.AccountIdentifier{
+				Address: "recipient",
+			},
+			Amount: &types.Amount{
+				Value:    "5",
+				Currency: currency,
+			},
+		},
+	}
+	broadcastOps := []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 0,
+			},
+			Type: "Vin",
+			Account: &types.AccountIdentifier{
+				Address: "sender",
+			},
+			Amount: &types.Amount{
+				Value:    "-10",
+				Currency: currency,
+			},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 1,
+			},
+			Type: "Vout",
+			Account: &types.AccountIdentifier{
+				Address: "recipient",
+			},
+			Amount: &types.Amount{
+				Value:    "7",
+				Currency: currency,
+			},
+		},
+	}
+	metadataOptions := map[string]interface{}{
+		"metadata": "test",
+	}
+	helper.On(
+		"Preprocess",
+		ctx,
+		network,
+		dryRunOps,
+		(map[string]interface{})(nil),
+	).Return(metadataOptions, nil, nil).Once()
+	fetchedMetadata := map[string]interface{}{
+		"tx_meta": "help",
+	}
+	helper.On(
+		"Metadata",
+		ctx,
+		network,
+		metadataOptions,
+		[]*types.PublicKey{},
+	).Return(fetchedMetadata, []*types.Amount{
+		{
+			Value:    "7",
+			Currency: currency,
+		},
+	}, nil).Once()
+	var j job.Job
+	jobStorage.On("Update", ctx, dbTx, mock.Anything).Run(func(args mock.Arguments) {
+		j = *args.Get(2).(*job.Job)
+	}).Return("job1", nil).Once()
+	jobStorage.On("Update", ctx, dbTx, mock.Anything).Run(func(args mock.Arguments) {
+		j = *args.Get(2).(*job.Job)
+	}).Return("job1", nil).Once()
+	helper.On("BroadcastAll", ctx).Return(nil).Once()
+
+	// Start processor
+	go func() {
+		err := c.Process(ctx)
+		assert.Contains(t, err.Error(), "fake failure")
+		close(processCanceled)
+	}()
+
+	// Process second scenario
+	helper.On("HeadBlockExists", ctx).Return(true).Once()
+	dbTx2 := db.NewDatabaseTransaction(ctx, false)
+	helper.On("DatabaseTransaction", ctx).Return(dbTx2).Once()
+	jobStorage.On("Ready", ctx, dbTx2).Return([]*job.Job{&j}, nil).Once()
+	jobStorage.On("Update", ctx, dbTx2, mock.Anything).Run(func(args mock.Arguments) {
+		j = *args.Get(2).(*job.Job)
+	}).Return("job1", nil).Once()
+	helper.On(
+		"Preprocess",
+		ctx,
+		network,
+		broadcastOps,
+		(map[string]interface{})(nil),
+	).Return(nil, nil, errors.New("fake failure")).Once()
+
+	<-processCanceled
+	jobStorage.AssertExpectations(t)
+	helper.AssertExpectations(t)
+}

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -581,7 +581,7 @@ func TestProcess(t *testing.T) {
 		network,
 		metadataOptions,
 		[]*types.PublicKey{},
-	).Return(fetchedMetadata, nil).Once()
+	).Return(fetchedMetadata, nil, nil).Once()
 
 	unsignedTx := "unsigned transaction"
 	signingPayloads := []*types.SigningPayload{
@@ -988,7 +988,7 @@ func TestProcess_Failed(t *testing.T) {
 		{
 			Address: "hello2",
 		},
-	}, nil).Once()
+	}, nil, nil).Once()
 	helper.On(
 		"GetKey",
 		ctx,
@@ -1036,7 +1036,7 @@ func TestProcess_Failed(t *testing.T) {
 				CurveType: types.Edwards25519,
 			},
 		},
-	).Return(fetchedMetadata, nil).Once()
+	).Return(fetchedMetadata, nil, nil).Once()
 
 	unsignedTx := "unsigned transaction"
 	signingPayloads := []*types.SigningPayload{

--- a/constructor/coordinator/types.go
+++ b/constructor/coordinator/types.go
@@ -136,7 +136,7 @@ type Helper interface {
 		*types.NetworkIdentifier,
 		map[string]interface{},
 		[]*types.PublicKey,
-	) (map[string]interface{}, error)
+	) (map[string]interface{}, []*types.Amount, error)
 
 	// Payloads calls the /construction/payloads endpoint
 	// using the offline node.

--- a/constructor/job/errors.go
+++ b/constructor/job/errors.go
@@ -17,6 +17,10 @@ package job
 import "errors"
 
 var (
+	// ErrNoBroadcastToConfirm is returned when there is no broadcast
+	// to confirm in a job.
+	ErrNoBroadcastToConfirm = errors.New("no broadcast to confirm")
+
 	// ErrVariableNotFound is returned when a variable is not
 	// present in a Job's state.
 	ErrVariableNotFound = errors.New("variable not found")
@@ -29,6 +33,10 @@ var (
 	// ErrUnableToHandleBroadcast is returned if a Job cannot handle a
 	// broadcast completion (usually because there is no broadcast to confirm).
 	ErrUnableToHandleBroadcast = errors.New("unable to handle broadcast")
+
+	// ErrUnableToHandleDryRun is returned if a Job cannot handle a
+	// dry run completion.
+	ErrUnableToHandleDryRun = errors.New("unable to handle dry run")
 
 	// ErrUnableToCreateBroadcast is returned when it is not possible
 	// to create a broadcast or check if a broadcast should be created

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -111,6 +111,12 @@ const (
 	// in an array of []*types.Amount. This is typically used when parsing
 	// the suggested fee response from /construction/metadata.
 	FindCurrencyAmount ActionType = "find_currency_amount"
+
+	// Assert ensures that a provided number is >= 0 and causes
+	// execution to exit if this is not true. This is useful when
+	// ensuring that an account has sufficient balance to pay the
+	// suggested fee to broadcast a transaction.
+	Assert ActionType = "assert"
 )
 
 // Action is a step of computation that

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -50,6 +50,12 @@ const (
 	// certain transactions may only be considered complete
 	// after some time (ex: staking transaction).
 	ConfirmationDepth ReservedVariable = "confirmation_depth"
+
+	// DryRun is a boolean that indicates whether we should perform the
+	// entire transaction construction process or just /construction/preprocess
+	// and /construction/metadata to determine the suggested transaction
+	// fee.
+	DryRun ReservedVariable = "dry_run"
 )
 
 // ActionType is a type of Action that can be processed.
@@ -100,6 +106,11 @@ const (
 	// RandomNumber generates a random number in some range [min, max).
 	// It is used to generate random transaction amounts.
 	RandomNumber ActionType = "random_number"
+
+	// FindCurrencyAmount finds a *types.Amount for a certain currency
+	// in an array of []*types.Amount. This is typically used when parsing
+	// the suggested fee response from /construction/metadata.
+	FindCurrencyAmount ActionType = "find_currency_amount"
 )
 
 // Action is a step of computation that
@@ -217,6 +228,13 @@ type RandomNumberInput struct {
 	Maximum string `json:"maximum"`
 }
 
+// FindCurrencyAmountInput is the input
+// to FindCurrencyAmount.
+type FindCurrencyAmountInput struct {
+	Currency *types.Currency `json:"currency"`
+	Amounts  []*types.Amount `json:"amounts"`
+}
+
 // Scenario is a collection of Actions with a specific
 // confirmation depth.
 //
@@ -314,4 +332,5 @@ type Broadcast struct {
 	Intent            []*types.Operation
 	Metadata          map[string]interface{}
 	ConfirmationDepth int64
+	DryRun            bool
 }

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -54,8 +54,13 @@ const (
 	// DryRun is a boolean that indicates whether we should perform the
 	// entire transaction construction process or just /construction/preprocess
 	// and /construction/metadata to determine the suggested transaction
-	// fee.
+	// fee. If this variable is not populated, we assume that it is NOT
+	// a dry run.
 	DryRun ReservedVariable = "dry_run"
+
+	// SuggestedFee is the []*types.Amount returned from
+	// an implementation's /construction/metadata endpoint (if implemented).
+	SuggestedFee ReservedVariable = "suggested_fee"
 )
 
 // ActionType is a type of Action that can be processed.

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1033,6 +1033,10 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 				OutputPath: "rand_number",
 			},
 			{
+				Type:  job.Assert,
+				Input: `{{rand_number}}`,
+			},
+			{
 				Type:  job.PrintMessage,
 				Input: `{"random_number": {{rand_number}}}`,
 			},
@@ -1193,6 +1197,32 @@ func TestJob_Failures(t *testing.T) {
 				},
 			},
 			expectedErr: ErrInvalidActionType,
+			helper:      &mocks.Helper{},
+		},
+		"assertion invalid input": {
+			scenario: &job.Scenario{
+				Name: "create_address",
+				Actions: []*job.Action{
+					{
+						Type:  "assert",
+						Input: `"hello"`,
+					},
+				},
+			},
+			expectedErr: ErrInvalidInput,
+			helper:      &mocks.Helper{},
+		},
+		"failed assertion": {
+			scenario: &job.Scenario{
+				Name: "create_address",
+				Actions: []*job.Action{
+					{
+						Type:  "assert",
+						Input: `"-1"`,
+					},
+				},
+			},
+			expectedErr: ErrActionFailed,
 			helper:      &mocks.Helper{},
 		},
 		"invalid json": {

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1013,13 +1013,18 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 		Name: "create_send",
 		Actions: []*job.Action{
 			{
+				Type:       job.SetVariable,
+				Input:      `{"symbol":"BTC","decimals":8}`,
+				OutputPath: "default_curr",
+			},
+			{
 				Type:       job.RandomString,
 				Input:      `{"regex": "[a-z]+", "limit":10}`,
 				OutputPath: "random_address",
 			},
 			{
 				Type:       job.SetVariable,
-				Input:      `[{"operation_identifier":{"index":0},"type":"","status":"","account":{{account.account_identifier}},"amount":{"value":"-90","currency":{"symbol":"BTC","decimals":8}}},{"operation_identifier":{"index":1},"type":"","status":"","account":{"address":{{random_address}}},"amount":{"value":"100","currency":{"symbol":"BTC","decimals":8}}}]`, // nolint
+				Input:      `[{"operation_identifier":{"index":0},"type":"","status":"","account":{{account.account_identifier}},"amount":{"value":"-90","currency":{{default_curr}}}},{"operation_identifier":{"index":1},"type":"","status":"","account":{"address":{{random_address}}},"amount":{"value":"100","currency":{{default_curr}}}}]`, // nolint
 				OutputPath: "create_send.operations",
 			},
 			{
@@ -1035,6 +1040,30 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 			{
 				Type:  job.Assert,
 				Input: `{{rand_number}}`,
+			},
+			{
+				Type:       job.SetVariable,
+				Input:      `{"symbol":"ETH","decimals":18}`,
+				OutputPath: "eth_curr",
+			},
+			{
+				Type:       job.SetVariable,
+				Input:      `[{"value":"100", "currency":{{default_curr}}},{"value":"200", "currency":{{eth_curr}}}]`,
+				OutputPath: "mock_suggested_fee_resp",
+			},
+			{
+				Type:       job.FindCurrencyAmount,
+				Input:      `{"currency":{{eth_curr}}, "amounts":{{mock_suggested_fee_resp}}}`,
+				OutputPath: "eth_amount",
+			},
+			{
+				Type:       job.Math,
+				Input:      `{"operation":"subtraction", "left_value":{{eth_amount.value}}, "right_value":"200"}`,
+				OutputPath: "eth_check",
+			},
+			{
+				Type:  job.Assert,
+				Input: `{{eth_check}}`,
 			},
 			{
 				Type:  job.PrintMessage,
@@ -1204,7 +1233,7 @@ func TestJob_Failures(t *testing.T) {
 				Name: "create_address",
 				Actions: []*job.Action{
 					{
-						Type:  "assert",
+						Type:  job.Assert,
 						Input: `"hello"`,
 					},
 				},
@@ -1217,8 +1246,47 @@ func TestJob_Failures(t *testing.T) {
 				Name: "create_address",
 				Actions: []*job.Action{
 					{
-						Type:  "assert",
+						Type:  job.Assert,
 						Input: `"-1"`,
+					},
+				},
+			},
+			expectedErr: ErrActionFailed,
+			helper:      &mocks.Helper{},
+		},
+		"invalid currency": {
+			scenario: &job.Scenario{
+				Name: "create_address",
+				Actions: []*job.Action{
+					{
+						Type:  job.FindCurrencyAmount,
+						Input: `{"currency":{"decimals":8}}`,
+					},
+				},
+			},
+			expectedErr: ErrInvalidInput,
+			helper:      &mocks.Helper{},
+		},
+		"repeat currency": {
+			scenario: &job.Scenario{
+				Name: "create_address",
+				Actions: []*job.Action{
+					{
+						Type:  job.FindCurrencyAmount,
+						Input: `{"currency":{"symbol":"BTC", "decimals":8},"amounts":[{"value":"100","currency":{"symbol":"BTC", "decimals":8}},{"value":"100","currency":{"symbol":"BTC", "decimals":8}}]}`,
+					},
+				},
+			},
+			expectedErr: ErrInvalidInput,
+			helper:      &mocks.Helper{},
+		},
+		"can't find currency": {
+			scenario: &job.Scenario{
+				Name: "create_address",
+				Actions: []*job.Action{
+					{
+						Type:  job.FindCurrencyAmount,
+						Input: `{"currency":{"symbol":"BTC", "decimals":8}}`,
 					},
 				},
 			},

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1273,7 +1273,7 @@ func TestJob_Failures(t *testing.T) {
 				Actions: []*job.Action{
 					{
 						Type:  job.FindCurrencyAmount,
-						Input: `{"currency":{"symbol":"BTC", "decimals":8},"amounts":[{"value":"100","currency":{"symbol":"BTC", "decimals":8}},{"value":"100","currency":{"symbol":"BTC", "decimals":8}}]}`,
+						Input: `{"currency":{"symbol":"BTC", "decimals":8},"amounts":[{"value":"100","currency":{"symbol":"BTC", "decimals":8}},{"value":"100","currency":{"symbol":"BTC", "decimals":8}}]}`, // nolint
 					},
 				},
 			},

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -154,9 +154,9 @@ func (f *Fetcher) ConstructionMetadata(
 	network *types.NetworkIdentifier,
 	options map[string]interface{},
 	publicKeys []*types.PublicKey,
-) (map[string]interface{}, *Error) {
+) (map[string]interface{}, []*types.Amount, *Error) {
 	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
-		return nil, &Error{
+		return nil, nil, &Error{
 			Err: fmt.Errorf("%w: %s", ErrCouldNotAcquireSemaphore, err.Error()),
 		}
 	}
@@ -174,17 +174,17 @@ func (f *Fetcher) ConstructionMetadata(
 			Err:       fmt.Errorf("%w: /construction/metadata %s", ErrRequestFailed, err.Error()),
 			ClientErr: clientErr,
 		}
-		return nil, fetcherErr
+		return nil, nil, fetcherErr
 	}
 
 	if err := asserter.ConstructionMetadataResponse(metadata); err != nil {
 		fetcherErr := &Error{
 			Err: fmt.Errorf("%w: /construction/metadata %s", ErrAssertionFailed, err.Error()),
 		}
-		return nil, fetcherErr
+		return nil, nil, fetcherErr
 	}
 
-	return metadata.Metadata, nil
+	return metadata.Metadata, metadata.SuggestedFee, nil
 }
 
 // ConstructionParse is called on both unsigned and signed transactions to

--- a/mocks/constructor/coordinator/helper.go
+++ b/mocks/constructor/coordinator/helper.go
@@ -269,7 +269,7 @@ func (_m *Helper) LockedAccounts(_a0 context.Context, _a1 storage.DatabaseTransa
 }
 
 // Metadata provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *Helper) Metadata(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 map[string]interface{}, _a3 []*types.PublicKey) (map[string]interface{}, error) {
+func (_m *Helper) Metadata(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 map[string]interface{}, _a3 []*types.PublicKey) (map[string]interface{}, []*types.Amount, error) {
 	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 map[string]interface{}
@@ -281,14 +281,23 @@ func (_m *Helper) Metadata(_a0 context.Context, _a1 *types.NetworkIdentifier, _a
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *types.NetworkIdentifier, map[string]interface{}, []*types.PublicKey) error); ok {
+	var r1 []*types.Amount
+	if rf, ok := ret.Get(1).(func(context.Context, *types.NetworkIdentifier, map[string]interface{}, []*types.PublicKey) []*types.Amount); ok {
 		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]*types.Amount)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, *types.NetworkIdentifier, map[string]interface{}, []*types.PublicKey) error); ok {
+		r2 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // Parse provides a mock function with given fields: _a0, _a1, _a2, _a3


### PR DESCRIPTION
This PR adds support for "dry running" a transaction to get the `SuggestedFee` without actually signing or broadcasting it. This is useful for amending transactions in `UTXO-based` blockchains and for ensuring an account has sufficient funds in `account-based` blockchains.

### Changes
- [x] Add `dry_run` to `Broadcast`
- [x] Add `FindCurrencyAmount` to actions (need to parse suggested fees)
- [x] Add `Assert` to actions where a value can be checked to be positive (otherwise will exit)...ensure we don't create invalid transactions
- [x] implement `Assert`
- [x] implement `FindCurrencyAmount`
- [x] implement `dry_run`
  - [x] existing tests passing