### PR TITLE
[Storage] Optimize storage.AccountCoin Encoding

### DIFF
--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -158,10 +158,13 @@ func (c *CoinStorage) addCoin(
 	transaction DatabaseTransaction,
 ) error {
 	_, key := getCoinKey(coin.CoinIdentifier)
-	encodedResult := c.db.Compressor().EncodeAccountCoin(&AccountCoin{
+	encodedResult, err := c.db.Compressor().EncodeAccountCoin(&AccountCoin{
 		Account: account,
 		Coin:    coin,
 	})
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrCoinDataEncodeFailed, err)
+	}
 
 	if err := storeUniqueKey(ctx, transaction, key, encodedResult, true); err != nil {
 		return fmt.Errorf("%w: %v", ErrCoinStoreFailed, err)

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -106,7 +106,7 @@ func (c *CoinStorage) getAndDecodeCoin(
 	}
 
 	var accountCoin AccountCoin
-	if err := c.db.Compressor().decodeAccountCoin(val, &accountCoin, true); err != nil {
+	if err := c.db.Compressor().DecodeAccountCoin(val, &accountCoin, true); err != nil {
 		return false, nil, nil, fmt.Errorf("%w: %v", ErrCoinDecodeFailed, err)
 	}
 
@@ -158,7 +158,7 @@ func (c *CoinStorage) addCoin(
 	transaction DatabaseTransaction,
 ) error {
 	_, key := getCoinKey(coin.CoinIdentifier)
-	encodedResult := c.db.Compressor().encodeAccountCoin(&AccountCoin{
+	encodedResult := c.db.Compressor().EncodeAccountCoin(&AccountCoin{
 		Account: account,
 		Coin:    coin,
 	})

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -73,8 +73,8 @@ func NewCoinStorage(
 	}
 }
 
-func getCoinKey(identifier *types.CoinIdentifier) (string, []byte) {
-	return coinNamespace, []byte(fmt.Sprintf("%s/%s", coinNamespace, identifier.Identifier))
+func getCoinKey(identifier *types.CoinIdentifier) []byte {
+	return []byte(fmt.Sprintf("%s/%s", coinNamespace, identifier.Identifier))
 }
 
 func getCoinAccountPrefix(accountIdentifier *types.AccountIdentifier) []byte {
@@ -95,7 +95,7 @@ func (c *CoinStorage) getAndDecodeCoin(
 	transaction DatabaseTransaction,
 	coinIdentifier *types.CoinIdentifier,
 ) (bool, *types.Coin, *types.AccountIdentifier, error) {
-	_, key := getCoinKey(coinIdentifier)
+	key := getCoinKey(coinIdentifier)
 	exists, val, err := transaction.Get(ctx, key)
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("%w: %v", ErrCoinQueryFailed, err)
@@ -157,7 +157,7 @@ func (c *CoinStorage) addCoin(
 	coin *types.Coin,
 	transaction DatabaseTransaction,
 ) error {
-	_, key := getCoinKey(coin.CoinIdentifier)
+	key := getCoinKey(coin.CoinIdentifier)
 	encodedResult, err := c.db.Compressor().EncodeAccountCoin(&AccountCoin{
 		Account: account,
 		Coin:    coin,
@@ -213,7 +213,7 @@ func (c *CoinStorage) removeCoin(
 	coinIdentifier *types.CoinIdentifier,
 	transaction DatabaseTransaction,
 ) error {
-	_, key := getCoinKey(coinIdentifier)
+	key := getCoinKey(coinIdentifier)
 	exists, _, err := transaction.Get(ctx, key)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrCoinQueryFailed, err)

--- a/storage/compressor.go
+++ b/storage/compressor.go
@@ -245,7 +245,7 @@ func (c *Compressor) decodeMap(input []byte) (map[string]interface{}, error) {
 // amountCurrencyDecimals|accountMetadata|subAccountAddress|
 // subAccountMetadata|amountMetadata|currencyMetadata
 //
-// In both cases, the | character is represetned by the unicodeRecordSeparator rune.
+// In both cases, the | character is represented by the unicodeRecordSeparator rune.
 func (c *Compressor) EncodeAccountCoin(
 	accountCoin *AccountCoin,
 ) ([]byte, error) { // nolint:gocognit

--- a/storage/compressor.go
+++ b/storage/compressor.go
@@ -224,7 +224,7 @@ func (c *Compressor) encodeAndWrite(output *bytes.Buffer, object interface{}) er
 	}
 
 	c.pool.Put(buf)
-	return err
+	return nil
 }
 
 func (c *Compressor) decodeMap(input []byte) (map[string]interface{}, error) {

--- a/storage/compressor.go
+++ b/storage/compressor.go
@@ -237,13 +237,18 @@ func (c *Compressor) decodeMap(input []byte) (map[string]interface{}, error) {
 }
 
 // EncodeAccountCoin is used to encode an *AccountCoin using the scheme (on the happy path):
-// accountAddress|coinIdentifier|amountValue|amountCurrencySymbol|amountCurrencyDecimals // nolint
+// accountAddress|coinIdentifier|amountValue|amountCurrencySymbol|
+// amountCurrencyDecimals
 //
 // And the following scheme on the unhappy path:
-// accountAddress|coinIdentifier|amountValue|amountCurrencySymbol|amountCurrencyDecimals|accountMetadata|subAccountAddress|subAccountMetadata|amountMetadata|currencyMetadata // nolint
+// accountAddress|coinIdentifier|amountValue|amountCurrencySymbol|
+// amountCurrencyDecimals|accountMetadata|subAccountAddress|
+// subAccountMetadata|amountMetadata|currencyMetadata
 //
 // In both cases, the | character is represetned by the unicodeRecordSeparator rune.
-func (c *Compressor) EncodeAccountCoin(accountCoin *AccountCoin) ([]byte, error) {
+func (c *Compressor) EncodeAccountCoin(
+	accountCoin *AccountCoin,
+) ([]byte, error) { // nolint:gocognit
 	output := c.pool.Get()
 	if _, err := output.WriteString(accountCoin.Account.Address); err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrObjectEncodeFailed, err.Error())
@@ -333,7 +338,7 @@ func (c *Compressor) EncodeAccountCoin(accountCoin *AccountCoin) ([]byte, error)
 
 // DecodeAccountCoin decodes an AccountCoin and optionally
 // reclaims the memory associated with the input.
-func (c *Compressor) DecodeAccountCoin(
+func (c *Compressor) DecodeAccountCoin( // nolint:gocognit
 	b []byte,
 	accountCoin *AccountCoin,
 	reclaimInput bool,

--- a/storage/compressor_test.go
+++ b/storage/compressor_test.go
@@ -158,7 +158,7 @@ func BenchmarkAccountCoinOptimized(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// encode
-		manualResult := c.EncodeAccountCoin(benchmarkCoin)
+		manualResult, _ := c.EncodeAccountCoin(benchmarkCoin)
 
 		// decode
 		var decoded AccountCoin
@@ -170,7 +170,7 @@ func BenchmarkComplexAccountCoinOptimized(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// encode
-		manualResult := c.EncodeAccountCoin(complexCoin)
+		manualResult, _ := c.EncodeAccountCoin(complexCoin)
 
 		// decode
 		var decoded AccountCoin
@@ -239,8 +239,10 @@ func TestEncodeDecodeAccountCoin(t *testing.T) {
 		assert.NoError(t, err)
 
 		t.Run(name, func(t *testing.T) {
-			standardResult, _ := c.Encode("", test.accountCoin)
-			optimizedResult := c.EncodeAccountCoin(test.accountCoin)
+			standardResult, err := c.Encode("", test.accountCoin)
+			assert.NoError(t, err)
+			optimizedResult, err := c.EncodeAccountCoin(test.accountCoin)
+			assert.NoError(t, err)
 			fmt.Printf(
 				"Uncompressed: %d, Standard Compressed: %d, Optimized: %d\n",
 				len(types.PrintStruct(test.accountCoin)),

--- a/storage/compressor_test.go
+++ b/storage/compressor_test.go
@@ -79,3 +79,179 @@ func TestCompressor(t *testing.T) {
 
 	assert.NoError(t, g.Wait())
 }
+
+var (
+	benchmarkCoin = &AccountCoin{
+		Account: &types.AccountIdentifier{
+			Address: "hello",
+		},
+		Coin: &types.Coin{
+			CoinIdentifier: &types.CoinIdentifier{
+				Identifier: "coin1",
+			},
+			Amount: &types.Amount{
+				Value: "100",
+				Currency: &types.Currency{
+					Symbol:   "BTC",
+					Decimals: 8,
+				},
+			},
+		},
+	}
+
+	complexCoin = &AccountCoin{
+		Account: &types.AccountIdentifier{
+			Address: "hello",
+			SubAccount: &types.SubAccountIdentifier{
+				Address: "sub",
+				Metadata: map[string]interface{}{
+					"test": "stuff",
+				},
+			},
+		},
+		Coin: &types.Coin{
+			CoinIdentifier: &types.CoinIdentifier{
+				Identifier: "coin1",
+			},
+			Amount: &types.Amount{
+				Value: "100",
+				Currency: &types.Currency{
+					Symbol:   "BTC",
+					Decimals: 8,
+					Metadata: map[string]interface{}{
+						"issuer": "satoshi",
+					},
+				},
+			},
+		},
+	}
+)
+
+func BenchmarkAccountCoinStandard(b *testing.B) {
+	c, _ := NewCompressor(nil, NewBufferPool())
+
+	for i := 0; i < b.N; i++ {
+		// encode
+		compressedResult, _ := c.Encode("", benchmarkCoin)
+
+		// decode
+		var decoded AccountCoin
+		_ = c.Decode("", compressedResult, &decoded, true)
+	}
+}
+
+func BenchmarkComplexAccountCoinStandard(b *testing.B) {
+	c, _ := NewCompressor(nil, NewBufferPool())
+
+	for i := 0; i < b.N; i++ {
+		// encode
+		compressedResult, _ := c.Encode("", complexCoin)
+
+		// decode
+		var decoded AccountCoin
+		_ = c.Decode("", compressedResult, &decoded, true)
+	}
+}
+
+func BenchmarkAccountCoinOptimized(b *testing.B) {
+	c, _ := NewCompressor(nil, NewBufferPool())
+
+	for i := 0; i < b.N; i++ {
+		// encode
+		manualResult := c.EncodeAccountCoin(benchmarkCoin)
+
+		// decode
+		var decoded AccountCoin
+		_ = c.DecodeAccountCoin(manualResult, &decoded, true)
+	}
+}
+func BenchmarkComplexAccountCoinOptimized(b *testing.B) {
+	c, _ := NewCompressor(nil, NewBufferPool())
+
+	for i := 0; i < b.N; i++ {
+		// encode
+		manualResult := c.EncodeAccountCoin(complexCoin)
+
+		// decode
+		var decoded AccountCoin
+		_ = c.DecodeAccountCoin(manualResult, &decoded, true)
+	}
+}
+
+func TestEncodeDecodeAccountCoin(t *testing.T) {
+	tests := map[string]struct {
+		accountCoin *AccountCoin
+	}{
+		"simple": {
+			accountCoin: benchmarkCoin,
+		},
+		"sub account info": {
+			accountCoin: &AccountCoin{
+				Account: &types.AccountIdentifier{
+					Address: "hello",
+					SubAccount: &types.SubAccountIdentifier{
+						Address: "sub",
+						Metadata: map[string]interface{}{
+							"test": "stuff",
+						},
+					},
+				},
+				Coin: &types.Coin{
+					CoinIdentifier: &types.CoinIdentifier{
+						Identifier: "coin1",
+					},
+					Amount: &types.Amount{
+						Value: "100",
+						Currency: &types.Currency{
+							Symbol:   "BTC",
+							Decimals: 8,
+						},
+					},
+				},
+			},
+		},
+		"currency metadata": {
+			accountCoin: &AccountCoin{
+				Account: &types.AccountIdentifier{
+					Address: "hello",
+				},
+				Coin: &types.Coin{
+					CoinIdentifier: &types.CoinIdentifier{
+						Identifier: "coin1",
+					},
+					Amount: &types.Amount{
+						Value: "100",
+						Currency: &types.Currency{
+							Symbol:   "BTC",
+							Decimals: 8,
+							Metadata: map[string]interface{}{
+								"issuer": "satoshi",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		c, err := NewCompressor(nil, NewBufferPool())
+		assert.NoError(t, err)
+
+		t.Run(name, func(t *testing.T) {
+			standardResult, _ := c.Encode("", test.accountCoin)
+			optimizedResult := c.EncodeAccountCoin(test.accountCoin)
+			fmt.Printf(
+				"Uncompressed: %d, Standard Compressed: %d, Optimized: %d\n",
+				len(types.PrintStruct(test.accountCoin)),
+				len(standardResult),
+				len(optimizedResult),
+			)
+
+			var decoded AccountCoin
+			assert.NoError(t, c.DecodeAccountCoin(optimizedResult, &decoded, true))
+
+			assert.Equal(t, test.accountCoin, &decoded)
+		})
+	}
+}


### PR DESCRIPTION
This PR changes `CoinStorage` to use an optimized encoding scheme instead of the standard `zstd` encoding. This significantly reduces the size of data stored on disk, utilizes much less memory, and is waaaaaay faster.

### Size Comparison (81% reduction in size 🎉 )
```text
Small Data (happy path):
Uncompressed: 147 B, Standard Compressed: 116 B, Optimized: 21 B

Complex Data (tons of metadata):
Uncompressed: 207 B, Standard Compressed: 137 B, Optimized: 41 B
```

### Runtime Benchmarks (99.5% reduction in time/op 🎉 )
```text
BenchmarkAccountCoinStandard
BenchmarkAccountCoinStandard-12            	   15799	     74628 ns/op	    2793 B/op	      29 allocs/op
BenchmarkComplexAccountCoinStandard
BenchmarkComplexAccountCoinStandard-12     	   15390	     80565 ns/op	    3597 B/op	      44 allocs/op
BenchmarkAccountCoinOptimized
BenchmarkAccountCoinOptimized-12           	 3039498	       373 ns/op	     192 B/op	      10 allocs/op
BenchmarkComplexAccountCoinOptimized
BenchmarkComplexAccountCoinOptimized-12    	  572340	      2071 ns/op	    1696 B/op	      34 allocs/op
```