### PR TITLE
[Utils] Add util for checking if implementation at tip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint-examples:
 	golangci-lint run -v -E ${LINT_SETTINGS}
 
 lint: | lint-examples
-	golangci-lint run -v -E ${LINT_SETTINGS},gomnd && \
+	golangci-lint run --timeout 2m0s -v -E ${LINT_SETTINGS},gomnd && \
 	make check-comments;
 
 format:

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -974,9 +974,8 @@ func (b *BlockStorage) AtTip(
 		return false, nil, fmt.Errorf("%w: %v", ErrHeadBlockGetFailed, err)
 	}
 
-	currentTime := utils.Milliseconds()
-	tipCutoff := currentTime - (tipDelay * utils.MillisecondsInSecond)
-	if block.Timestamp < tipCutoff {
+	atTip := utils.AtTip(tipDelay, block.Timestamp)
+	if !atTip {
 		return false, nil, nil
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -388,3 +388,38 @@ func GetAccountBalances(
 
 	return accountBalances, nil
 }
+
+// AtTip returns a boolean indicating if a block timestamp
+// is within tipDelay from the current time.
+func AtTip(
+	tipDelay int64,
+	blockTimestamp int64,
+) bool {
+	currentTime := Milliseconds()
+	tipCutoff := currentTime - (tipDelay * MillisecondsInSecond)
+	if blockTimestamp < tipCutoff {
+		return false
+	}
+
+	return true
+}
+
+// CheckAtTip returns a boolean indicating if a
+// Rosetta implementation is at tip.
+func CheckAtTip(
+	ctx context.Context,
+	networkIdentifier *types.NetworkIdentifier,
+	helper FetcherHelper,
+	tipDelay int64,
+) (bool, error) {
+	status, fetchErr := helper.NetworkStatusRetry(
+		ctx,
+		networkIdentifier,
+		nil,
+	)
+	if fetchErr != nil {
+		return false, fmt.Errorf("%w: unable to get network status", fetchErr.Err)
+	}
+
+	return AtTip(tipDelay, status.CurrentBlockTimestamp), nil
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -397,11 +397,8 @@ func AtTip(
 ) bool {
 	currentTime := Milliseconds()
 	tipCutoff := currentTime - (tipDelay * MillisecondsInSecond)
-	if blockTimestamp < tipCutoff {
-		return false
-	}
 
-	return true
+	return blockTimestamp >= tipCutoff
 }
 
 // CheckAtTip returns a boolean indicating if a


### PR DESCRIPTION
To determine if we should begin running `check:construction`, we need to know if we are at tip. This PR adds a convenience function to the `utils` package that does this.

### Changes
- [x] Add a method in `utils` for checking if a Rosetta implementation is at tip using the returned timestamp
- [x] Extend linter timeout