### PR TITLE
[Fetcher] Verbose network mismatch error

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -159,9 +160,16 @@ func (f *Fetcher) InitializeAsserter(
 
 	primaryNetwork := networkList.NetworkIdentifiers[0]
 	if networkIdentifier != nil {
-		exists, _ := CheckNetworkListForNetwork(networkList, networkIdentifier)
+		exists, supportedNetworks := CheckNetworkListForNetwork(networkList, networkIdentifier)
 		if !exists {
-			return nil, nil, &Error{Err: ErrNetworkMissing}
+			return nil, nil, &Error{
+				Err: fmt.Errorf(
+					"%w: %s not in %s",
+					ErrNetworkMissing,
+					types.PrintStruct(networkIdentifier),
+					types.PrintStruct(supportedNetworks),
+				),
+			}
 		}
 
 		primaryNetwork = networkIdentifier

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -32,6 +32,10 @@ const (
 	// because of high memory usage or because a client has opened too many
 	// connections.
 	connectionResetByPeer = "connection reset by peer"
+
+	// clientTimeout is returned when a request exceeds the set
+	// HTTP timeout setting.
+	clientTimeout = "Client.Timeout exceeded"
 )
 
 // backoffRetries creates the backoff.BackOff struct used by all
@@ -47,10 +51,12 @@ func backoffRetries(
 
 // transientError returns a boolean indicating if a particular
 // error is considered transient (so the request should be
-// retried).
+// retried). Currently, we consider EOF, connection reset by
+// peer, and timeout to be transient.
 func transientError(err error) bool {
 	if strings.Contains(err.Error(), io.EOF.Error()) ||
-		strings.Contains(err.Error(), connectionResetByPeer) {
+		strings.Contains(err.Error(), connectionResetByPeer) ||
+		strings.Contains(err.Error(), clientTimeout) {
 		return true
 	}
 


### PR DESCRIPTION
This is a very small PR that returns more details about network mismatch when `InitializeAsserter` fails.