### PR TITLE
[Constructor] Load ENVs + Make HTTP Requests

### DIFF
--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -271,8 +271,9 @@ const (
 // HTTPRequestInput is the input to
 // HTTP Request.
 type HTTPRequestInput struct {
-	Method string `json:"method"`
-	URL    string `json:"url"`
+	Method  string `json:"method"`
+	URL     string `json:"url"`
+	Timeout int    `json:"timeout"`
 
 	// If the Method is POST, the Body
 	// can be populated with JSON.

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -15,6 +15,8 @@
 package job
 
 import (
+	"net/http"
+
 	"github.com/coinbase/rosetta-sdk-go/keys"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -122,6 +124,16 @@ const (
 	// ensuring that an account has sufficient balance to pay the
 	// suggested fee to broadcast a transaction.
 	Assert ActionType = "assert"
+
+	// LoadEnv loads some value from an environment variable. This
+	// is very useful injecting an API token for algorithmic fauceting
+	// when running CI.
+	LoadEnv ActionType = "load_env"
+
+	// HTTPRequest makes an HTTP request at some URL. This is useful
+	// for making a request to a faucet to automate Construction API
+	// testing.
+	HTTPRequest ActionType = "http_request"
 )
 
 // Action is a step of computation that
@@ -244,6 +256,27 @@ type RandomNumberInput struct {
 type FindCurrencyAmountInput struct {
 	Currency *types.Currency `json:"currency"`
 	Amounts  []*types.Amount `json:"amounts"`
+}
+
+// HTTPMethod is a type representing
+// allowed HTTP methods.
+type HTTPMethod string
+
+// Supported HTTP Methods
+const (
+	MethodGet  = http.MethodGet
+	MethodPost = http.MethodPost
+)
+
+// HTTPRequestInput is the input to
+// HTTP Request.
+type HTTPRequestInput struct {
+	Method string `json:"method"`
+	URL    string `json:"url"`
+
+	// If the Method is POST, the Body
+	// can be populated with JSON.
+	Body string `json:"body"`
 }
 
 // Scenario is a collection of Actions with a specific

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -724,7 +724,11 @@ func HTTPRequestWorker(rawInput string) (string, error) {
 		}
 		request.Header.Set("Accept", "application/json")
 	case job.MethodPost:
-		request, err = http.NewRequest(http.MethodPost, input.URL, bytes.NewBufferString(input.Body))
+		request, err = http.NewRequest(
+			http.MethodPost,
+			input.URL,
+			bytes.NewBufferString(input.Body),
+		)
 		if err != nil {
 			return "", fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
 		}
@@ -750,7 +754,12 @@ func HTTPRequestWorker(rawInput string) (string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("%w: status code %d with body %s", ErrActionFailed, resp.StatusCode, body)
+		return "", fmt.Errorf(
+			"%w: status code %d with body %s",
+			ErrActionFailed,
+			resp.StatusCode,
+			body,
+		)
 	}
 
 	return string(body), nil

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -15,11 +15,15 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/constructor/job"
@@ -73,6 +77,8 @@ func (w *Worker) invokeWorker(
 		return FindCurrencyAmountWorker(input)
 	case job.LoadEnv:
 		return LoadEnvWorker(input)
+	case job.HTTPRequest:
+		return HTTPRequestWorker(input)
 	default:
 		return "", fmt.Errorf("%w: %s", ErrInvalidActionType, action)
 	}
@@ -689,4 +695,63 @@ func LoadEnvWorker(rawInput string) (string, error) {
 	}
 
 	return os.Getenv(input), nil
+}
+
+// HTTPRequestWorker makes an HTTP request and returns the response to
+// store in a variable. This is useful for algorithmic fauceting.
+func HTTPRequestWorker(rawInput string) (string, error) {
+	var input job.HTTPRequestInput
+	err := job.UnmarshalInput([]byte(rawInput), &input)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
+	}
+
+	if input.Timeout <= 0 {
+		return "", fmt.Errorf("%w: %d is not a valid timeout", ErrInvalidInput, input.Timeout)
+	}
+
+	if len(input.URL) == 0 {
+		return "", fmt.Errorf("%w: URL is empty", ErrInvalidInput)
+	}
+
+	client := &http.Client{Timeout: time.Duration(input.Timeout) * time.Second}
+	var request *http.Request
+	switch input.Method {
+	case job.MethodGet:
+		request, err = http.NewRequest(http.MethodGet, input.URL, nil)
+		if err != nil {
+			return "", fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
+		}
+		request.Header.Set("Accept", "application/json")
+	case job.MethodPost:
+		request, err = http.NewRequest(http.MethodPost, input.URL, bytes.NewBufferString(input.Body))
+		if err != nil {
+			return "", fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
+		}
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Accept", "application/json")
+	default:
+		return "", fmt.Errorf(
+			"%w: %s is not a supported HTTP method",
+			ErrInvalidInput,
+			input.Method,
+		)
+	}
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: status code %d with body %s", ErrActionFailed, resp.StatusCode, body)
+	}
+
+	return string(body), nil
 }

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/constructor/job"
@@ -70,6 +71,8 @@ func (w *Worker) invokeWorker(
 		return "", AssertWorker(input)
 	case job.FindCurrencyAmount:
 		return FindCurrencyAmountWorker(input)
+	case job.LoadEnv:
+		return LoadEnvWorker(input)
 	default:
 		return "", fmt.Errorf("%w: %s", ErrInvalidActionType, action)
 	}
@@ -672,4 +675,18 @@ func FindCurrencyAmountWorker(rawInput string) (string, error) {
 		ErrActionFailed,
 		types.PrintStruct(input.Currency),
 	)
+}
+
+// LoadEnvWorker loads an environment variable and stores
+// it in state. This is useful for algorithmic fauceting.
+func LoadEnvWorker(rawInput string) (string, error) {
+	// We unmarshal the input here to handle string
+	// unwrapping automatically.
+	var input string
+	err := job.UnmarshalInput([]byte(rawInput), &input)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
+	}
+
+	return os.Getenv(input), nil
 }

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -725,7 +725,11 @@ func HTTPRequestWorker(rawInput string) (string, error) {
 		}
 		request.Header.Set("Accept", "application/json")
 	case job.MethodPost:
