### PR TITLE
[Keys][Bug] Fix ImportPrivateKey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint-examples:
 	golangci-lint run -v -E ${LINT_SETTINGS}
 
 lint: | lint-examples
-	golangci-lint run -v -E ${LINT_SETTINGS},gomnd; \
+	golangci-lint run -v -E ${LINT_SETTINGS},gomnd && \
 	make check-comments;
 
 format:

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -15,6 +15,7 @@
 package asserter
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -196,6 +197,10 @@ func PublicKey(
 
 	if len(publicKey.Bytes) == 0 {
 		return ErrPublicKeyBytesEmpty
+	}
+
+	if bytes.Compare(publicKey.Bytes, make([]byte, len(publicKey.Bytes))) == 0 {
+		return ErrPublicKeyBytesZero
 	}
 
 	if err := CurveType(publicKey.CurveType); err != nil {

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -15,7 +15,6 @@
 package asserter
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -199,7 +198,7 @@ func PublicKey(
 		return ErrPublicKeyBytesEmpty
 	}
 
-	if bytes.Equal(publicKey.Bytes, make([]byte, len(publicKey.Bytes))) {
+	if BytesArrayZero(publicKey.Bytes) {
 		return ErrPublicKeyBytesZero
 	}
 
@@ -240,6 +239,10 @@ func SigningPayload(
 
 	if len(signingPayload.Bytes) == 0 {
 		return ErrSigningPayloadBytesEmpty
+	}
+
+	if BytesArrayZero(signingPayload.Bytes) {
+		return ErrSigningPayloadBytesZero
 	}
 
 	// SignatureType can be optionally populated
@@ -285,6 +288,10 @@ func Signatures(
 
 		if len(signature.Bytes) == 0 {
 			return fmt.Errorf("%w: signature %d has 0 bytes", ErrSignatureBytesEmpty, i)
+		}
+
+		if BytesArrayZero(signature.Bytes) {
+			return ErrSignatureBytesZero
 		}
 	}
 

--- a/asserter/construction.go
+++ b/asserter/construction.go
@@ -199,7 +199,7 @@ func PublicKey(
 		return ErrPublicKeyBytesEmpty
 	}
 
-	if bytes.Compare(publicKey.Bytes, make([]byte, len(publicKey.Bytes))) == 0 {
+	if bytes.Equal(publicKey.Bytes, make([]byte, len(publicKey.Bytes))) {
 		return ErrPublicKeyBytesZero
 	}
 

--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -591,6 +591,13 @@ func TestPublicKey(t *testing.T) {
 				CurveType: types.Secp256k1,
 			},
 		},
+		"zero public key": {
+			publicKey: &types.PublicKey{
+				Bytes:     []byte{0, 0, 0, 0},
+				CurveType: types.Secp256k1,
+			},
+			err: ErrPublicKeyBytesZero,
+		},
 		"nil public key": {
 			err: ErrPublicKeyIsNil,
 		},

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -200,11 +200,15 @@ var (
 	ErrSigningPayloadBytesEmpty = errors.New(
 		"signing payload bytes cannot be empty",
 	)
+	ErrSigningPayloadBytesZero = errors.New(
+		"signing payload bytes cannot be 0",
+	)
 	ErrSignaturesEmpty               = errors.New("signatures cannot be empty")
 	ErrSignaturesReturnedSigMismatch = errors.New(
 		"requested signature type does not match returned signature type",
 	)
 	ErrSignatureBytesEmpty       = errors.New("signature bytes cannot be empty")
+	ErrSignatureBytesZero        = errors.New("signature bytes cannot be 0")
 	ErrSignatureTypeNotSupported = errors.New("not a supported SignatureType")
 
 	ConstructionErrs = []error{
@@ -226,13 +230,16 @@ var (
 		ErrConstructionPayloadsResponsePayloadsEmpty,
 		ErrPublicKeyIsNil,
 		ErrPublicKeyBytesEmpty,
+		ErrPublicKeyBytesZero,
 		ErrCurveTypeNotSupported,
 		ErrSigningPayloadIsNil,
 		ErrSigningPayloadAddrEmpty,
 		ErrSigningPayloadBytesEmpty,
+		ErrSigningPayloadBytesZero,
 		ErrSignaturesEmpty,
 		ErrSignaturesReturnedSigMismatch,
 		ErrSignatureBytesEmpty,
+		ErrSignatureBytesZero,
 		ErrSignatureTypeNotSupported,
 	}
 

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -191,6 +191,7 @@ var (
 	ErrConstructionPayloadsResponsePayloadsEmpty = errors.New("signing payloads cannot be empty")
 	ErrPublicKeyIsNil                            = errors.New("PublicKey cannot be nil")
 	ErrPublicKeyBytesEmpty                       = errors.New("public key bytes cannot be empty")
+	ErrPublicKeyBytesZero                        = errors.New("public key bytes 0")
 	ErrCurveTypeNotSupported                     = errors.New("not a supported CurveType")
 	ErrSigningPayloadIsNil                       = errors.New("signing payload cannot be nil")
 	ErrSigningPayloadAddrEmpty                   = errors.New(

--- a/asserter/utils.go
+++ b/asserter/utils.go
@@ -15,6 +15,7 @@
 package asserter
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -64,4 +65,10 @@ func AccountArray(arrName string, arr []*types.AccountIdentifier) error {
 	}
 
 	return nil
+}
+
+// BytesArrayZero returns a boolean indicating if
+// all elements in an array are 0.
+func BytesArrayZero(arr []byte) bool {
+	return bytes.Equal(arr, make([]byte, len(arr)))
 }

--- a/keys/errors.go
+++ b/keys/errors.go
@@ -24,6 +24,7 @@ import (
 var (
 	ErrPrivKeyUndecodable   = errors.New("could not decode privkey")
 	ErrPrivKeyLengthInvalid = errors.New("invalid privkey length")
+	ErrPrivKeyZero          = errors.New("privkey cannot be 0")
 
 	ErrKeyGenSecp256k1Failed = errors.New(
 		"keygen: error generating key pair for secp256k1 curve type",
@@ -56,6 +57,7 @@ func Err(err error) bool {
 	keyErrors := []error{
 		ErrPrivKeyUndecodable,
 		ErrPrivKeyLengthInvalid,
+		ErrPrivKeyZero,
 		ErrKeyGenSecp256k1Failed,
 		ErrKeyGenEdwards25519Failed,
 		ErrCurveTypeNotSupported,

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -63,17 +63,16 @@ func ImportPrivateKey(privKeyHex string, curve types.CurveType) (*KeyPair, error
 
 		return keyPair, nil
 	case types.Edwards25519:
-		privKeyBytes := ed25519.NewKeyFromSeed(privKey)
-		pubKeyBytes := privKeyBytes.Public().(ed25519.PublicKey)
+		rawPrivKey := ed25519.NewKeyFromSeed(privKey)
 
 		pubKey := &types.PublicKey{
-			Bytes:     pubKeyBytes,
+			Bytes:     rawPrivKey.Public().(ed25519.PublicKey),
 			CurveType: curve,
 		}
 
 		keyPair := &KeyPair{
 			PublicKey:  pubKey,
-			PrivateKey: privKeyBytes.Seed(),
+			PrivateKey: rawPrivKey.Seed(),
 		}
 
 		return keyPair, nil

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -64,8 +64,7 @@ func ImportPrivateKey(privKeyHex string, curve types.CurveType) (*KeyPair, error
 		return keyPair, nil
 	case types.Edwards25519:
 		privKeyBytes := ed25519.NewKeyFromSeed(privKey)
-		pubKeyBytes := make([]byte, ed25519.PublicKeySize)
-		copy(pubKeyBytes, privKey[32:])
+		pubKeyBytes := privKeyBytes.Public().(ed25519.PublicKey)
 
 		pubKey := &types.PublicKey{
 			Bytes:     pubKeyBytes,

--- a/keys/signer_edwards25519_test.go
+++ b/keys/signer_edwards25519_test.go
@@ -96,9 +96,12 @@ func TestVerifyEdwards25519(t *testing.T) {
 		errMsg    error
 	}
 
+	simpleBytes := make([]byte, 32)
+	copy(simpleBytes, "hello")
+
 	payload := &types.SigningPayload{
 		AccountIdentifier: &types.AccountIdentifier{Address: "test"},
-		Bytes:             make([]byte, 32),
+		Bytes:             simpleBytes,
 		SignatureType:     types.Ed25519,
 	}
 	testSignature, err := signerEdwards25519.Sign(payload, types.Ed25519)
@@ -108,17 +111,22 @@ func TestVerifyEdwards25519(t *testing.T) {
 		{mockSignature(
 			types.Ecdsa,
 			signerEdwards25519.PublicKey(),
-			make([]byte, 32),
-			make([]byte, 32)), ErrVerifyUnsupportedPayloadSignatureType},
+			simpleBytes,
+			simpleBytes), ErrVerifyUnsupportedPayloadSignatureType},
 		{mockSignature(
 			types.EcdsaRecovery,
 			signerEdwards25519.PublicKey(),
-			make([]byte, 32),
-			make([]byte, 32)), ErrVerifyUnsupportedPayloadSignatureType},
+			simpleBytes,
+			simpleBytes), ErrVerifyUnsupportedPayloadSignatureType},
 		{mockSignature(
 			types.Ed25519,
 			signerEdwards25519.PublicKey(),
-			make([]byte, 40),
+			func() []byte {
+				b := make([]byte, 40)
+				copy(b, "hello")
+
+				return b
+			}(),
 			testSignature.Bytes), ErrVerifyFailed},
 	}
 
@@ -130,7 +138,7 @@ func TestVerifyEdwards25519(t *testing.T) {
 	goodSignature := mockSignature(
 		types.Ed25519,
 		signerEdwards25519.PublicKey(),
-		make([]byte, 32),
+		simpleBytes,
 		testSignature.Bytes,
 	)
 	assert.Equal(t, nil, signerEdwards25519.Verify(goodSignature))

--- a/keys/signer_edwards25519_test.go
+++ b/keys/signer_edwards25519_test.go
@@ -63,6 +63,7 @@ func TestSignEdwards25519(t *testing.T) {
 		if !test.err {
 			assert.NoError(t, err)
 			assert.Len(t, signature.Bytes, 64)
+			assert.Equal(t, signerEdwards25519.PublicKey(), signature.PublicKey)
 		} else {
 			assert.Contains(t, err.Error(), test.errMsg.Error())
 		}

--- a/keys/signer_secp256k1_test.go
+++ b/keys/signer_secp256k1_test.go
@@ -108,17 +108,20 @@ func TestVerifySecp256k1(t *testing.T) {
 	testSignatureEcdsa, _ := signerSecp256k1.Sign(payloadEcdsa, types.Ecdsa)
 	testSignatureEcdsaRecovery, _ := signerSecp256k1.Sign(payloadEcdsaRecovery, types.EcdsaRecovery)
 
+	simpleBytes := make([]byte, 33)
+	copy(simpleBytes, "hello")
+
 	var signatureTests = []signatureTest{
 		{mockSecpSignature(
 			types.Ed25519,
 			signerSecp256k1.PublicKey(),
 			hash("hello"),
-			make([]byte, 33)), ErrVerifyUnsupportedSignatureType},
+			simpleBytes), ErrVerifyUnsupportedSignatureType},
 		{mockSecpSignature(
 			types.Ecdsa,
 			signerSecp256k1.PublicKey(),
 			hash("hello"),
-			make([]byte, 33)), ErrVerifyFailed},
+			simpleBytes), ErrVerifyFailed},
 	}
 
 	for _, test := range signatureTests {

--- a/keys/signer_secp256k1_test.go
+++ b/keys/signer_secp256k1_test.go
@@ -62,6 +62,7 @@ func TestSignSecp256k1(t *testing.T) {
 		if !test.err {
 			assert.NoError(t, err)
 			assert.Equal(t, len(signature.Bytes), test.sigLen)
+			assert.Equal(t, signerSecp256k1.PublicKey(), signature.PublicKey)
 		} else {
 			assert.Contains(t, err.Error(), test.errMsg.Error())
 		}


### PR DESCRIPTION
This PR fixes an issue where the PublicKey is all 0s when importing `edwards25519` keys. This bug was introduced in #93.

### Changes
- [x] Add assertion that `PublicKey.Bytes` aren't just 0s
- [x] Add test ensuring `PublicKey` is populated in `Signature`
- [x] Import public key correctly for `edwards25519` keys
- [x] Assert no byte payloads are just 0 values
- [x] Add additional validation after generation and import