### PR TITLE
rename Err() functions

### DIFF
--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -370,10 +370,10 @@ var (
 	}
 )
 
-// ErrAsserter takes an error as an argument and returns
+// Err takes an error as an argument and returns
 // whether or not the error is one thrown by the asserter
 // along with the specific source of the error
-func ErrAsserter(err error) (bool, string) {
+func Err(err error) (bool, string) {
 	assertErrs := map[string][]error{
 		"account balance error": AccountBalanceErrs,
 		"block error":           BlockErrs,

--- a/asserter/errors_test.go
+++ b/asserter/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrAsserter(t *testing.T) {
+func TestErr(t *testing.T) {
 	var tests = map[string]struct {
 		err    error
 		is     bool
@@ -66,7 +66,7 @@ func TestErrAsserter(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			is, source := ErrAsserter(test.err)
+			is, source := Err(test.err)
 			assert.Equal(t, test.is, is)
 			assert.Equal(t, test.source, source)
 		})

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -101,7 +101,7 @@ func (f *Fetcher) AccountBalanceRetry(
 			}
 		}
 
-		if is, _ := asserter.ErrAsserter(err.Err); is {
+		if is, _ := asserter.Err(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /account/balance not attempting retry", err.Err),
 				ClientErr: err.ClientErr,

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -303,7 +303,7 @@ func (f *Fetcher) BlockRetry(
 			return nil, &Error{Err: ctx.Err()}
 		}
 
-		if is, _ := asserter.ErrAsserter(err.Err); is {
+		if is, _ := asserter.Err(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /block not attempting retry", err.Err),
 				ClientErr: err.ClientErr,

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -90,7 +90,7 @@ func (f *Fetcher) NetworkStatusRetry(
 			}
 		}
 
-		if is, _ := asserter.ErrAsserter(err.Err); is {
+		if is, _ := asserter.Err(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/status not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
@@ -172,7 +172,7 @@ func (f *Fetcher) NetworkListRetry(
 			}
 		}
 
-		if is, _ := asserter.ErrAsserter(err.Err); is {
+		if is, _ := asserter.Err(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/list not attempting retry", err.Err),
 				ClientErr: err.ClientErr,
@@ -254,7 +254,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 			}
 		}
 
-		if is, _ := asserter.ErrAsserter(err.Err); is {
+		if is, _ := asserter.Err(err.Err); is {
 			fetcherErr := &Error{
 				Err:       fmt.Errorf("%w: /network/options not attempting retry", err.Err),
 				ClientErr: err.ClientErr,

--- a/keys/errors.go
+++ b/keys/errors.go
@@ -50,9 +50,9 @@ var (
 	ErrVerifyFailed = errors.New("verify: verify returned false")
 )
 
-// ErrKeys takes an error as an argument and returns
+// Err takes an error as an argument and returns
 // whether or not the error is one thrown by the keys package
-func ErrKeys(err error) bool {
+func Err(err error) bool {
 	keyErrors := []error{
 		ErrPrivKeyUndecodable,
 		ErrPrivKeyLengthInvalid,

--- a/keys/errors_test.go
+++ b/keys/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrKeys(t *testing.T) {
+func TestErr(t *testing.T) {
 	var tests = map[string]struct {
 		err error
 		is  bool
@@ -38,7 +38,7 @@ func TestErrKeys(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			is := ErrKeys(test.err)
+			is := Err(test.err)
 			assert.Equal(t, test.is, is)
 		})
 	}

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -113,10 +113,10 @@ var (
 	}
 )
 
-// ErrParser takes an error as an argument and returns
+// Err takes an error as an argument and returns
 // whether or not the error is one thrown by the asserter
 // along with the specific source of the error
-func ErrParser(err error) (bool, string) {
+func Err(err error) (bool, string) {
 	parserErrs := map[string][]error{
 		"intent error":           IntentErrs,
 		"match operations error": MatchOpsErrs,

--- a/parser/errors_test.go
+++ b/parser/errors_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrParser(t *testing.T) {
+func TestErr(t *testing.T) {
 	var tests = map[string]struct {
 		err    error
 		is     bool
@@ -40,7 +40,7 @@ func TestErrParser(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			is, source := ErrParser(test.err)
+			is, source := Err(test.err)
 			assert.Equal(t, test.is, is)
 			assert.Equal(t, test.source, source)
 		})

--- a/reconciler/errors.go
+++ b/reconciler/errors.go
@@ -45,9 +45,9 @@ var (
 	ErrLiveBalanceLookupFailed  = errors.New("unable to lookup live balance")
 )
 
-// ErrReconciler takes an error as an argument and returns
+// Err takes an error as an argument and returns
 // whether or not the error is one thrown by the keys package
-func ErrReconciler(err error) bool {
+func Err(err error) bool {
 	reconcilerErrors := []error{
 		ErrHeadBlockBehindLive,
 		ErrAccountUpdated,

--- a/reconciler/errors_test.go
+++ b/reconciler/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrKeys(t *testing.T) {
+func TestErr(t *testing.T) {
 	var tests = map[string]struct {
 		err error
 		is  bool
@@ -38,7 +38,7 @@ func TestErrKeys(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			is := ErrReconciler(test.err)
+			is := Err(test.err)
 			assert.Equal(t, test.is, is)
 		})
 	}

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -398,10 +398,10 @@ var (
 	}
 )
 
-// ErrStorage takes an error as an argument and returns
+// Err takes an error as an argument and returns
 // whether or not the error is one thrown by the asserter
 // along with the specific source of the error
-func ErrStorage(err error) (bool, string) {
+func Err(err error) (bool, string) {
 	storageErrs := map[string][]error{
 		"balance storage error":   BalanceStorageErrs,
 		"block storage error":     BlockStorageErrs,

--- a/storage/errors_test.go
+++ b/storage/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrAsserter(t *testing.T) {
+func TestErr(t *testing.T) {
 	var tests = map[string]struct {
 		err    error
 		is     bool
@@ -76,7 +76,7 @@ func TestErrAsserter(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			is, source := ErrStorage(test.err)
+			is, source := Err(test.err)
 			assert.Equal(t, test.is, is)
 			assert.Equal(t, test.source, source)
 		})

--- a/syncer/errors.go
+++ b/syncer/errors.go
@@ -53,9 +53,9 @@ var (
 	ErrNextSyncableRangeFailed     = errors.New("unable to get next syncable range")
 )
 
-// ErrSyncer takes an error as an argument and returns
+// Err takes an error as an argument and returns
 // whether or not the error is one thrown by the keys package
-func ErrSyncer(err error) bool {
+func Err(err error) bool {
 	syncerErrors := []error{
 		ErrCannotRemoveGenesisBlock,
 		ErrOutOfOrder,

--- a/syncer/errors_test.go
+++ b/syncer/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestErrKeys(t *testing.T) {
+func TestErr(t *testing.T) {
 	var tests = map[string]struct {
 		err error
 		is  bool
@@ -38,7 +38,7 @@ func TestErrKeys(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			is := ErrSyncer(test.err)
+			is := Err(test.err)
 			assert.Equal(t, test.is, is)
 		})
 	}


### PR DESCRIPTION
Fixes # .

### Motivation
following up on [https://github.com/coinbase/rosetta-sdk-go/pull/145/files#r486685115](https://github.com/coinbase/rosetta-sdk-go/pull/145/files#r486685115)

### Solution
ex: `asserter.ErrAsserter` -> `asserter.Err`

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
