### PR TITLE
Put Account in Balance Fetch Error

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -416,7 +416,13 @@ func (r *Reconciler) bestLiveBalance(
 		return nil, nil, ErrBlockGone
 	}
 
-	return nil, nil, err
+	return nil, nil, fmt.Errorf(
+		"%w: unable to get live balance for %s %s at %s",
+		err,
+		types.PrintStruct(account),
+		types.PrintStruct(currency),
+		types.PrintStruct(lookupBlock),
+	)
 }
 
 // accountReconciliation returns an error if the provided

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -295,7 +295,13 @@ func (b *BalanceStorage) UpdateBalance(
 		// Use helper to fetch existing balance.
 		amount, err := b.helper.AccountBalance(ctx, change.Account, change.Currency, parentBlock)
 		if err != nil {
-			return fmt.Errorf("%w: unable to get previous account balance", err)
+			return fmt.Errorf(
+				"%w: unable to get previous account balance for %s %s at %s",
+				err,
+				types.PrintStruct(change.Account),
+				types.PrintStruct(change.Currency),
+				types.PrintStruct(parentBlock),
+			)
 		}
 
 		existingValue = amount.Value


### PR DESCRIPTION
This PR returns the `AccountIdentifier` and `Currency` in any balance fetching errors. This makes it a lot easier to debug issues with the `/account/balance` endpoint.