### PR TITLE
[BUG] [Keys] Import Private Key Error

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -40,8 +40,9 @@ func ImportPrivKey(privKeyHex string, curve types.CurveType) (*KeyPair, error) {
 	// throwing an error).
 	if len(privKey) != PrivKeyBytesLen {
 		return nil, fmt.Errorf(
-			"%w: expected 32 bytes but got %v",
+			"%w: expected %d bytes but got %v",
 			ErrPrivKeyLengthInvalid,
+			PrivKeyBytesLen,
 			len(privKey),
 		)
 	}
@@ -73,7 +74,7 @@ func ImportPrivKey(privKeyHex string, curve types.CurveType) (*KeyPair, error) {
 
 		keyPair := &KeyPair{
 			PublicKey:  pubKey,
-			PrivateKey: privKeyBytes,
+			PrivateKey: privKeyBytes.Seed(),
 		}
 
 		return keyPair, nil
@@ -136,8 +137,9 @@ func (k *KeyPair) IsValid() error {
 	// Will change if we support more CurveTypes with different privkey sizes
 	if len(k.PrivateKey) != PrivKeyBytesLen {
 		return fmt.Errorf(
-			"%w: expected 32 bytes but got %v",
+			"%w: expected %d bytes but got %v",
 			ErrPrivKeyLengthInvalid,
+			PrivKeyBytesLen,
 			len(k.PrivateKey),
 		)
 	}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -35,6 +35,17 @@ func ImportPrivKey(privKeyHex string, curve types.CurveType) (*KeyPair, error) {
 		return nil, fmt.Errorf("%w: %s", ErrPrivKeyUndecodable, privKeyHex)
 	}
 
+	// We check the parsed private key length to ensure we don't panic (most
+	// crypto libraries panic with incorrect private key lengths instead of
+	// throwing an error).
+	if len(privKey) != PrivKeyBytesLen {
+		return nil, fmt.Errorf(
+			"%w: expected 32 bytes but got %v",
+			ErrPrivKeyLengthInvalid,
+			len(privKey),
+		)
+	}
+
 	switch curve {
 	case types.Secp256k1:
 		rawPrivKey, rawPubKey := btcec.PrivKeyFromBytes(btcec.S256(), privKey)
@@ -125,7 +136,7 @@ func (k *KeyPair) IsValid() error {
 	// Will change if we support more CurveTypes with different privkey sizes
 	if len(k.PrivateKey) != PrivKeyBytesLen {
 		return fmt.Errorf(
-			"%w: expected 32 bytes but go %v",
+			"%w: expected 32 bytes but got %v",
 			ErrPrivKeyLengthInvalid,
 			len(k.PrivateKey),
 		)

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -28,8 +28,8 @@ import (
 // PrivKeyBytesLen are 32-bytes for all supported curvetypes
 const PrivKeyBytesLen = 32
 
-// ImportPrivKey returns a Keypair from a hex-encoded privkey string
-func ImportPrivKey(privKeyHex string, curve types.CurveType) (*KeyPair, error) {
+// ImportPrivateKey returns a Keypair from a hex-encoded privkey string
+func ImportPrivateKey(privKeyHex string, curve types.CurveType) (*KeyPair, error) {
 	privKey, err := hex.DecodeString(privKeyHex)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrPrivKeyUndecodable, privKeyHex)
@@ -134,7 +134,9 @@ func (k *KeyPair) IsValid() error {
 		return err
 	}
 
-	// Will change if we support more CurveTypes with different privkey sizes
+	// We will need to add a switch statement here if we add support
+	// for CurveTypes that have a different private key length than
+	// PrivKeyBytesLen.
 	if len(k.PrivateKey) != PrivKeyBytesLen {
 		return fmt.Errorf(
 			"%w: expected %d bytes but got %v",

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -110,7 +110,7 @@ func TestKeypairValidity(t *testing.T) {
 	}
 }
 
-func TestImportPrivKey(t *testing.T) {
+func TestImportPrivateKey(t *testing.T) {
 	importPrivKeyTests := map[string]struct {
 		privKey   string
 		curveType types.CurveType
@@ -121,16 +121,28 @@ func TestImportPrivKey(t *testing.T) {
 			types.Edwards25519,
 			nil,
 		},
-		"simple Secp256k1": {"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a", types.Secp256k1, nil},
-		"short ed25519":    {"asd", types.Secp256k1, ErrPrivKeyUndecodable},
-		"short Secp256k1":  {"asd", types.Edwards25519, ErrPrivKeyUndecodable},
-		"long ed25519":     {"aeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebbaeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebb", types.Secp256k1, ErrPrivKeyLengthInvalid},
-		"long Secp256k1":   {"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a", types.Edwards25519, ErrPrivKeyLengthInvalid},
+		"simple Secp256k1": {
+			"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a",
+			types.Secp256k1,
+			nil,
+		},
+		"short ed25519":   {"asd", types.Secp256k1, ErrPrivKeyUndecodable},
+		"short Secp256k1": {"asd", types.Edwards25519, ErrPrivKeyUndecodable},
+		"long ed25519": {
+			"aeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebbaeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebb", // nolint:lll
+			types.Secp256k1,
+			ErrPrivKeyLengthInvalid,
+		},
+		"long Secp256k1": {
+			"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a", // nolint:lll
+			types.Edwards25519,
+			ErrPrivKeyLengthInvalid,
+		},
 	}
 
 	for name, test := range importPrivKeyTests {
 		t.Run(name, func(t *testing.T) {
-			kp, err := ImportPrivKey(test.privKey, test.curveType)
+			kp, err := ImportPrivateKey(test.privKey, test.curveType)
 			if test.err != nil {
 				assert.Nil(t, kp)
 				assert.True(t, errors.Is(err, test.err))

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -111,39 +111,33 @@ func TestKeypairValidity(t *testing.T) {
 }
 
 func TestImportPrivKey(t *testing.T) {
-	type importKeyTest struct {
+	importPrivKeyTests := map[string]struct {
 		privKey   string
 		curveType types.CurveType
 		err       error
-	}
-
-	importPrivKeyTests := []importKeyTest{
-		{
+	}{
+		"simple ed25519": {
 			"aeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebb",
 			types.Edwards25519,
 			nil,
 		},
-		{
-			"01ea48249742650907004331e85536f868e2d3959434ba751d8aa230138a9707",
-			types.Edwards25519,
-			nil,
-		},
-		{
-			"f1821e051843bce17c1f31023609e9412ae4525d27447fc93afa4a271ee60550",
-			types.Edwards25519,
-			nil,
-		},
-		{"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a", types.Secp256k1, nil},
-		{"0e842a16b2d39a4dff5c63688513cb2109e30c3c30bc4eb502cc54f4614493f6", types.Secp256k1, nil},
-		{"42efc44bdf7b2d4d45ddd6ddb727ed498c91e7070914c9ed0d80af680ff42b3e", types.Secp256k1, nil},
-		{"asd", types.Secp256k1, ErrPrivKeyUndecodable},
-		{"asd", types.Edwards25519, ErrPrivKeyUndecodable},
+		"simple Secp256k1": {"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a", types.Secp256k1, nil},
+		"short ed25519":    {"asd", types.Secp256k1, ErrPrivKeyUndecodable},
+		"short Secp256k1":  {"asd", types.Edwards25519, ErrPrivKeyUndecodable},
+		"long ed25519":     {"aeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebbaeb121b4c545f0f850e1480492508c65a250e9965b0d90176fab4d7506398ebb", types.Secp256k1, ErrPrivKeyLengthInvalid},
+		"long Secp256k1":   {"0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a0b188af56b25d007fbc4bbf2176cd2a54d876ce4774bb5df38b7c83349405b7a", types.Edwards25519, ErrPrivKeyLengthInvalid},
 	}
 
-	for _, test := range importPrivKeyTests {
-		_, err := ImportPrivKey(test.privKey, test.curveType)
-		if err != nil {
-			assert.True(t, errors.Is(err, test.err))
-		}
+	for name, test := range importPrivKeyTests {
+		t.Run(name, func(t *testing.T) {
+			kp, err := ImportPrivKey(test.privKey, test.curveType)
+			if test.err != nil {
+				assert.Nil(t, kp)
+				assert.True(t, errors.Is(err, test.err))
+			} else {
+				assert.NoError(t, kp.IsValid())
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/statefulsyncer/stateful_syncer.go
+++ b/statefulsyncer/stateful_syncer.go
@@ -35,7 +35,7 @@ const (
 	// DefaultPruningDepth is the depth from tip
 	// we attempt to prune. A large pruning depth here
 	// protects us from re-orgs.
-	DefaultPruningDepth = int64(100)
+	DefaultPruningDepth = int64(100) // nolint:gomnd
 
 	// pruneSleepTime is how long we sleep between
 	// pruning attempts.

--- a/storage/key_storage.go
+++ b/storage/key_storage.go
@@ -254,9 +254,8 @@ func (k *KeyStorage) RandomAccount(ctx context.Context) (*types.AccountIdentifie
 
 // ImportAccounts loads a set of prefunded accounts into key storage.
 func (k *KeyStorage) ImportAccounts(ctx context.Context, accounts []*PrefundedAccount) error {
-	// Import prefunded account and save to database
 	for _, acc := range accounts {
-		keyPair, err := keys.ImportPrivKey(acc.PrivateKeyHex, acc.CurveType)
+		keyPair, err := keys.ImportPrivateKey(acc.PrivateKeyHex, acc.CurveType)
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrAddrImportFailed, err)
 		}


### PR DESCRIPTION
Fixes #164 

This PR fixes a bug in `keys` where `Edwards25519` private keys are not imported correctly in `ImportPrivateKey`.

### Changes
- [x] Add test of `IsValid` on imported keys
- [x] Check private key bytes length before attempting to import in `ImportPrivKey` to avoid panic
- [x] Call `.Seed()` on imported `Edwards25519` private keys
- [x] `ImportPrivKey` -> `ImportPrivateKey`