### PR TITLE
[Utils] Add collection of utils

### DIFF
--- a/constructor/coordinator/coordinator.go
+++ b/constructor/coordinator/coordinator.go
@@ -471,8 +471,6 @@ func (c *Coordinator) process( // nolint:gocognit
 	returnFunds bool,
 ) (time.Duration, error) {
 	if !c.helper.HeadBlockExists(ctx) {
-		log.Println("waiting for first block synced...")
-
 		// We will sleep until at least one block has been synced.
 		// Many of the storage-based commands require a synced block
 		// to work correctly (i.e. when fetching a balance, a block

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -57,6 +57,11 @@ const (
 
 	// OneHundred is the number 100.
 	OneHundred = 100
+
+	// minBlocksPerSecond is the minimum blocks per second
+	// to consider when estimating time to tip if the provided
+	// estimate is 0.
+	minBlocksPerSecond = 0.0001
 )
 
 var (
@@ -472,4 +477,25 @@ func MonitorMemoryUsage(
 	}
 
 	return usage
+}
+
+// TimeToTip returns the estimate time to tip given
+// the current sync speed.
+func TimeToTip(
+	blocksPerSecond float64,
+	lastSyncedIndex int64,
+	tipIndex int64,
+) time.Duration {
+	if blocksPerSecond <= 0 { // ensure we don't divide by 0
+		blocksPerSecond = minBlocksPerSecond
+	}
+
+	remainingBlocks := tipIndex - lastSyncedIndex
+	if remainingBlocks < 0 { // ensure we don't get negative time
+		remainingBlocks = 0
+	}
+
+	secondsRemaining := int64(float64(remainingBlocks) / blocksPerSecond)
+
+	return time.Duration(secondsRemaining) * time.Second
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -482,3 +482,40 @@ func TestCheckAtTip(t *testing.T) {
 		})
 	}
 }
+
+func TestTimeToTip(t *testing.T) {
+	tests := map[string]struct {
+		blocksPerSecond float64
+		lastSyncedIndex int64
+		tipIndex        int64
+
+		expectedTime string
+	}{
+		"far from tip": {
+			blocksPerSecond: 6,
+			lastSyncedIndex: 10,
+			tipIndex:        10000,
+
+			expectedTime: "27m45s",
+		},
+		"0 blocks per second": {
+			blocksPerSecond: 0,
+			lastSyncedIndex: 10,
+			tipIndex:        1000,
+			expectedTime:    "2750h0m0s",
+		},
+		"negative blocks remaining": {
+			blocksPerSecond: 10,
+			lastSyncedIndex: 100,
+			tipIndex:        10,
+			expectedTime:    "0s",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			timeToTip := TimeToTip(test.blocksPerSecond, test.lastSyncedIndex, test.tipIndex)
+			assert.Equal(t, test.expectedTime, timeToTip.String())
+		})
+	}
+}


### PR DESCRIPTION
Related Issue: https://github.com/coinbase/rosetta-cli/issues/100

This PR adds a collection of new functions to the `utils` package that help in getting memory usage and estimating time to tip.

### Changes
- [x] Add context sleep
- [x] Get memory usage
- [x] Get estimate to tip
- [x] Don't print waiting for first block synced