### PR TITLE
[BUG] Return Funds Workflow

### DIFF
--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -1849,15 +1849,8 @@ func TestReturnFunds_NoWorkflow(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, db)
 
-	// HeadBlockExists is false first
-	helper.On("HeadBlockExists", ctx).Return(false).Once()
-	helper.On("HeadBlockExists", ctx).Return(true).Once()
-
-	dbTxFail := db.NewDatabaseTransaction(ctx, false)
-	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
-	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
-
-	// Start processor
+	// We should exit immediately, so we don't need to prepare
+	// our helper or handler.
 	go func() {
 		err := c.ReturnFunds(ctx)
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR fixes a small bug introduced #156 where we may attempt to create any workflow when calling `ReturnFunds`.

### Changes
- [x] return immediately if no returns flow exists
- [x] log when beginning and ending return funds
- [x] ensure we only attempt `return_funds` while returning funds