### PR TITLE
[fetcher] errors overhaul

### DIFF
--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -115,7 +115,7 @@ func TestVersion(t *testing.T) {
 		},
 		"nil version": {
 			version: nil,
-			err:     errors.New("version is nil"),
+			err:     ErrVersionIsNil,
 		},
 		"invalid NodeVersion": {
 			version: &types.Version{

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -16,7 +16,6 @@ package fetcher
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -102,7 +101,7 @@ func (f *Fetcher) AccountBalanceRetry(
 			}
 		}
 
-		if errors.Is(err.Err, ErrAssertionFailed) {
+		if is, _ := asserter.ErrAsserter(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /account/balance not attempting retry", err.Err),
 				ClientErr: err.ClientErr,

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -61,9 +61,8 @@ func (f *Fetcher) AccountBalance(
 	); err != nil {
 		fetcherErr := &Error{
 			Err: fmt.Errorf(
-				"%w: /account/balance %s",
-				ErrAssertionFailed,
-				err.Error(),
+				"%w: /account/balance",
+				err,
 			),
 		}
 		return nil, nil, nil, nil, fetcherErr

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -266,7 +266,7 @@ func (f *Fetcher) Block(
 
 	if err := f.Asserter.Block(block); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /block %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /block", err),
 		}
 		return nil, fetcherErr
 	}

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -16,7 +16,6 @@ package fetcher
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -304,7 +303,7 @@ func (f *Fetcher) BlockRetry(
 			return nil, &Error{Err: ctx.Err()}
 		}
 
-		if errors.Is(err.Err, ErrAssertionFailed) {
+		if is, _ := asserter.ErrAsserter(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /block not attempting retry", err.Err),
 				ClientErr: err.ClientErr,

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -58,7 +58,7 @@ func (f *Fetcher) ConstructionCombine(
 
 	if err := asserter.ConstructionCombineResponse(response); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /construction/combine %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /construction/combine", err),
 		}
 		return "", fetcherErr
 	}
@@ -101,7 +101,7 @@ func (f *Fetcher) ConstructionDerive(
 
 	if err := asserter.ConstructionDeriveResponse(response); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /construction/derive %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /construction/derive", err),
 		}
 		return nil, nil, fetcherErr
 	}
@@ -139,7 +139,7 @@ func (f *Fetcher) ConstructionHash(
 
 	if err := asserter.TransactionIdentifierResponse(response); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /construction/hash %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /construction/hash", err),
 		}
 		return nil, fetcherErr
 	}
@@ -179,7 +179,7 @@ func (f *Fetcher) ConstructionMetadata(
 
 	if err := asserter.ConstructionMetadataResponse(metadata); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /construction/metadata %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /construction/metadata", err),
 		}
 		return nil, fetcherErr
 	}
@@ -222,7 +222,7 @@ func (f *Fetcher) ConstructionParse(
 
 	if err := f.Asserter.ConstructionParseResponse(response, signed); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /construction/parse %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /construction/parse", err),
 		}
 		return nil, nil, nil, fetcherErr
 	}
@@ -274,7 +274,7 @@ func (f *Fetcher) ConstructionPayloads(
 
 	if err := asserter.ConstructionPayloadsResponse(response); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /construction/payloads %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /construction/payloads", err),
 		}
 		return "", nil, fetcherErr
 	}
@@ -320,7 +320,7 @@ func (f *Fetcher) ConstructionPreprocess(
 
 	if err := asserter.ConstructionPreprocessResponse(response); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /construction/preprocess %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /construction/preprocess", err),
 		}
 		return nil, nil, fetcherErr
 	}
@@ -359,7 +359,7 @@ func (f *Fetcher) ConstructionSubmit(
 
 	if err := asserter.TransactionIdentifierResponse(submitResponse); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /construction/submit %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /construction/submit", err),
 		}
 		return nil, nil, fetcherErr
 	}

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -44,10 +44,6 @@ var (
 	// fails because it was attempted too many times.
 	ErrExhaustedRetries = errors.New("retries exhausted")
 
-	// ErrAssertionFailed is returned when a fetch succeeds
-	// but fails assertion.
-	ErrAssertionFailed = errors.New("assertion failed")
-
 	// ErrCouldNotAcquireSemaphore is returned when acquiring
 	// the connection semaphore returns an error.
 	ErrCouldNotAcquireSemaphore = errors.New("could not acquire semaphore")

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
 	"github.com/stretchr/testify/assert"
@@ -148,7 +149,7 @@ func TestInitializeAsserter(t *testing.T) {
 					},
 				},
 			},
-			expectedError: ErrAssertionFailed,
+			expectedError: asserter.ErrVersionIsNil,
 		},
 	}
 

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -53,7 +53,7 @@ func (f *Fetcher) Mempool(
 	mempool := response.TransactionIdentifiers
 	if err := asserter.MempoolTransactions(mempool); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /mempool %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /mempool", err),
 		}
 		return nil, fetcherErr
 	}
@@ -93,7 +93,7 @@ func (f *Fetcher) MempoolTransaction(
 	mempoolTransaction := response.Transaction
 	if err := f.Asserter.Transaction(mempoolTransaction); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /mempool/transaction %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /mempool/transaction", err),
 		}
 		return nil, nil, fetcherErr
 	}

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -16,7 +16,6 @@ package fetcher
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
@@ -91,7 +90,7 @@ func (f *Fetcher) NetworkStatusRetry(
 			}
 		}
 
-		if errors.Is(err.Err, ErrAssertionFailed) {
+		if is, _ := asserter.ErrAsserter(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/status not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
@@ -173,7 +172,7 @@ func (f *Fetcher) NetworkListRetry(
 			}
 		}
 
-		if errors.Is(err.Err, ErrAssertionFailed) {
+		if is, _ := asserter.ErrAsserter(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/list not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
@@ -255,7 +254,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 			}
 		}
 
-		if errors.Is(err.Err, ErrAssertionFailed) {
+		if is, _ := asserter.ErrAsserter(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/options not attempting retry", err.Err),
 				ClientErr: err.ClientErr,

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -55,7 +55,7 @@ func (f *Fetcher) NetworkStatus(
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /network/status %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /network/status", err),
 		}
 		return nil, fetcherErr
 	}
@@ -139,7 +139,7 @@ func (f *Fetcher) NetworkList(
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /network/list %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /network/list", err),
 		}
 		return nil, fetcherErr
 	}
@@ -219,7 +219,7 @@ func (f *Fetcher) NetworkOptions(
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {
 		fetcherErr := &Error{
-			Err: fmt.Errorf("%w: /network/options %s", ErrAssertionFailed, err.Error()),
+			Err: fmt.Errorf("%w: /network/options", err),
 		}
 		return nil, fetcherErr
 	}


### PR DESCRIPTION
Fixes # .

### Motivation
errors overhaul in all other packages now allows `rosetta-cli` to check assertion errors without needing to use the generic ErrAssertionFailed

### Solution
returning asserter errors in fetcher instead of generic ErrAssertionFailed

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->