-		request, err = http.NewRequest(http.MethodPost, input.URL, bytes.NewBufferString(input.Body))
+		request, err = http.NewRequest(
+			http.MethodPost,
+			input.URL,
+			bytes.NewBufferString(input.Body),
+		)
 		if err != nil {
 			return "", fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
 		}
@@ -751,7 +755,12 @@ func HTTPRequestWorker(rawInput string) (string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("%w: status code %d with body %s", ErrActionFailed, resp.StatusCode, body)
+		return "", fmt.Errorf(
+			"%w: status code %d with body %s",
+			ErrActionFailed,
+			resp.StatusCode,
+			body,
+		)
 	}
 
 	return string(body), nil

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1526,8 +1526,9 @@ func TestHTTPRequestWorker(t *testing.T) {
 		expectedMethod  string
 		expectedBody    string
 
-		response   string
-		statusCode int
+		response    string
+		contentType string
+		statusCode  int
 
 		output string
 		err    error
@@ -1542,6 +1543,7 @@ func TestHTTPRequestWorker(t *testing.T) {
 			expectedLatency: 1,
 			expectedMethod:  http.MethodGet,
 			expectedBody:    "",
+			contentType:     "application/json; charset=UTF-8",
 			response:        `{"money":100}`,
 			statusCode:      http.StatusOK,
 			output:          `{"money":100}`,
@@ -1557,6 +1559,7 @@ func TestHTTPRequestWorker(t *testing.T) {
 			expectedLatency: 1,
 			expectedMethod:  http.MethodPost,
 			expectedBody:    `{"address":"123"}`,
+			contentType:     "application/json; charset=UTF-8",
 			response:        `{"money":100}`,
 			statusCode:      http.StatusOK,
 			output:          `{"money":100}`,
@@ -1599,6 +1602,7 @@ func TestHTTPRequestWorker(t *testing.T) {
 			expectedLatency: 1200,
 			expectedMethod:  http.MethodGet,
 			expectedBody:    "",
+			contentType:     "application/json; charset=UTF-8",
 			response:        `{"money":100}`,
 			statusCode:      http.StatusOK,
 			err:             ErrActionFailed,
@@ -1613,9 +1617,25 @@ func TestHTTPRequestWorker(t *testing.T) {
 			expectedLatency: 1,
 			expectedMethod:  http.MethodGet,
 			expectedBody:    "",
+			contentType:     "application/json; charset=UTF-8",
 			response:        `{"money":100}`,
 			statusCode:      http.StatusInternalServerError,
 			err:             ErrActionFailed,
+		},
+		"invalid content type": { // we don't throw an error
+			input: &job.HTTPRequestInput{
+				Method:  job.MethodGet,
+				URL:     "/faucet?test=123",
+				Timeout: 10,
+			},
+			expectedPath:    "/faucet?test=123",
+			expectedLatency: 1,
+			expectedMethod:  http.MethodGet,
+			expectedBody:    "",
+			contentType:     "text/plain",
+			response:        `{"money":100}`,
+			statusCode:      http.StatusOK,
+			output:          `{"money":100}`,
 		},
 	}
 
@@ -1632,7 +1652,7 @@ func TestHTTPRequestWorker(t *testing.T) {
 
 				time.Sleep(time.Duration(test.expectedLatency) * time.Millisecond)
 
-				w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+				w.Header().Set("Content-Type", test.contentType)
 				w.WriteHeader(test.statusCode)
 				fmt.Fprintf(w, test.response)
 			}))

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"regexp"
 	"testing"
 
@@ -1074,8 +1075,8 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 				Input: `{"random_number": {{rand_number}}}`,
 			},
 			{
-				Type:       job.SetVariable,
-				Input:      `"10"`,
+				Type:       job.LoadEnv,
+				Input:      `"valA"`,
 				OutputPath: "valA",
 			},
 			{
@@ -1096,6 +1097,7 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 		},
 	}
 
+	os.Setenv("valA", `"10"`)
 	workflow := &job.Workflow{
 		Name:      string(job.CreateAccount),
 		Scenarios: []*job.Scenario{s, s2},

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1592,6 +1592,16 @@ func TestHTTPRequestWorker(t *testing.T) {
 			dontPrependURL: true,
 			err:            ErrInvalidInput,
 		},
+		"invalid url": {
+			input: &job.HTTPRequestInput{
+				Method:  job.MethodPost,
+				URL:     "blah",
+				Timeout: 100,
+				Body:    `{"address":"123"}`,
+			},
+			dontPrependURL: true,
+			err:            ErrInvalidInput,
+		},
 		"timeout": {
 			input: &job.HTTPRequestInput{
 				Method:  job.MethodGet,


### PR DESCRIPTION
This PR adds support for reading ENVs and making HTTP requests while running workflows. This would allow anyone to make a request to a faucet during the `request_funds` workflow.

### Changes
- [x] Add support for loading ENVs (`load_env`)
- [x] Make HTTP Requests