### PR TITLE
Assert ConstructionPreprocessResponse.Options not nil

### DIFF
--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -29,6 +29,10 @@ func ConstructionPreprocessResponse(
 		return ErrConstructionPreprocessResponseIsNil
 	}
 
+	if response.Options == nil {
+		return ErrConstructionPreprocessOptionsIsNil
+	}
+
 	for _, accountIdentifier := range response.RequiredPublicKeys {
 		if err := AccountIdentifier(accountIdentifier); err != nil {
 			return err

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -60,6 +60,10 @@ func TestConstructionPreprocessResponse(t *testing.T) {
 		"nil response": {
 			err: ErrConstructionPreprocessResponseIsNil,
 		},
+		"nil options": {
+			response: &types.ConstructionPreprocessResponse{},
+			err:      ErrConstructionPreprocessOptionsIsNil,
+		},
 	}
 
 	for name, test := range tests {

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -153,6 +153,9 @@ var (
 	ErrConstructionPreprocessResponseIsNil = errors.New(
 		"ConstructionPreprocessResponse cannot be nil",
 	)
+	ErrConstructionPreprocessOptionsIsNil = errors.New(
+		"ConstructionPreprocessResponse.Options cannot be nil",
+	)
 	ErrConstructionMetadataResponseIsNil = errors.New(
 		"ConstructionMetadataResponse cannot be nil",
 	)


### PR DESCRIPTION
This adds a client assertion to ConstructionPreprocessResponses so that
the Options field is not nil.

The returned options are passed as-is to /construct/metadata and the
server asserter for _that_ endpoint checks that Options isn't nil, so
adding this check makes the error more evident.
