### PR TITLE
[Constructor] Return Funds Workflow

### DIFF
--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -33,6 +33,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+const (
+	unsignedTx    = "unsigned transaction"
+	networkTx     = "network transaction"
+	jobIdentifier = "job"
+)
+
 func simpleAsserterConfiguration() (*asserter.Asserter, error) {
 	return asserter.NewClientWithOptions(
 		&types.NetworkIdentifier{
@@ -587,7 +593,6 @@ func TestProcess(t *testing.T) {
 		[]*types.PublicKey{},
 	).Return(fetchedMetadata, nil, nil).Once()
 
-	unsignedTx := "unsigned transaction"
 	signingPayloads := []*types.SigningPayload{
 		{
 			AccountIdentifier: &types.AccountIdentifier{Address: "address1"},
@@ -626,7 +631,6 @@ func TestProcess(t *testing.T) {
 		ctx,
 		signingPayloads,
 	).Return(signatures, nil).Once()
-	networkTx := "network transaction"
 	helper.On(
 		"Combine",
 		ctx,
@@ -932,12 +936,12 @@ func TestProcess_Failed(t *testing.T) {
 		dbTx,
 		mock.Anything,
 	).Return(
-		"job",
+		jobIdentifier,
 		nil,
 	).Run(
 		func(args mock.Arguments) {
 			j = *args.Get(2).(*job.Job)
-			j.Identifier = "job"
+			j.Identifier = jobIdentifier
 		},
 	).Once()
 
@@ -1046,7 +1050,6 @@ func TestProcess_Failed(t *testing.T) {
 		},
 	).Return(fetchedMetadata, nil, nil).Once()
 
-	unsignedTx := "unsigned transaction"
 	signingPayloads := []*types.SigningPayload{
 		{
 			AccountIdentifier: &types.AccountIdentifier{Address: "address1"},
@@ -1094,7 +1097,6 @@ func TestProcess_Failed(t *testing.T) {
 		ctx,
 		signingPayloads,
 	).Return(signatures, nil).Once()
-	networkTx := "network transaction"
 	helper.On(
 		"Combine",
 		ctx,
@@ -1122,14 +1124,14 @@ func TestProcess_Failed(t *testing.T) {
 		"Broadcast",
 		ctx,
 		dbTx,
-		"job",
+		jobIdentifier,
 		network,
 		ops,
 		txIdentifier,
 		networkTx,
 		int64(1),
 	).Return(nil).Once()
-	handler.On("TransactionCreated", ctx, "job", txIdentifier).Return(nil).Once()
+	handler.On("TransactionCreated", ctx, jobIdentifier, txIdentifier).Return(nil).Once()
 	helper.On("BroadcastAll", ctx).Return(nil).Once()
 
 	// Start processor
@@ -1157,7 +1159,7 @@ func TestProcess_Failed(t *testing.T) {
 	go func() {
 		<-markConfirmed
 		dbTx3 := db.NewDatabaseTransaction(ctx, false)
-		jobStorage.On("Get", ctx, dbTx3, "job").Return(&j, nil).Once()
+		jobStorage.On("Get", ctx, dbTx3, jobIdentifier).Return(&j, nil).Once()
 		jobStorage.On(
 			"Update",
 			ctx,
@@ -1165,15 +1167,15 @@ func TestProcess_Failed(t *testing.T) {
 			mock.Anything,
 		).Run(func(args mock.Arguments) {
 			j = *args.Get(2).(*job.Job)
-			j.Identifier = "job"
+			j.Identifier = jobIdentifier
 			cancel()
 		}).Return(
-			"job",
+			jobIdentifier,
 			nil,
 		)
 
 		// Process second step of job
-		err = c.BroadcastComplete(ctx, dbTx3, "job", nil)
+		err = c.BroadcastComplete(ctx, dbTx3, jobIdentifier, nil)
 		assert.NoError(t, err)
 	}()
 
@@ -1648,7 +1650,15 @@ func TestReturnFunds_NoBalance(t *testing.T) {
 	dbTxFail := db.NewDatabaseTransaction(ctx, false)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
 	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
-	jobStorage.On("Processing", ctx, dbTxFail, string(job.ReturnFunds)).Return([]*job.Job{}, nil).Once()
+	jobStorage.On(
+		"Processing",
+		ctx,
+		dbTxFail,
+		string(job.ReturnFunds),
+	).Return(
+		[]*job.Job{},
+		nil,
+	).Once()
 	helper.On("AllAccounts", ctx, dbTxFail).Return([]*types.AccountIdentifier{
 		{Address: "address1"},
 		{Address: "address2"},
@@ -1979,7 +1989,15 @@ func TestReturnFunds(t *testing.T) {
 	dbTxFail := db.NewDatabaseTransaction(ctx, false)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
 	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
-	jobStorage.On("Processing", ctx, dbTxFail, string(job.ReturnFunds)).Return([]*job.Job{}, nil).Once()
+	jobStorage.On(
+		"Processing",
+		ctx,
+		dbTxFail,
+		string(job.ReturnFunds),
+	).Return(
+		[]*job.Job{},
+		nil,
+	).Once()
 	helper.On("AllAccounts", ctx, dbTxFail).Return([]*types.AccountIdentifier{
 		{Address: "address1"},
 	}, nil).Once()
@@ -2011,12 +2029,12 @@ func TestReturnFunds(t *testing.T) {
 		dbTxFail,
 		mock.Anything,
 	).Return(
-		"job",
+		jobIdentifier,
 		nil,
 	).Run(
 		func(args mock.Arguments) {
 			j = *args.Get(2).(*job.Job)
-			j.Identifier = "job"
+			j.Identifier = jobIdentifier
 		},
 	).Once()
 
@@ -2080,7 +2098,6 @@ func TestReturnFunds(t *testing.T) {
 		[]*types.PublicKey{},
 	).Return(fetchedMetadata, nil, nil).Once()
 
-	unsignedTx := "unsigned transaction"
 	signingPayloads := []*types.SigningPayload{
 		{
 			AccountIdentifier: &types.AccountIdentifier{Address: "address1"},
@@ -2119,7 +2136,6 @@ func TestReturnFunds(t *testing.T) {
 		ctx,
 		signingPayloads,
 	).Return(signatures, nil).Once()
-	networkTx := "network transaction"
 	helper.On(
 		"Combine",
 		ctx,
@@ -2150,14 +2166,14 @@ func TestReturnFunds(t *testing.T) {
 		"Broadcast",
 		ctx,
 		dbTxFail,
-		"job",
+		jobIdentifier,
 		network,
 		ops,
 		txIdentifier,
 		networkTx,
 		int64(1),
 	).Return(nil).Once()
-	handler.On("TransactionCreated", ctx, "job", txIdentifier).Return(nil).Once()
+	handler.On("TransactionCreated", ctx, jobIdentifier, txIdentifier).Return(nil).Once()
 	helper.On("BroadcastAll", ctx).Return(nil).Once()
 
 	// Start processor
@@ -2172,7 +2188,15 @@ func TestReturnFunds(t *testing.T) {
 	dbTx := db.NewDatabaseTransaction(ctx, false)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx).Once()
 	jobStorage.On("Ready", ctx, dbTx).Return([]*job.Job{}, nil).Once()
-	jobStorage.On("Processing", ctx, dbTx, string(job.ReturnFunds)).Return([]*job.Job{&j}, nil).Once()
+	jobStorage.On(
+		"Processing",
+		ctx,
+		dbTx,
+		string(job.ReturnFunds),
+	).Return(
+		[]*job.Job{&j},
+		nil,
+	).Once()
 
 	markConfirmed := make(chan struct{})
 	jobStorage.On("Broadcasting", ctx, dbTx).Return([]*job.Job{
@@ -2214,7 +2238,7 @@ func TestReturnFunds(t *testing.T) {
 	go func() {
 		<-markConfirmed
 		dbTx2 := db.NewDatabaseTransaction(ctx, false)
-		jobStorage.On("Get", ctx, dbTx2, "job").Return(&j, nil).Once()
+		jobStorage.On("Get", ctx, dbTx2, jobIdentifier).Return(&j, nil).Once()
 		jobStorage.On(
 			"Update",
 			ctx,
@@ -2222,9 +2246,9 @@ func TestReturnFunds(t *testing.T) {
 			mock.Anything,
 		).Run(func(args mock.Arguments) {
 			j = *args.Get(2).(*job.Job)
-			j.Identifier = "job"
+			j.Identifier = jobIdentifier
 		}).Return(
-			"job",
+			jobIdentifier,
 			nil,
 		)
 		tx := &types.Transaction{
@@ -2232,7 +2256,7 @@ func TestReturnFunds(t *testing.T) {
 			Operations:            onchainOps,
 		}
 
-		err = c.BroadcastComplete(ctx, dbTx2, "job", tx)
+		err = c.BroadcastComplete(ctx, dbTx2, jobIdentifier, tx)
 		assert.NoError(t, err)
 	}()
 
@@ -2241,7 +2265,15 @@ func TestReturnFunds(t *testing.T) {
 	dbTx3 := db.NewDatabaseTransaction(ctx, false)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx3).Once()
 	jobStorage.On("Ready", ctx, dbTx3).Return([]*job.Job{}, nil).Once()
-	jobStorage.On("Processing", ctx, dbTx3, string(job.ReturnFunds)).Return([]*job.Job{}, nil).Once()
+	jobStorage.On(
+		"Processing",
+		ctx,
+		dbTx3,
+		string(job.ReturnFunds),
+	).Return(
+		[]*job.Job{},
+		nil,
+	).Once()
 	helper.On("AllAccounts", ctx, dbTx3).Return([]*types.AccountIdentifier{
 		{Address: "address1"},
 	}, nil).Once()

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -1489,3 +1489,812 @@ func TestProcess_DryRun(t *testing.T) {
 	jobStorage.AssertExpectations(t)
 	helper.AssertExpectations(t)
 }
+
+// func TestReturnFunds(t *testing.T) {
+// 	ctx := context.Background()
+// 	ctx, cancel := context.WithCancel(ctx)
+//
+// 	jobStorage := &mocks.JobStorage{}
+// 	helper := &mocks.Helper{}
+// 	handler := &mocks.Handler{}
+// 	p := defaultParser(t)
+// 	workflows := []*job.Workflow{
+// 		{
+// 			Name:        string(job.RequestFunds),
+// 			Concurrency: 1,
+// 			Scenarios: []*job.Scenario{
+// 				{
+// 					Name: "find_address",
+// 					Actions: []*job.Action{
+// 						{
+// 							Type:       job.SetVariable,
+// 							Input:      `{"symbol":"tBTC", "decimals":8}`,
+// 							OutputPath: "currency",
+// 						},
+// 						{
+// 							Type:       job.FindBalance,
+// 							Input:      `{"minimum_balance":{"value": "0", "currency": {{currency}}}, "create_limit":1}`, // nolint
+// 							OutputPath: "random_address",
+// 						},
+// 					},
+// 				},
+// 				{
+// 					Name: "request",
+// 					Actions: []*job.Action{
+// 						{
+// 							Type:       job.FindBalance,
+// 							Input:      `{"account_identifier": {{random_address.account_identifier}}, "minimum_balance":{"value": "100", "currency": {{currency}}}}`, // nolint
+// 							OutputPath: "loaded_address",
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:        string(job.CreateAccount),
+// 			Concurrency: 1,
+// 			Scenarios: []*job.Scenario{
+// 				{
+// 					Name: "create_account",
+// 					Actions: []*job.Action{
+// 						{
+// 							Type:       job.SetVariable,
+// 							Input:      `{"network":"Testnet3", "blockchain":"Bitcoin"}`,
+// 							OutputPath: "network",
+// 						},
+// 						{
+// 							Type:       job.GenerateKey,
+// 							Input:      `{"curve_type": "secp256k1"}`,
+// 							OutputPath: "key",
+// 						},
+// 						{
+// 							Type:       job.Derive,
+// 							Input:      `{"network_identifier": {{network}}, "public_key": {{key.public_key}}}`,
+// 							OutputPath: "account",
+// 						},
+// 						{
+// 							Type:  job.SaveAccount,
+// 							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			Name:        "transfer",
+// 			Concurrency: 1,
+// 			Scenarios: []*job.Scenario{
+// 				{
+// 					Name: "transfer",
+// 					Actions: []*job.Action{
+// 						{
+// 							Type:       job.SetVariable,
+// 							Input:      `{"network":"Testnet3", "blockchain":"Bitcoin"}`,
+// 							OutputPath: "transfer.network",
+// 						},
+// 						{
+// 							Type:       job.SetVariable,
+// 							Input:      `{"symbol":"tBTC", "decimals":8}`,
+// 							OutputPath: "currency",
+// 						},
+// 						{
+// 							Type:       job.FindBalance,
+// 							Input:      `{"minimum_balance":{"value": "100", "currency": {{currency}}}, "create_limit": 100}`, // nolint
+// 							OutputPath: "sender",
+// 						},
+// 						{
+// 							Type:       job.Math,
+// 							Input:      `{"operation":"subtraction", "left_value": "0", "right_value":{{sender.balance.value}}}`,
+// 							OutputPath: "sender_amount",
+// 						},
+// 						{
+// 							Type:       job.FindBalance,
+// 							Input:      `{"not_account_identifier":[{{sender.account_identifier}}], "minimum_balance":{"value": "0", "currency": {{currency}}}, "create_limit": 100}`, // nolint
+// 							OutputPath: "recipient",
+// 						},
+// 						{
+// 							Type:       job.Math,
+// 							Input:      `{"operation":"subtraction", "left_value":{{sender.balance.value}}, "right_value":"10"}`,
+// 							OutputPath: "recipient_amount",
+// 						},
+// 						{
+// 							Type:       job.SetVariable,
+// 							Input:      `"1"`,
+// 							OutputPath: "transfer.confirmation_depth",
+// 						},
+// 						{
+// 							Type:       job.SetVariable,
+// 							Input:      `{"test": "works"}`,
+// 							OutputPath: "transfer.preprocess_metadata",
+// 						},
+// 						{
+// 							Type:       job.SetVariable,
+// 							Input:      `[{"operation_identifier":{"index":0},"type":"Vin","status":"","account":{{sender.account_identifier}},"amount":{"value":{{sender_amount}},"currency":{{currency}}}},{"operation_identifier":{"index":1},"type":"Vout","status":"","account":{{recipient.account_identifier}},"amount":{"value":{{recipient_amount}},"currency":{{currency}}}}]`, // nolint
+// 							OutputPath: "transfer.operations",
+// 						},
+// 					},
+// 				},
+// 				{
+// 					Name: "print_transaction",
+// 					Actions: []*job.Action{
+// 						{
+// 							Type:  job.PrintMessage,
+// 							Input: `{{transfer.transaction}}`,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
+//
+// 	c, err := New(
+// 		jobStorage,
+// 		helper,
+// 		handler,
+// 		p,
+// 		workflows,
+// 	)
+// 	assert.NotNil(t, c)
+// 	assert.NoError(t, err)
+//
+// 	// Create coordination channels
+// 	processCanceled := make(chan struct{})
+//
+// 	dir, err := utils.CreateTempDir()
+// 	assert.NoError(t, err)
+//
+// 	db, err := storage.NewBadgerStorage(
+// 		ctx,
+// 		dir,
+// 		storage.WithIndexCacheSize(storage.TinyIndexCacheSize),
+// 	)
+// 	assert.NoError(t, err)
+// 	assert.NotNil(t, db)
+//
+// 	// HeadBlockExists is false first
+// 	helper.On("HeadBlockExists", ctx).Return(false).Once()
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+//
+// 	// Attempt to transfer
+// 	// We use a "read" database transaction in this test because we mock
+// 	// all responses from the database and "write" transactions require a
+// 	// lock. While it would be possible to orchestrate these locks in this
+// 	// test, it is simpler to just use a "read" transaction.
+// 	dbTxFail := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
+// 	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Processing", ctx, dbTxFail, "transfer").Return([]*job.Job{}, nil).Once()
+// 	helper.On("AllAccounts", ctx, dbTxFail).Return([]*types.AccountIdentifier{}, nil).Once()
+//
+// 	// Start processor
+// 	go func() {
+// 		err := c.Process(ctx)
+// 		fmt.Println(err)
+// 		assert.True(t, errors.Is(err, context.Canceled))
+// 		close(processCanceled)
+// 	}()
+//
+// 	// Determine account must be created
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+//
+// 	dbTx := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTx).Once()
+// 	jobStorage.On("Ready", ctx, dbTx).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Broadcasting", ctx, dbTx).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Processing", ctx, dbTx, "create_account").Return([]*job.Job{}, nil).Once()
+// 	helper.On(
+// 		"Derive",
+// 		ctx,
+// 		&types.NetworkIdentifier{
+// 			Blockchain: "Bitcoin",
+// 			Network:    "Testnet3",
+// 		},
+// 		mock.Anything,
+// 		(map[string]interface{})(nil),
+// 	).Return(
+// 		&types.AccountIdentifier{Address: "address1"},
+// 		nil,
+// 		nil,
+// 	).Once()
+// 	helper.On(
+// 		"StoreKey",
+// 		ctx,
+// 		dbTx,
+// 		&types.AccountIdentifier{Address: "address1"},
+// 		mock.Anything,
+// 	).Return(nil).Once()
+// 	jobStorage.On("Update", ctx, dbTx, mock.Anything).Return("job1", nil).Once()
+// 	helper.On("BroadcastAll", ctx).Return(nil).Once()
+//
+// 	// Attempt to run transfer again (but determine funds are needed)
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+// 	dbTxFail2 := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail2).Once()
+// 	jobStorage.On("Ready", ctx, dbTxFail2).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Processing", ctx, dbTxFail2, "transfer").Return([]*job.Job{}, nil).Once()
+// 	helper.On("AllAccounts", ctx, dbTxFail2).Return([]*types.AccountIdentifier{
+// 		{Address: "address1"},
+// 	}, nil).Once()
+// 	helper.On("LockedAccounts", ctx, dbTxFail2).Return([]*types.AccountIdentifier{}, nil).Once()
+// 	helper.On(
+// 		"Balance",
+// 		ctx,
+// 		dbTxFail2,
+// 		&types.AccountIdentifier{Address: "address1"},
+// 		&types.Currency{
+// 			Symbol:   "tBTC",
+// 			Decimals: 8,
+// 		},
+// 	).Return(
+// 		&types.Amount{
+// 			Value: "0",
+// 			Currency: &types.Currency{
+// 				Symbol:   "tBTC",
+// 				Decimals: 8,
+// 			},
+// 		},
+// 		nil,
+// 	).Once()
+//
+// 	// Attempt funds request
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+//
+// 	dbTx2 := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTx2).Once()
+// 	jobStorage.On("Ready", ctx, dbTx2).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Broadcasting", ctx, dbTx2).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Processing", ctx, dbTx2, "request_funds").Return([]*job.Job{}, nil).Once()
+// 	helper.On("AllAccounts", ctx, dbTx2).Return([]*types.AccountIdentifier{
+// 		{Address: "address1"},
+// 	}, nil).Once()
+// 	helper.On("LockedAccounts", ctx, dbTx2).Return([]*types.AccountIdentifier{}, nil).Once()
+// 	helper.On(
+// 		"Balance",
+// 		ctx,
+// 		dbTx2,
+// 		&types.AccountIdentifier{Address: "address1"},
+// 		&types.Currency{
+// 			Symbol:   "tBTC",
+// 			Decimals: 8,
+// 		},
+// 	).Return(
+// 		&types.Amount{
+// 			Value: "0",
+// 			Currency: &types.Currency{
+// 				Symbol:   "tBTC",
+// 				Decimals: 8,
+// 			},
+// 		},
+// 		nil,
+// 	).Once()
+// 	var jobExtra job.Job
+// 	jobStorage.On(
+// 		"Update",
+// 		ctx,
+// 		dbTx2,
+// 		mock.Anything,
+// 	).Return(
+// 		"jobExtra",
+// 		nil,
+// 	).Run(
+// 		func(args mock.Arguments) {
+// 			jobExtra = *args.Get(2).(*job.Job)
+// 			jobExtra.Identifier = "jobExtra"
+// 		},
+// 	).Once()
+// 	helper.On("BroadcastAll", ctx).Return(nil).Once()
+//
+// 	// Load funds
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+// 	dbTxExtra := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTxExtra).Once()
+// 	jobStorage.On("Ready", ctx, dbTxExtra).Return([]*job.Job{&jobExtra}, nil).Once()
+// 	helper.On("AllAccounts", ctx, dbTxExtra).Return([]*types.AccountIdentifier{
+// 		{Address: "address1"},
+// 	}, nil).Once()
+// 	helper.On("LockedAccounts", ctx, dbTxExtra).Return([]*types.AccountIdentifier{}, nil).Once()
+// 	helper.On(
+// 		"Balance",
+// 		ctx,
+// 		dbTxExtra,
+// 		&types.AccountIdentifier{Address: "address1"},
+// 		&types.Currency{
+// 			Symbol:   "tBTC",
+// 			Decimals: 8,
+// 		},
+// 	).Return(
+// 		&types.Amount{
+// 			Value: "100",
+// 			Currency: &types.Currency{
+// 				Symbol:   "tBTC",
+// 				Decimals: 8,
+// 			},
+// 		},
+// 		nil,
+// 	).Once()
+//
+// 	// Wait until we get here to continue setting up mocks
+// 	jobStorage.On("Update", ctx, dbTxExtra, mock.Anything).Return("jobExtra", nil).Once()
+// 	helper.On("BroadcastAll", ctx).Return(nil).Once()
+//
+// 	// Attempt to transfer again
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+// 	dbTxFail3 := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail3).Once()
+// 	jobStorage.On("Ready", ctx, dbTxFail3).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Processing", ctx, dbTxFail3, "transfer").Return([]*job.Job{}, nil).Once()
+// 	helper.On("AllAccounts", ctx, dbTxFail3).Return([]*types.AccountIdentifier{
+// 		{Address: "address1"},
+// 	}, nil).Once()
+// 	helper.On("LockedAccounts", ctx, dbTxFail3).Return([]*types.AccountIdentifier{}, nil).Once()
+// 	helper.On(
+// 		"Balance",
+// 		ctx,
+// 		dbTxFail3,
+// 		&types.AccountIdentifier{Address: "address1"},
+// 		&types.Currency{
+// 			Symbol:   "tBTC",
+// 			Decimals: 8,
+// 		},
+// 	).Return(
+// 		&types.Amount{
+// 			Value: "100",
+// 			Currency: &types.Currency{
+// 				Symbol:   "tBTC",
+// 				Decimals: 8,
+// 			},
+// 		},
+// 		nil,
+// 	).Once()
+// 	helper.On("AllAccounts", ctx, dbTxFail3).Return([]*types.AccountIdentifier{
+// 		{Address: "address1"},
+// 	}, nil).Once()
+// 	helper.On("LockedAccounts", ctx, dbTxFail3).Return([]*types.AccountIdentifier{}, nil).Once()
+//
+// 	// Attempt to create recipient
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+// 	dbTx3 := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTx3).Once()
+// 	jobStorage.On("Ready", ctx, dbTx3).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Broadcasting", ctx, dbTx3).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Processing", ctx, dbTx3, "create_account").Return([]*job.Job{}, nil).Once()
+// 	helper.On(
+// 		"Derive",
+// 		ctx,
+// 		&types.NetworkIdentifier{
+// 			Blockchain: "Bitcoin",
+// 			Network:    "Testnet3",
+// 		},
+// 		mock.Anything,
+// 		(map[string]interface{})(nil),
+// 	).Return(
+// 		&types.AccountIdentifier{Address: "address2"},
+// 		nil,
+// 		nil,
+// 	).Once()
+// 	helper.On(
+// 		"StoreKey",
+// 		ctx,
+// 		dbTx3,
+// 		&types.AccountIdentifier{Address: "address2"},
+// 		mock.Anything,
+// 	).Return(nil).Once()
+// 	jobStorage.On("Update", ctx, dbTx3, mock.Anything).Return("job3", nil).Once()
+// 	helper.On("BroadcastAll", ctx).Return(nil).Once()
+//
+// 	// Attempt to create transfer
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+// 	dbTx4 := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTx4).Once()
+// 	jobStorage.On("Ready", ctx, dbTx4).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Processing", ctx, dbTx4, "transfer").Return([]*job.Job{}, nil).Once()
+// 	helper.On("AllAccounts", ctx, dbTx4).Return([]*types.AccountIdentifier{
+// 		{Address: "address1"},
+// 		{Address: "address2"},
+// 	}, nil).Once()
+// 	helper.On("LockedAccounts", ctx, dbTx4).Return([]*types.AccountIdentifier{}, nil).Once()
+// 	helper.On(
+// 		"Balance",
+// 		ctx,
+// 		dbTx4,
+// 		&types.AccountIdentifier{Address: "address1"},
+// 		&types.Currency{
+// 			Symbol:   "tBTC",
+// 			Decimals: 8,
+// 		},
+// 	).Return(
+// 		&types.Amount{
+// 			Value: "100",
+// 			Currency: &types.Currency{
+// 				Symbol:   "tBTC",
+// 				Decimals: 8,
+// 			},
+// 		},
+// 		nil,
+// 	).Once()
+// 	helper.On("AllAccounts", ctx, dbTx4).Return([]*types.AccountIdentifier{
+// 		{Address: "address1"},
+// 		{Address: "address2"},
+// 	}, nil).Once()
+// 	helper.On("LockedAccounts", ctx, dbTx4).Return([]*types.AccountIdentifier{}, nil).Once()
+// 	helper.On(
+// 		"Balance",
+// 		ctx,
+// 		dbTx4,
+// 		&types.AccountIdentifier{Address: "address2"},
+// 		&types.Currency{
+// 			Symbol:   "tBTC",
+// 			Decimals: 8,
+// 		},
+// 	).Return(
+// 		&types.Amount{
+// 			Value: "0",
+// 			Currency: &types.Currency{
+// 				Symbol:   "tBTC",
+// 				Decimals: 8,
+// 			},
+// 		},
+// 		nil,
+// 	).Once()
+// 	var job4 job.Job
+// 	jobStorage.On(
+// 		"Update",
+// 		ctx,
+// 		dbTx4,
+// 		mock.Anything,
+// 	).Return(
+// 		"job4",
+// 		nil,
+// 	).Run(
+// 		func(args mock.Arguments) {
+// 			job4 = *args.Get(2).(*job.Job)
+// 			job4.Identifier = "job4"
+// 		},
+// 	).Once()
+//
+// 	// Construct Transaction
+// 	network := &types.NetworkIdentifier{
+// 		Blockchain: "Bitcoin",
+// 		Network:    "Testnet3",
+// 	}
+// 	currency := &types.Currency{
+// 		Symbol:   "tBTC",
+// 		Decimals: 8,
+// 	}
+// 	ops := []*types.Operation{
+// 		{
+// 			OperationIdentifier: &types.OperationIdentifier{
+// 				Index: 0,
+// 			},
+// 			Type: "Vin",
+// 			Account: &types.AccountIdentifier{
+// 				Address: "address1",
+// 			},
+// 			Amount: &types.Amount{
+// 				Value:    "-100",
+// 				Currency: currency,
+// 			},
+// 		},
+// 		{
+// 			OperationIdentifier: &types.OperationIdentifier{
+// 				Index: 1,
+// 			},
+// 			Type: "Vout",
+// 			Account: &types.AccountIdentifier{
+// 				Address: "address2",
+// 			},
+// 			Amount: &types.Amount{
+// 				Value:    "90",
+// 				Currency: currency,
+// 			},
+// 		},
+// 	}
+// 	metadataOptions := map[string]interface{}{
+// 		"metadata": "test",
+// 	}
+// 	helper.On(
+// 		"Preprocess",
+// 		ctx,
+// 		network,
+// 		ops,
+// 		map[string]interface{}{
+// 			"test": "works",
+// 		},
+// 	).Return(metadataOptions, nil, nil).Once()
+// 	fetchedMetadata := map[string]interface{}{
+// 		"tx_meta": "help",
+// 	}
+// 	helper.On(
+// 		"Metadata",
+// 		ctx,
+// 		network,
+// 		metadataOptions,
+// 		[]*types.PublicKey{},
+// 	).Return(fetchedMetadata, nil, nil).Once()
+//
+// 	unsignedTx := "unsigned transaction"
+// 	signingPayloads := []*types.SigningPayload{
+// 		{
+// 			AccountIdentifier: &types.AccountIdentifier{Address: "address1"},
+// 			Bytes:             []byte("blah"),
+// 			SignatureType:     types.Ecdsa,
+// 		},
+// 	}
+// 	helper.On(
+// 		"Payloads",
+// 		ctx,
+// 		network,
+// 		ops,
+// 		fetchedMetadata,
+// 		[]*types.PublicKey{},
+// 	).Return(unsignedTx, signingPayloads, nil).Once()
+// 	helper.On(
+// 		"Parse",
+// 		ctx,
+// 		network,
+// 		false,
+// 		unsignedTx,
+// 	).Return(ops, []*types.AccountIdentifier{}, nil, nil).Once()
+// 	signatures := []*types.Signature{
+// 		{
+// 			SigningPayload: signingPayloads[0],
+// 			PublicKey: &types.PublicKey{
+// 				Bytes:     []byte("pubkey"),
+// 				CurveType: types.Secp256k1,
+// 			},
+// 			SignatureType: types.Ecdsa,
+// 			Bytes:         []byte("signature"),
+// 		},
+// 	}
+// 	helper.On(
+// 		"Sign",
+// 		ctx,
+// 		signingPayloads,
+// 	).Return(signatures, nil).Once()
+// 	networkTx := "network transaction"
+// 	helper.On(
+// 		"Combine",
+// 		ctx,
+// 		network,
+// 		unsignedTx,
+// 		signatures,
+// 	).Return(networkTx, nil).Once()
+// 	helper.On(
+// 		"Parse",
+// 		ctx,
+// 		network,
+// 		true,
+// 		networkTx,
+// 	).Return(
+// 		ops,
+// 		[]*types.AccountIdentifier{{Address: "address1"}},
+// 		nil,
+// 		nil,
+// 	).Once()
+// 	txIdentifier := &types.TransactionIdentifier{Hash: "transaction hash"}
+// 	helper.On(
+// 		"Hash",
+// 		ctx,
+// 		network,
+// 		networkTx,
+// 	).Return(txIdentifier, nil).Once()
+// 	helper.On(
+// 		"Broadcast",
+// 		ctx,
+// 		dbTx4,
+// 		"job4",
+// 		network,
+// 		ops,
+// 		txIdentifier,
+// 		networkTx,
+// 		int64(1),
+// 	).Return(nil).Once()
+// 	handler.On("TransactionCreated", ctx, "job4", txIdentifier).Return(nil).Once()
+// 	helper.On("BroadcastAll", ctx).Return(nil).Once()
+//
+// 	// Wait for transfer to complete
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+// 	dbTx5 := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTx5).Once()
+// 	jobStorage.On("Ready", ctx, dbTx5).Return([]*job.Job{}, nil).Once()
+// 	jobStorage.On("Processing", ctx, dbTx5, "transfer").Return([]*job.Job{&job4}, nil).Once()
+//
+// 	markConfirmed := make(chan struct{})
+// 	jobStorage.On("Broadcasting", ctx, dbTx5).Return([]*job.Job{
+// 		&job4,
+// 	}, nil).Run(func(args mock.Arguments) {
+// 		close(markConfirmed)
+// 	}).Once()
+//
+// 	onchainOps := []*types.Operation{
+// 		{
+// 			OperationIdentifier: &types.OperationIdentifier{
+// 				Index: 0,
+// 			},
+// 			Status: "success",
+// 			Type:   "Vin",
+// 			Account: &types.AccountIdentifier{
+// 				Address: "address1",
+// 			},
+// 			Amount: &types.Amount{
+// 				Value:    "-100",
+// 				Currency: currency,
+// 			},
+// 		},
+// 		{
+// 			OperationIdentifier: &types.OperationIdentifier{
+// 				Index: 1,
+// 			},
+// 			Status: "success",
+// 			Type:   "Vout",
+// 			Account: &types.AccountIdentifier{
+// 				Address: "address2",
+// 			},
+// 			Amount: &types.Amount{
+// 				Value:    "90",
+// 				Currency: currency,
+// 			},
+// 		},
+// 	}
+// 	go func() {
+// 		<-markConfirmed
+// 		dbTx6 := db.NewDatabaseTransaction(ctx, false)
+// 		jobStorage.On("Get", ctx, dbTx6, "job4").Return(&job4, nil).Once()
+// 		jobStorage.On(
+// 			"Update",
+// 			ctx,
+// 			dbTx6,
+// 			mock.Anything,
+// 		).Run(func(args mock.Arguments) {
+// 			job4 = *args.Get(2).(*job.Job)
+// 			job4.Identifier = "job4"
+// 		}).Return(
+// 			"job4",
+// 			nil,
+// 		)
+// 		tx := &types.Transaction{
+// 			TransactionIdentifier: txIdentifier,
+// 			Operations:            onchainOps,
+// 		}
+//
+// 		// Process second step of job4
+// 		err = c.BroadcastComplete(ctx, dbTx6, "job4", tx)
+// 		assert.NoError(t, err)
+// 	}()
+//
+// 	helper.On("HeadBlockExists", ctx).Return(true).Once()
+// 	dbTx7 := db.NewDatabaseTransaction(ctx, false)
+// 	helper.On("DatabaseTransaction", ctx).Return(dbTx7).Once()
+// 	jobStorage.On("Ready", ctx, dbTx7).Return([]*job.Job{&job4}, nil).Once()
+// 	jobStorage.On(
+// 		"Update",
+// 		ctx,
+// 		dbTx7,
+// 		mock.Anything,
+// 	).Return(
+// 		"job4",
+// 		nil,
+// 	)
+// 	helper.On("BroadcastAll", ctx).Return(nil).Run(func(args mock.Arguments) {
+// 		fmt.Printf("canceling %+v\n", args)
+// 		cancel()
+// 	}).Once()
+//
+// 	<-processCanceled
+// 	jobStorage.AssertExpectations(t)
+// 	helper.AssertExpectations(t)
+// }
+
+func TestReturnFunds_NoWorkflow(t *testing.T) {
+	ctx := context.Background()
+	jobStorage := &mocks.JobStorage{}
+	helper := &mocks.Helper{}
+	handler := &mocks.Handler{}
+	p := defaultParser(t)
+	workflows := []*job.Workflow{
+		{
+			Name:        string(job.RequestFunds),
+			Concurrency: 1,
+			Scenarios: []*job.Scenario{
+				{
+					Name: "find_address",
+					Actions: []*job.Action{
+						{
+							Type:       job.SetVariable,
+							Input:      `{"symbol":"tBTC", "decimals":8}`,
+							OutputPath: "currency",
+						},
+						{
+							Type:       job.FindBalance,
+							Input:      `{"minimum_balance":{"value": "0", "currency": {{currency}}}, "create_limit":1}`, // nolint
+							OutputPath: "random_address",
+						},
+					},
+				},
+				{
+					Name: "request",
+					Actions: []*job.Action{
+						{
+							Type:       job.FindBalance,
+							Input:      `{"account_identifier": {{random_address.account_identifier}}, "minimum_balance":{"value": "100", "currency": {{currency}}}}`, // nolint
+							OutputPath: "loaded_address",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        string(job.CreateAccount),
+			Concurrency: 1,
+			Scenarios: []*job.Scenario{
+				{
+					Name: "create_account",
+					Actions: []*job.Action{
+						{
+							Type:       job.SetVariable,
+							Input:      `{"network":"Testnet3", "blockchain":"Bitcoin"}`,
+							OutputPath: "network",
+						},
+						{
+							Type:       job.GenerateKey,
+							Input:      `{"curve_type": "secp256k1"}`,
+							OutputPath: "key",
+						},
+						{
+							Type:       job.Derive,
+							Input:      `{"network_identifier": {{network}}, "public_key": {{key.public_key}}}`,
+							OutputPath: "account",
+						},
+						{
+							Type:  job.SaveAccount,
+							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c, err := New(
+		jobStorage,
+		helper,
+		handler,
+		p,
+		workflows,
+	)
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
+
+	// Create coordination channels
+	processCanceled := make(chan struct{})
+
+	dir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+
+	db, err := storage.NewBadgerStorage(
+		ctx,
+		dir,
+		storage.WithIndexCacheSize(storage.TinyIndexCacheSize),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+
+	// HeadBlockExists is false first
+	helper.On("HeadBlockExists", ctx).Return(false).Once()
+	helper.On("HeadBlockExists", ctx).Return(true).Once()
+
+	dbTxFail := db.NewDatabaseTransaction(ctx, false)
+	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
+	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
+
+	// Start processor
+	go func() {
+		err := c.ReturnFunds(ctx)
+		assert.Nil(t, err)
+		close(processCanceled)
+	}()
+
+	<-processCanceled
+	jobStorage.AssertExpectations(t)
+	helper.AssertExpectations(t)
+}

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -1230,6 +1230,39 @@ func TestInitialization_OnlyCreateAccountWorkflows(t *testing.T) {
 	handler.AssertExpectations(t)
 }
 
+func TestInitialization_InvalidConcurrency(t *testing.T) {
+	jobStorage := &mocks.JobStorage{}
+	helper := &mocks.Helper{}
+	handler := &mocks.Handler{}
+	p := defaultParser(t)
+	workflows := []*job.Workflow{
+		{
+			Name:        string(job.CreateAccount),
+			Concurrency: 1,
+		},
+		{
+			Name:        string(job.RequestFunds),
+			Concurrency: 1,
+		},
+		{
+			Name:        "transfer",
+			Concurrency: 0,
+		},
+	}
+
+	c, err := New(
+		jobStorage,
+		helper,
+		handler,
+		p,
+		workflows,
+	)
+	assert.Nil(t, c)
+	assert.True(t, errors.Is(err, ErrInvalidConcurrency))
+	helper.AssertExpectations(t)
+	handler.AssertExpectations(t)
+}
+
 func TestInitialization_OnlyRequestFundsWorkflows(t *testing.T) {
 	jobStorage := &mocks.JobStorage{}
 	helper := &mocks.Helper{}

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -1825,3 +1825,455 @@ func TestReturnFunds_NoWorkflow(t *testing.T) {
 	jobStorage.AssertExpectations(t)
 	helper.AssertExpectations(t)
 }
+
+func TestReturnFunds(t *testing.T) {
+	ctx := context.Background()
+	jobStorage := &mocks.JobStorage{}
+	helper := &mocks.Helper{}
+	handler := &mocks.Handler{}
+	p := defaultParser(t)
+	workflows := []*job.Workflow{
+		{
+			Name:        string(job.RequestFunds),
+			Concurrency: 1,
+			Scenarios: []*job.Scenario{
+				{
+					Name: "find_address",
+					Actions: []*job.Action{
+						{
+							Type:       job.SetVariable,
+							Input:      `{"symbol":"tBTC", "decimals":8}`,
+							OutputPath: "currency",
+						},
+						{
+							Type:       job.FindBalance,
+							Input:      `{"minimum_balance":{"value": "0", "currency": {{currency}}}, "create_limit":1}`, // nolint
+							OutputPath: "random_address",
+						},
+					},
+				},
+				{
+					Name: "request",
+					Actions: []*job.Action{
+						{
+							Type:       job.FindBalance,
+							Input:      `{"account_identifier": {{random_address.account_identifier}}, "minimum_balance":{"value": "100", "currency": {{currency}}}}`, // nolint
+							OutputPath: "loaded_address",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        string(job.CreateAccount),
+			Concurrency: 1,
+			Scenarios: []*job.Scenario{
+				{
+					Name: "create_account",
+					Actions: []*job.Action{
+						{
+							Type:       job.SetVariable,
+							Input:      `{"network":"Testnet3", "blockchain":"Bitcoin"}`,
+							OutputPath: "network",
+						},
+						{
+							Type:       job.GenerateKey,
+							Input:      `{"curve_type": "secp256k1"}`,
+							OutputPath: "key",
+						},
+						{
+							Type:       job.Derive,
+							Input:      `{"network_identifier": {{network}}, "public_key": {{key.public_key}}}`,
+							OutputPath: "account",
+						},
+						{
+							Type:  job.SaveAccount,
+							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        string(job.ReturnFunds),
+			Concurrency: 1,
+			Scenarios: []*job.Scenario{
+				{
+					Name: "transfer",
+					Actions: []*job.Action{
+						{
+							Type:       job.SetVariable,
+							Input:      `{"network":"Testnet3", "blockchain":"Bitcoin"}`,
+							OutputPath: "transfer.network",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `{"symbol":"tBTC", "decimals":8}`,
+							OutputPath: "currency",
+						},
+						{
+							Type:       job.FindBalance,
+							Input:      `{"minimum_balance":{"value": "100", "currency": {{currency}}}, "create_limit": 100}`, // nolint
+							OutputPath: "sender",
+						},
+						{
+							Type:       job.Math,
+							Input:      `{"operation":"subtraction", "left_value": "0", "right_value":{{sender.balance.value}}}`,
+							OutputPath: "sender_amount",
+						},
+						{
+							Type:       job.Math,
+							Input:      `{"operation":"subtraction", "left_value":{{sender.balance.value}}, "right_value":"10"}`,
+							OutputPath: "recipient_amount",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `"1"`,
+							OutputPath: "transfer.confirmation_depth",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `{"test": "works"}`,
+							OutputPath: "transfer.preprocess_metadata",
+						},
+						{
+							Type:       job.SetVariable,
+							Input:      `[{"operation_identifier":{"index":0},"type":"Vin","status":"","account":{{sender.account_identifier}},"amount":{"value":{{sender_amount}},"currency":{{currency}}}},{"operation_identifier":{"index":1},"type":"Vout","status":"","account":{"address":"address2"},"amount":{"value":{{recipient_amount}},"currency":{{currency}}}}]`, // nolint
+							OutputPath: "transfer.operations",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c, err := New(
+		jobStorage,
+		helper,
+		handler,
+		p,
+		workflows,
+	)
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
+
+	// Create coordination channels
+	processCanceled := make(chan struct{})
+
+	dir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+
+	db, err := storage.NewBadgerStorage(
+		ctx,
+		dir,
+		storage.WithIndexCacheSize(storage.TinyIndexCacheSize),
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+
+	// HeadBlockExists is false first
+	helper.On("HeadBlockExists", ctx).Return(false).Once()
+	helper.On("HeadBlockExists", ctx).Return(true).Once()
+
+	// Attempt to transfer
+	dbTxFail := db.NewDatabaseTransaction(ctx, false)
+	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
+	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
+	jobStorage.On("Processing", ctx, dbTxFail, string(job.ReturnFunds)).Return([]*job.Job{}, nil).Once()
+	helper.On("AllAccounts", ctx, dbTxFail).Return([]*types.AccountIdentifier{
+		{Address: "address1"},
+	}, nil).Once()
+	helper.On("LockedAccounts", ctx, dbTxFail).Return([]*types.AccountIdentifier{}, nil).Once()
+	helper.On(
+		"Balance",
+		ctx,
+		dbTxFail,
+		&types.AccountIdentifier{Address: "address1"},
+		&types.Currency{
+			Symbol:   "tBTC",
+			Decimals: 8,
+		},
+	).Return(
+		&types.Amount{
+			Value: "100",
+			Currency: &types.Currency{
+				Symbol:   "tBTC",
+				Decimals: 8,
+			},
+		},
+		nil,
+	).Once()
+
+	var j job.Job
+	jobStorage.On(
+		"Update",
+		ctx,
+		dbTxFail,
+		mock.Anything,
+	).Return(
+		"job",
+		nil,
+	).Run(
+		func(args mock.Arguments) {
+			j = *args.Get(2).(*job.Job)
+			j.Identifier = "job"
+		},
+	).Once()
+
+	// Construct Transaction
+	network := &types.NetworkIdentifier{
+		Blockchain: "Bitcoin",
+		Network:    "Testnet3",
+	}
+	currency := &types.Currency{
+		Symbol:   "tBTC",
+		Decimals: 8,
+	}
+	ops := []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 0,
+			},
+			Type: "Vin",
+			Account: &types.AccountIdentifier{
+				Address: "address1",
+			},
+			Amount: &types.Amount{
+				Value:    "-100",
+				Currency: currency,
+			},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 1,
+			},
+			Type: "Vout",
+			Account: &types.AccountIdentifier{
+				Address: "address2",
+			},
+			Amount: &types.Amount{
+				Value:    "90",
+				Currency: currency,
+			},
+		},
+	}
+	metadataOptions := map[string]interface{}{
+		"metadata": "test",
+	}
+	helper.On(
+		"Preprocess",
+		ctx,
+		network,
+		ops,
+		map[string]interface{}{
+			"test": "works",
+		},
+	).Return(metadataOptions, nil, nil).Once()
+	fetchedMetadata := map[string]interface{}{
+		"tx_meta": "help",
+	}
+	helper.On(
+		"Metadata",
+		ctx,
+		network,
+		metadataOptions,
+		[]*types.PublicKey{},
+	).Return(fetchedMetadata, nil, nil).Once()
+
+	unsignedTx := "unsigned transaction"
+	signingPayloads := []*types.SigningPayload{
+		{
+			AccountIdentifier: &types.AccountIdentifier{Address: "address1"},
+			Bytes:             []byte("blah"),
+			SignatureType:     types.Ecdsa,
+		},
+	}
+	helper.On(
+		"Payloads",
+		ctx,
+		network,
+		ops,
+		fetchedMetadata,
+		[]*types.PublicKey{},
+	).Return(unsignedTx, signingPayloads, nil).Once()
+	helper.On(
+		"Parse",
+		ctx,
+		network,
+		false,
+		unsignedTx,
+	).Return(ops, []*types.AccountIdentifier{}, nil, nil).Once()
+	signatures := []*types.Signature{
+		{
+			SigningPayload: signingPayloads[0],
+			PublicKey: &types.PublicKey{
+				Bytes:     []byte("pubkey"),
+				CurveType: types.Secp256k1,
+			},
+			SignatureType: types.Ecdsa,
+			Bytes:         []byte("signature"),
+		},
+	}
+	helper.On(
+		"Sign",
+		ctx,
+		signingPayloads,
+	).Return(signatures, nil).Once()
+	networkTx := "network transaction"
+	helper.On(
+		"Combine",
+		ctx,
+		network,
+		unsignedTx,
+		signatures,
+	).Return(networkTx, nil).Once()
+	helper.On(
+		"Parse",
+		ctx,
+		network,
+		true,
+		networkTx,
+	).Return(
+		ops,
+		[]*types.AccountIdentifier{{Address: "address1"}},
+		nil,
+		nil,
+	).Once()
+	txIdentifier := &types.TransactionIdentifier{Hash: "transaction hash"}
+	helper.On(
+		"Hash",
+		ctx,
+		network,
+		networkTx,
+	).Return(txIdentifier, nil).Once()
+	helper.On(
+		"Broadcast",
+		ctx,
+		dbTxFail,
+		"job",
+		network,
+		ops,
+		txIdentifier,
+		networkTx,
+		int64(1),
+	).Return(nil).Once()
+	handler.On("TransactionCreated", ctx, "job", txIdentifier).Return(nil).Once()
+	helper.On("BroadcastAll", ctx).Return(nil).Once()
+
+	// Start processor
+	go func() {
+		err := c.ReturnFunds(ctx)
+		assert.NoError(t, err)
+		close(processCanceled)
+	}()
+
+	// Wait for transfer to complete
+	helper.On("HeadBlockExists", ctx).Return(true).Once()
+	dbTx := db.NewDatabaseTransaction(ctx, false)
+	helper.On("DatabaseTransaction", ctx).Return(dbTx).Once()
+	jobStorage.On("Ready", ctx, dbTx).Return([]*job.Job{}, nil).Once()
+	jobStorage.On("Processing", ctx, dbTx, string(job.ReturnFunds)).Return([]*job.Job{&j}, nil).Once()
+
+	markConfirmed := make(chan struct{})
+	jobStorage.On("Broadcasting", ctx, dbTx).Return([]*job.Job{
+		&j,
+	}, nil).Run(func(args mock.Arguments) {
+		close(markConfirmed)
+	}).Once()
+
+	onchainOps := []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 0,
+			},
+			Status: "success",
+			Type:   "Vin",
+			Account: &types.AccountIdentifier{
+				Address: "address1",
+			},
+			Amount: &types.Amount{
+				Value:    "-100",
+				Currency: currency,
+			},
+		},
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: 1,
+			},
+			Status: "success",
+			Type:   "Vout",
+			Account: &types.AccountIdentifier{
+				Address: "address2",
+			},
+			Amount: &types.Amount{
+				Value:    "90",
+				Currency: currency,
+			},
+		},
+	}
+	go func() {
+		<-markConfirmed
+		dbTx2 := db.NewDatabaseTransaction(ctx, false)
+		jobStorage.On("Get", ctx, dbTx2, "job").Return(&j, nil).Once()
+		jobStorage.On(
+			"Update",
+			ctx,
+			dbTx2,
+			mock.Anything,
+		).Run(func(args mock.Arguments) {
+			j = *args.Get(2).(*job.Job)
+			j.Identifier = "job"
+		}).Return(
+			"job",
+			nil,
+		)
+		tx := &types.Transaction{
+			TransactionIdentifier: txIdentifier,
+			Operations:            onchainOps,
+		}
+
+		err = c.BroadcastComplete(ctx, dbTx2, "job", tx)
+		assert.NoError(t, err)
+	}()
+
+	// No balance remaining
+	helper.On("HeadBlockExists", ctx).Return(true).Once()
+	dbTx3 := db.NewDatabaseTransaction(ctx, false)
+	helper.On("DatabaseTransaction", ctx).Return(dbTx3).Once()
+	jobStorage.On("Ready", ctx, dbTx3).Return([]*job.Job{}, nil).Once()
+	jobStorage.On("Processing", ctx, dbTx3, string(job.ReturnFunds)).Return([]*job.Job{}, nil).Once()
+	helper.On("AllAccounts", ctx, dbTx3).Return([]*types.AccountIdentifier{
+		{Address: "address1"},
+	}, nil).Once()
+	helper.On("LockedAccounts", ctx, dbTx3).Return([]*types.AccountIdentifier{}, nil).Once()
+	helper.On(
+		"Balance",
+		ctx,
+		dbTx3,
+		&types.AccountIdentifier{Address: "address1"},
+		&types.Currency{
+			Symbol:   "tBTC",
+			Decimals: 8,
+		},
+	).Return(
+		&types.Amount{
+			Value: "0",
+			Currency: &types.Currency{
+				Symbol:   "tBTC",
+				Decimals: 8,
+			},
+		},
+		nil,
+	).Once()
+
+	// Will exit this round because we've tried all workflows.
+	helper.On("HeadBlockExists", ctx).Return(true).Once()
+	dbTx4 := db.NewDatabaseTransaction(ctx, false)
+	helper.On("DatabaseTransaction", ctx).Return(dbTx4).Once()
+	jobStorage.On("Ready", ctx, dbTx4).Return([]*job.Job{}, nil).Once()
+	jobStorage.On("Broadcasting", ctx, dbTx4).Return([]*job.Job{}, nil).Once()
+
+	<-processCanceled
+	jobStorage.AssertExpectations(t)
+	helper.AssertExpectations(t)
+}

--- a/constructor/coordinator/errors.go
+++ b/constructor/coordinator/errors.go
@@ -32,6 +32,11 @@ var (
 	// and retry.
 	ErrNoAvailableJobs = errors.New("no jobs available")
 
+	// ErrReturnFundsComplete is returned when it is not possible
+	// to process any more ReturnFundsWorkflows or when there is no provided
+	// ReturnsFundsWorkflow.
+	ErrReturnFundsComplete = errors.New("return funds complete")
+
 	// ErrCreateAccountWorkflowMissing is returned when we want
 	// to create an account but the create account workflow is missing.
 	ErrCreateAccountWorkflowMissing = errors.New("create account workflow missing")

--- a/constructor/coordinator/errors.go
+++ b/constructor/coordinator/errors.go
@@ -57,4 +57,8 @@ var (
 	// ErrIncorrectConcurrency is returned when CreateAccount or RequestFunds
 	// have a concurrency greater than 1.
 	ErrIncorrectConcurrency = errors.New("incorrect concurrency")
+
+	// ErrInvalidConcurrency is returned when the concurrency of a Workflow
+	// is <= 0.
+	ErrInvalidConcurrency = errors.New("invalid concurrency")
 )

--- a/constructor/coordinator/types.go
+++ b/constructor/coordinator/types.go
@@ -208,6 +208,7 @@ type Coordinator struct {
 	workflows             []*job.Workflow
 	createAccountWorkflow *job.Workflow
 	requestFundsWorkflow  *job.Workflow
+	returnFundsWorkflow   *job.Workflow
 }
 
 // JobStorage allows for the persistent and transactional

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -270,17 +270,22 @@ type Scenario struct {
 type ReservedWorkflow string
 
 const (
-	// Note: required workflows will be executed with a concurrency of 1.
-
 	// CreateAccount is where another account (already with funds)
 	// creates a new account. It is possible to configure how many
-	// accounts should be created.
+	// accounts should be created. CreateAccount must be executed
+	// with a concurrency of 1.
 	CreateAccount ReservedWorkflow = "create_account"
 
 	// RequestFunds is where the user funds an account. This flow
 	// is invoked when there are no pending broadcasts and it is not possible
-	// to make progress on any Flows or start new ones.
+	// to make progress on any Flows or start new ones. RequestFunds
+	// must be executed with a concurrency of 1.
 	RequestFunds ReservedWorkflow = "request_funds"
+
+	// ReturnFunds is invoked on shutdown so funds can be
+	// returned to a single address (like a faucet). This
+	// is useful for CI testing.
+	ReturnFunds ReservedWorkflow = "return_funds"
 )
 
 // Workflow is a collection of scenarios to run (i.e.


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-cli/issues/112
Related: https://github.com/coinbase/rosetta-cli/issues/119

A common request among `rosetta-cli` users has been the ability to trigger a `ReturnFunds` workflow after processing transactions so that funds can be returned to a faucet.

### Message to Reviewers
Almost all the lines added here are tests!

### Changes
- [x] Add `ReturnFunds` as a `ReservedWorkflow`
- [x] Refactor `coordinator.Process` to run `ReturnFunds`
- [x] Add test coverage