### PR TITLE
[Asserter] Add more test coverage for BytesArrayZero

### DIFF
--- a/asserter/construction_test.go
+++ b/asserter/construction_test.go
@@ -660,6 +660,15 @@ func TestSigningPayload(t *testing.T) {
 			},
 			err: ErrSigningPayloadAddrEmpty,
 		},
+		"zero signing payload": {
+			signingPayload: &types.SigningPayload{
+				AccountIdentifier: &types.AccountIdentifier{
+					Address: "hello",
+				},
+				Bytes: []byte{0, 0, 0, 0},
+			},
+			err: ErrSigningPayloadBytesZero,
+		},
 		"empty bytes": {
 			signingPayload: &types.SigningPayload{
 				AccountIdentifier: &types.AccountIdentifier{
@@ -759,6 +768,21 @@ func TestSignatures(t *testing.T) {
 				},
 			},
 			err: ErrSignatureBytesEmpty,
+		},
+		"signature zero bytes": {
+			signatures: []*types.Signature{
+				{
+					SigningPayload: &types.SigningPayload{
+						AccountIdentifier: validAccount,
+						Bytes:             []byte("blah"),
+						SignatureType:     types.Ed25519,
+					},
+					PublicKey:     validPublicKey,
+					SignatureType: types.Ed25519,
+					Bytes:         []byte{0},
+				},
+			},
+			err: ErrSignatureBytesZero,
 		},
 		"signature type mismatch": {
 			signatures: []*types.Signature{

--- a/storage/key_storage.go
+++ b/storage/key_storage.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
-	"time"
+	"math/big"
 
 	"github.com/coinbase/rosetta-sdk-go/keys"
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/coinbase/rosetta-sdk-go/utils"
 )
 
 // WARNING: KEY STORAGE USING THIS PACKAGE IS NOT SECURE!!!! ONLY USE
@@ -34,10 +34,6 @@ type PrefundedAccount struct {
 	AccountIdentifier *types.AccountIdentifier `json:"account_identifier"`
 	CurveType         types.CurveType          `json:"curve_type"`
 	Currency          *types.Currency          `json:"currency"`
-}
-
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
 }
 
 const (
@@ -249,7 +245,8 @@ func (k *KeyStorage) RandomAccount(ctx context.Context) (*types.AccountIdentifie
 		return nil, ErrNoAddrAvailable
 	}
 
-	return accounts[rand.Intn(len(accounts))], nil
+	randomNumber := utils.RandomNumber(big.NewInt(0), big.NewInt(int64(len(accounts))))
+	return accounts[randomNumber.Int64()], nil
 }
 
 // ImportAccounts loads a set of prefunded accounts into key storage.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,13 +17,13 @@ package utils
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"math/big"
-	"math/rand"
 	"os"
 	"path"
 	"time"
@@ -33,10 +33,6 @@ import (
 
 	"github.com/fatih/color"
 )
-
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
 
 const (
 	// DefaultFilePermissions specifies that the user can
@@ -241,11 +237,13 @@ func Zero() *big.Float {
 }
 
 // RandomNumber returns some number in the range [minimum, maximum).
-// Source: https://golang.org/pkg/math/big/#Int.Rand
+// Source: https://golang.org/pkg/crypto/rand/#Int
 func RandomNumber(minimum *big.Int, maximum *big.Int) *big.Int {
-	source := rand.New(rand.NewSource(time.Now().UnixNano()))
 	transformed := new(big.Int).Sub(maximum, minimum)
-	addition := new(big.Int).Rand(source, transformed)
+	addition, err := rand.Int(rand.Reader, transformed)
+	if err != nil {
+		log.Fatalf("cannot get random number: %v", err)
+	}
 
 	return new(big.Int).Add(minimum, addition)
 }


### PR DESCRIPTION
This PR adds additional test coverage for the new zero bytes check introduced in #167.

### Changes
- [x] Add test to `Signature`
- [x] Add test to `SigningPayload`
- [x] use `crypto/rand` instead of `math/rand` (salus)

