### PR TITLE
[Storage] Automatically Prune BlockStorage

### DIFF
--- a/statefulsyncer/stateful_syncer.go
+++ b/statefulsyncer/stateful_syncer.go
@@ -130,7 +130,7 @@ func (s *StatefulSyncer) Sync(ctx context.Context, startIndex int64, endIndex in
 // Prune will repeatedly attempt to prune BlockStorage until
 // the context is canceled or an error is encountered.
 func (s *StatefulSyncer) Prune(ctx context.Context, depth int64) error {
-	for ctx.Err() != nil {
+	for ctx.Err() == nil {
 		headBlock, err := s.blockStorage.GetHeadBlockIdentifier(ctx)
 		if headBlock == nil && errors.Is(err, storage.ErrHeadBlockNotFound) {
 			// this will occur when we are waiting for the first block to be synced

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -183,7 +183,7 @@ func (b *BlockStorage) pruneBlock(
 		return -1, fmt.Errorf("%w: cannot get head block identifier", err)
 	}
 
-	if oldestIndex >= head.Index-syncer.PastBlockSize*2 {
+	if oldestIndex > head.Index-syncer.PastBlockSize*2 {
 		return -1, ErrPruningDepthInsufficient
 	}
 

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -326,18 +326,14 @@ func TestBlock(t *testing.T) {
 	})
 
 	t.Run("Set genesis block", func(t *testing.T) {
-		dbTx := storage.db.NewDatabaseTransaction(ctx, false)
-		oldestIndex, err := storage.GetOldestBlockIndex(ctx, dbTx)
-		dbTx.Discard(ctx)
+		oldestIndex, err := storage.GetOldestBlockIndex(ctx)
 		assert.Equal(t, int64(-1), oldestIndex)
 		assert.Error(t, ErrOldestIndexMissing, err)
 
 		err = storage.AddBlock(ctx, genesisBlock)
 		assert.NoError(t, err)
 
-		dbTx = storage.db.NewDatabaseTransaction(ctx, false)
-		oldestIndex, err = storage.GetOldestBlockIndex(ctx, dbTx)
-		dbTx.Discard(ctx)
+		oldestIndex, err = storage.GetOldestBlockIndex(ctx)
 		assert.Equal(t, int64(0), oldestIndex)
 		assert.NoError(t, err)
 
@@ -382,9 +378,7 @@ func TestBlock(t *testing.T) {
 		assert.Equal(t, newBlock.BlockIdentifier, newestBlock)
 		assert.Equal(t, newBlock.Transactions[0], transaction)
 
-		dbTx := storage.db.NewDatabaseTransaction(ctx, false)
-		oldestIndex, err := storage.GetOldestBlockIndex(ctx, dbTx)
-		dbTx.Discard(ctx)
+		oldestIndex, err := storage.GetOldestBlockIndex(ctx)
 		assert.Equal(t, int64(0), oldestIndex)
 		assert.NoError(t, err)
 	})
@@ -419,9 +413,7 @@ func TestBlock(t *testing.T) {
 		err = storage.AddBlock(ctx, newBlock2)
 		assert.NoError(t, err)
 
-		dbTx := storage.db.NewDatabaseTransaction(ctx, false)
-		oldestIndex, err := storage.GetOldestBlockIndex(ctx, dbTx)
-		dbTx.Discard(ctx)
+		oldestIndex, err := storage.GetOldestBlockIndex(ctx)
 		assert.Equal(t, int64(0), oldestIndex)
 		assert.NoError(t, err)
 
@@ -473,9 +465,7 @@ func TestBlock(t *testing.T) {
 		err := storage.RemoveBlock(ctx, newBlock2.BlockIdentifier)
 		assert.NoError(t, err)
 
-		dbTx := storage.db.NewDatabaseTransaction(ctx, false)
-		oldestIndex, err := storage.GetOldestBlockIndex(ctx, dbTx)
-		dbTx.Discard(ctx)
+		oldestIndex, err := storage.GetOldestBlockIndex(ctx)
 		assert.Equal(t, int64(0), oldestIndex)
 		assert.NoError(t, err)
 
@@ -504,9 +494,7 @@ func TestBlock(t *testing.T) {
 		err := storage.AddBlock(ctx, complexBlock)
 		assert.NoError(t, err)
 
-		dbTx := storage.db.NewDatabaseTransaction(ctx, false)
-		oldestIndex, err := storage.GetOldestBlockIndex(ctx, dbTx)
-		dbTx.Discard(ctx)
+		oldestIndex, err := storage.GetOldestBlockIndex(ctx)
 		assert.Equal(t, int64(0), oldestIndex)
 		assert.NoError(t, err)
 
@@ -621,9 +609,7 @@ func TestBlock(t *testing.T) {
 		assert.Equal(t, int64(100), lastPruned)
 		assert.NoError(t, err)
 
-		dbTx := storage.db.NewDatabaseTransaction(ctx, false)
-		oldestIndex, err := storage.GetOldestBlockIndex(ctx, dbTx)
-		dbTx.Discard(ctx)
+		oldestIndex, err := storage.GetOldestBlockIndex(ctx)
 		assert.Equal(t, int64(101), oldestIndex)
 		assert.NoError(t, err)
 
@@ -696,9 +682,7 @@ func TestManyBlocks(t *testing.T) {
 	assert.Equal(t, int64(9959), lastPruned)
 	assert.NoError(t, err)
 
-	dbTx := storage.db.NewDatabaseTransaction(ctx, false)
-	oldestIndex, err := storage.GetOldestBlockIndex(ctx, dbTx)
-	dbTx.Discard(ctx)
+	oldestIndex, err := storage.GetOldestBlockIndex(ctx)
 	assert.Equal(t, int64(9960), oldestIndex)
 	assert.NoError(t, err)
 

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -591,7 +591,7 @@ func TestBlock(t *testing.T) {
 		assert.Contains(t, err.Error(), ErrPruningDepthInsufficient.Error())
 
 		// Attempt to sync sufficient blocks so we can test pruning
-		for i := int64(gapBlock.BlockIdentifier.Index + 1); i < 200; i++ {
+		for i := gapBlock.BlockIdentifier.Index + 1; i < 200; i++ {
 			blockIdentifier := &types.BlockIdentifier{
 				Index: i,
 				Hash:  fmt.Sprintf("block %d", i),

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -375,7 +375,7 @@ var (
 	ErrCannotAccessPrunedData         = errors.New("cannot access pruned data")
 	ErrNothingToPrune                 = errors.New("nothing to prune")
 	ErrPruningFailed                  = errors.New("pruning failed")
-	ErrPruningDepthInsufficent        = errors.New("pruning depth insufficent")
+	ErrPruningDepthInsufficient       = errors.New("pruning depth insufficent")
 	ErrCannotPruneTransaction         = errors.New("cannot prune transaction")
 
 	BlockStorageErrs = []error{
@@ -411,7 +411,7 @@ var (
 		ErrCannotAccessPrunedData,
 		ErrNothingToPrune,
 		ErrPruningFailed,
-		ErrPruningDepthInsufficent,
+		ErrPruningDepthInsufficient,
 		ErrCannotPruneTransaction,
 	}
 )

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -376,6 +376,7 @@ var (
 	ErrNothingToPrune                 = errors.New("nothing to prune")
 	ErrPruningFailed                  = errors.New("pruning failed")
 	ErrPruningDepthInsufficent        = errors.New("pruning depth insufficent")
+	ErrCannotPruneTransaction         = errors.New("cannot prune transaction")
 
 	BlockStorageErrs = []error{
 		ErrHeadBlockNotFound,
@@ -411,6 +412,7 @@ var (
 		ErrNothingToPrune,
 		ErrPruningFailed,
 		ErrPruningDepthInsufficent,
+		ErrCannotPruneTransaction,
 	}
 )
 

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -375,7 +375,7 @@ var (
 	ErrCannotAccessPrunedData         = errors.New("cannot access pruned data")
 	ErrNothingToPrune                 = errors.New("nothing to prune")
 	ErrPruningFailed                  = errors.New("pruning failed")
-	ErrPruningDepthInsufficient       = errors.New("pruning depth insufficent")
+	ErrPruningDepthInsufficient       = errors.New("pruning depth insufficient")
 	ErrCannotPruneTransaction         = errors.New("cannot prune transaction")
 
 	BlockStorageErrs = []error{

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -368,6 +368,9 @@ var (
 	ErrTransactionNotFound            = errors.New("unable to find transaction")
 	ErrTransactionDoesNotExistInBlock = errors.New("transaction does not exist in block")
 	ErrHeadBlockGetFailed             = errors.New("unable to get head block")
+	ErrOldestIndexUpdateFailed        = errors.New("oldest index update failed")
+	ErrOldestIndexMissing             = errors.New("oldest index missing")
+	ErrOldestIndexRead                = errors.New("cannot read oldest index")
 
 	BlockStorageErrs = []error{
 		ErrHeadBlockNotFound,
@@ -395,6 +398,9 @@ var (
 		ErrTransactionNotFound,
 		ErrTransactionDoesNotExistInBlock,
 		ErrHeadBlockGetFailed,
+		ErrOldestIndexUpdateFailed,
+		ErrOldestIndexMissing,
+		ErrOldestIndexRead,
 	}
 )
 

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -371,6 +371,11 @@ var (
 	ErrOldestIndexUpdateFailed        = errors.New("oldest index update failed")
 	ErrOldestIndexMissing             = errors.New("oldest index missing")
 	ErrOldestIndexRead                = errors.New("cannot read oldest index")
+	ErrCannotRemoveOldest             = errors.New("cannot remove oldest index")
+	ErrCannotAccessPrunedData         = errors.New("cannot access pruned data")
+	ErrNothingToPrune                 = errors.New("nothing to prune")
+	ErrPruningFailed                  = errors.New("pruning failed")
+	ErrPruningDepthInsufficent        = errors.New("pruning depth insufficent")
 
 	BlockStorageErrs = []error{
 		ErrHeadBlockNotFound,
@@ -401,6 +406,11 @@ var (
 		ErrOldestIndexUpdateFailed,
 		ErrOldestIndexMissing,
 		ErrOldestIndexRead,
+		ErrCannotRemoveOldest,
+		ErrCannotAccessPrunedData,
+		ErrNothingToPrune,
+		ErrPruningFailed,
+		ErrPruningDepthInsufficent,
 	}
 )
 

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+)
+
+func storeUniqueKey(
+	ctx context.Context,
+	transaction DatabaseTransaction,
+	key []byte,
+	value []byte,
+	reclaimValue bool,
+) error {
+	exists, _, err := transaction.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		return fmt.Errorf(
+			"%w: duplicate key %s found",
+			ErrDuplicateKey,
+			string(key),
+		)
+	}
+
+	return transaction.Set(ctx, key, value, reclaimValue)
+}


### PR DESCRIPTION
Replaces: #161 

This PR includes a method for pruning `block_storage` that does not invalidate any of the [duplicate hash checks](https://github.com/coinbase/rosetta-cli#duplicate-hashes) performed by the `rosetta-cli`.

### Results (> 50% savings 🚀 )
When syncing the first 120k blocks on `bitcoin-testnet`:
```
676M	pruned-bitcoin-data
1.3G	non-pruned-bitcoin-data
```

_Savings will increase dramatically the more block data is ingested (these sizes include all data stored by the `rosetta-cli`, not just block and transaction data)._

### Changes
- [x] implement setter and getter for oldest block index
- [x] track oldest available block in block storage as index
- [x] Implement `Prune` method in `BlockStorage`
- [x] Ensure `SetNewStartIndex` and `CreateBlockCache` error if they try to read a pruned block
- [x] Prevent orphaning past pruned blocks (especially with new start index)
- [x] Throw error if we attempt to access a block that is less than oldest block
- [x] cleanup block storage code
- [x] Attempt to remove old data every X minutes in `Statefulsyncer`