### PR TITLE
[Constructor] Move Create Account Before Broadcast Check

### DIFF
--- a/constructor/coordinator/coordinator.go
+++ b/constructor/coordinator/coordinator.go
@@ -171,17 +171,6 @@ func (c *Coordinator) findJob(
 		)
 	}
 
-	if len(allBroadcasts) > 0 {
-		return nil, ErrNoAvailableJobs
-	}
-
-	// If we are returning funds, we should exit here
-	// because we don't want to create any new accounts
-	// or request funds while returning funds.
-	if returnFunds {
-		return nil, ErrReturnFundsComplete
-	}
-
 	// Check if ErrCreateAccount, then create account if less
 	// processing CreateAccount jobs than ReservedWorkflowConcurrency.
 	if c.seenErrCreateAccount {
@@ -199,6 +188,17 @@ func (c *Coordinator) findJob(
 		}
 
 		return job.New(c.createAccountWorkflow), nil
+	}
+
+	if len(allBroadcasts) > 0 {
+		return nil, ErrNoAvailableJobs
+	}
+
+	// If we are returning funds, we should exit here
+	// because we don't want to create any new accounts
+	// or request funds while returning funds.
+	if returnFunds {
+		return nil, ErrReturnFundsComplete
 	}
 
 	processing, err := c.storage.Processing(ctx, dbTx, string(job.RequestFunds))


### PR DESCRIPTION
This PR moves the check to determine if an account should be created to above the check for existing broadcasts. In practice, preventing account creation when pending broadcasts exist results in address creation stalling as soon as a few exist (as there is almost always a pended broadcast between a small set of accounts).