### PR TITLE
[Fetcher|Asserter] Assert any *types.Error returned is in /network/options

### DIFF
--- a/asserter/error.go
+++ b/asserter/error.go
@@ -1,0 +1,38 @@
+package asserter
+
+import (
+	"fmt"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+// Error ensures a *types.Error matches some error
+// provided in `/network/options`. To ensure we don't
+// silence errors on failure, we always include the *types.Error
+// in the error message.
+func (a *Asserter) Error(
+	err *types.Error,
+) error {
+	if a == nil {
+		return fmt.Errorf("%w: error: %s", ErrAsserterNotInitialized, types.PrintStruct(err))
+	}
+
+	if err := Error(err); err != nil {
+		return fmt.Errorf("%w: error: %s", err, types.PrintStruct(err))
+	}
+
+	val, ok := a.errorTypeMap[err.Code]
+	if !ok {
+		return fmt.Errorf("%w: code %d error: %s", ErrErrorUnexpectedCode, err.Code, types.PrintStruct(err))
+	}
+
+	if val.Message != err.Message {
+		return fmt.Errorf("%w: expected %s actual %s error: %s", ErrErrorMessageMismatch, val.Message, err.Message, types.PrintStruct(err))
+	}
+
+	if val.Retriable != err.Retriable {
+		return fmt.Errorf("%w: expected %s actual %s error: %s", ErrErrorRetriableMismatch, val.Message, err.Message, types.PrintStruct(err))
+	}
+
+	return nil
+}

--- a/asserter/error.go
+++ b/asserter/error.go
@@ -7,47 +7,42 @@ import (
 )
 
 // Error ensures a *types.Error matches some error
-// provided in `/network/options`. To ensure we don't
-// silence errors on failure, we always include the *types.Error
-// in the error message.
+// provided in `/network/options`.
 func (a *Asserter) Error(
 	err *types.Error,
 ) error {
 	if a == nil {
-		return fmt.Errorf("%w: error: %s", ErrAsserterNotInitialized, types.PrintStruct(err))
+		return ErrAsserterNotInitialized
 	}
 
 	if err := Error(err); err != nil {
-		return fmt.Errorf("%w: error: %s", err, types.PrintStruct(err))
+		return err
 	}
 
 	val, ok := a.errorTypeMap[err.Code]
 	if !ok {
 		return fmt.Errorf(
-			"%w: code %d error: %s",
+			"%w: code %d",
 			ErrErrorUnexpectedCode,
 			err.Code,
-			types.PrintStruct(err),
 		)
 	}
 
 	if val.Message != err.Message {
 		return fmt.Errorf(
-			"%w: expected %s actual %s error: %s",
+			"%w: expected %s actual %s",
 			ErrErrorMessageMismatch,
 			val.Message,
 			err.Message,
-			types.PrintStruct(err),
 		)
 	}
 
 	if val.Retriable != err.Retriable {
 		return fmt.Errorf(
-			"%w: expected %s actual %s error: %s",
+			"%w: expected %s actual %s",
 			ErrErrorRetriableMismatch,
 			val.Message,
 			err.Message,
-			types.PrintStruct(err),
 		)
 	}
 

--- a/asserter/error.go
+++ b/asserter/error.go
@@ -23,15 +23,32 @@ func (a *Asserter) Error(
 
 	val, ok := a.errorTypeMap[err.Code]
 	if !ok {
-		return fmt.Errorf("%w: code %d error: %s", ErrErrorUnexpectedCode, err.Code, types.PrintStruct(err))
+		return fmt.Errorf(
+			"%w: code %d error: %s",
+			ErrErrorUnexpectedCode,
+			err.Code,
+			types.PrintStruct(err),
+		)
 	}
 
 	if val.Message != err.Message {
-		return fmt.Errorf("%w: expected %s actual %s error: %s", ErrErrorMessageMismatch, val.Message, err.Message, types.PrintStruct(err))
+		return fmt.Errorf(
+			"%w: expected %s actual %s error: %s",
+			ErrErrorMessageMismatch,
+			val.Message,
+			err.Message,
+			types.PrintStruct(err),
+		)
 	}
 
 	if val.Retriable != err.Retriable {
-		return fmt.Errorf("%w: expected %s actual %s error: %s", ErrErrorRetriableMismatch, val.Message, err.Message, types.PrintStruct(err))
+		return fmt.Errorf(
+			"%w: expected %s actual %s error: %s",
+			ErrErrorRetriableMismatch,
+			val.Message,
+			err.Message,
+			types.PrintStruct(err),
+		)
 	}
 
 	return nil

--- a/asserter/error.go
+++ b/asserter/error.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package asserter
 
 import (

--- a/asserter/error_test.go
+++ b/asserter/error_test.go
@@ -1,0 +1,96 @@
+package asserter
+
+import (
+	"testing"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorMap(t *testing.T) {
+	var tests = map[string]struct {
+		err         *types.Error
+		expectedErr error
+	}{
+		"matching error": {
+			err: &types.Error{
+				Code:      10,
+				Message:   "error 10",
+				Retriable: true,
+				Details: map[string]interface{}{
+					"hello": "goodbye",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			asserter, err := NewClientWithResponses(
+				&types.NetworkIdentifier{
+					Blockchain: "hello",
+					Network:    "world",
+				},
+				&types.NetworkStatusResponse{
+					GenesisBlockIdentifier: &types.BlockIdentifier{
+						Index: 0,
+						Hash:  "block 0",
+					},
+					CurrentBlockIdentifier: &types.BlockIdentifier{
+						Index: 100,
+						Hash:  "block 100",
+					},
+					CurrentBlockTimestamp: MinUnixEpoch + 1,
+					Peers: []*types.Peer{
+						{
+							PeerID: "peer 1",
+						},
+					},
+				},
+				&types.NetworkOptionsResponse{
+					Version: &types.Version{
+						RosettaVersion: "1.4.0",
+						NodeVersion:    "1.0",
+					},
+					Allow: &types.Allow{
+						Errors: []*types.Error{
+							{
+								Code:      10,
+								Message:   "error 10",
+								Retriable: true,
+							},
+							{
+								Code:    1,
+								Message: "error 1",
+							},
+						},
+						OperationStatuses: []*types.OperationStatus{
+							{
+								Status:     "SUCCESS",
+								Successful: true,
+							},
+							{
+								Status:     "FAILURE",
+								Successful: false,
+							},
+						},
+						OperationTypes: []string{
+							"PAYMENT",
+						},
+					},
+				},
+			)
+			assert.NotNil(t, asserter)
+			assert.NoError(t, err)
+
+			err = asserter.Error(test.err)
+			if test.expectedErr != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/asserter/error_test.go
+++ b/asserter/error_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package asserter
 
 import (

--- a/asserter/error_test.go
+++ b/asserter/error_test.go
@@ -1,6 +1,7 @@
 package asserter
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -22,6 +23,48 @@ func TestErrorMap(t *testing.T) {
 					"hello": "goodbye",
 				},
 			},
+		},
+		"negative error": {
+			err: &types.Error{
+				Code:      -1,
+				Message:   "error 10",
+				Retriable: true,
+				Details: map[string]interface{}{
+					"hello": "goodbye",
+				},
+			},
+			expectedErr: ErrErrorCodeIsNeg,
+		},
+		"retriable error": {
+			err: &types.Error{
+				Code:    10,
+				Message: "error 10",
+				Details: map[string]interface{}{
+					"hello": "goodbye",
+				},
+			},
+			expectedErr: ErrErrorRetriableMismatch,
+		},
+		"code mismatch": {
+			err: &types.Error{
+				Code:    20,
+				Message: "error 20",
+				Details: map[string]interface{}{
+					"hello": "goodbye",
+				},
+			},
+			expectedErr: ErrErrorUnexpectedCode,
+		},
+		"message mismatch": {
+			err: &types.Error{
+				Code:      10,
+				Retriable: true,
+				Message:   "error 11",
+				Details: map[string]interface{}{
+					"hello": "goodbye",
+				},
+			},
+			expectedErr: ErrErrorMessageMismatch,
 		},
 	}
 
@@ -86,8 +129,7 @@ func TestErrorMap(t *testing.T) {
 
 			err = asserter.Error(test.err)
 			if test.expectedErr != nil {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), test.expectedErr.Error())
+				assert.True(t, errors.Is(err, test.expectedErr))
 			} else {
 				assert.NoError(t, err)
 			}

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -262,10 +262,8 @@ var (
 	ErrNoSuccessfulAllowedOperationStatuses = errors.New(
 		"no successful Allow.OperationStatuses found",
 	)
-	ErrErrorIsNil                                   = errors.New("Error is nil")
-	ErrErrorCodeIsNeg                               = errors.New("Error.Code is negative")
-	ErrErrorMessageMissing                          = errors.New("Error.Message is missing")
 	ErrErrorCodeUsedMultipleTimes                   = errors.New("error code used multiple times")
+	ErrErrorDetailsPopulated                        = errors.New("error details populated in /network/options")
 	ErrAllowIsNil                                   = errors.New("Allow is nil")
 	ErrNetworkOptionsResponseIsNil                  = errors.New("options is nil")
 	ErrNetworkListResponseIsNil                     = errors.New("NetworkListResponse is nil")
@@ -285,10 +283,8 @@ var (
 		ErrNetworkStatusResponseIsNil,
 		ErrNoAllowedOperationStatuses,
 		ErrNoSuccessfulAllowedOperationStatuses,
-		ErrErrorIsNil,
-		ErrErrorCodeIsNeg,
-		ErrErrorMessageMissing,
 		ErrErrorCodeUsedMultipleTimes,
+		ErrErrorDetailsPopulated,
 		ErrAllowIsNil,
 		ErrNetworkOptionsResponseIsNil,
 		ErrNetworkListResponseIsNil,
@@ -376,6 +372,25 @@ var (
 		ErrConstructionParseRequestIsNil,
 		ErrConstructionParseRequestEmpty,
 	}
+
+	///////////////////
+	/* ERROR ERRORS */
+	///////////////////
+	ErrErrorIsNil             = errors.New("Error is nil")
+	ErrErrorCodeIsNeg         = errors.New("Error.Code is negative")
+	ErrErrorMessageMissing    = errors.New("Error.Message is missing")
+	ErrErrorUnexpectedCode    = errors.New("Error.Code unexpected")
+	ErrErrorMessageMismatch   = errors.New("Error.Message does not match message from /network/options")
+	ErrErrorRetriableMismatch = errors.New("Error.Retriable mismatch")
+
+	ErrorErrs = []error{
+		ErrErrorIsNil,
+		ErrErrorCodeIsNeg,
+		ErrErrorMessageMissing,
+		ErrErrorUnexpectedCode,
+		ErrErrorMessageMismatch,
+		ErrErrorRetriableMismatch,
+	}
 )
 
 // Err takes an error as an argument and returns
@@ -389,6 +404,7 @@ func Err(err error) (bool, string) {
 		"construction error":    ConstructionErrs,
 		"network error":         NetworkErrs,
 		"server error":          ServerErrs,
+		"error error":           ErrorErrs,
 	}
 
 	for key, val := range assertErrs {

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -262,8 +262,10 @@ var (
 	ErrNoSuccessfulAllowedOperationStatuses = errors.New(
 		"no successful Allow.OperationStatuses found",
 	)
-	ErrErrorCodeUsedMultipleTimes                   = errors.New("error code used multiple times")
-	ErrErrorDetailsPopulated                        = errors.New("error details populated in /network/options")
+	ErrErrorCodeUsedMultipleTimes = errors.New("error code used multiple times")
+	ErrErrorDetailsPopulated      = errors.New(
+		"error details populated in /network/options",
+	)
 	ErrAllowIsNil                                   = errors.New("Allow is nil")
 	ErrNetworkOptionsResponseIsNil                  = errors.New("options is nil")
 	ErrNetworkListResponseIsNil                     = errors.New("NetworkListResponse is nil")
@@ -376,11 +378,13 @@ var (
 	///////////////////
 	/* ERROR ERRORS */
 	///////////////////
-	ErrErrorIsNil             = errors.New("Error is nil")
-	ErrErrorCodeIsNeg         = errors.New("Error.Code is negative")
-	ErrErrorMessageMissing    = errors.New("Error.Message is missing")
-	ErrErrorUnexpectedCode    = errors.New("Error.Code unexpected")
-	ErrErrorMessageMismatch   = errors.New("Error.Message does not match message from /network/options")
+	ErrErrorIsNil           = errors.New("Error is nil")
+	ErrErrorCodeIsNeg       = errors.New("Error.Code is negative")
+	ErrErrorMessageMissing  = errors.New("Error.Message is missing")
+	ErrErrorUnexpectedCode  = errors.New("Error.Code unexpected")
+	ErrErrorMessageMismatch = errors.New(
+		"Error.Message does not match message from /network/options",
+	)
 	ErrErrorRetriableMismatch = errors.New("Error.Retriable mismatch")
 
 	ErrorErrs = []error{

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -165,6 +165,12 @@ func Errors(rosettaErrors []*types.Error) error {
 			return err
 		}
 
+		// Error.Details should not be populated
+		// in the /network/options response.
+		if len(rosettaError.Details) > 0 {
+			return ErrErrorDetailsPopulated
+		}
+
 		_, exists := statusCodes[rosettaError.Code]
 		if exists {
 			return ErrErrorCodeUsedMultipleTimes

--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -259,6 +259,22 @@ func TestErrors(t *testing.T) {
 			},
 			err: nil,
 		},
+		"details populated": {
+			rosettaErrors: []*types.Error{
+				{
+					Code:    0,
+					Message: "error 1",
+					Details: map[string]interface{}{
+						"hello": "goodbye",
+					},
+				},
+				{
+					Code:    1,
+					Message: "error 2",
+				},
+			},
+			err: ErrErrorDetailsPopulated,
+		},
 		"duplicate error codes": {
 			rosettaErrors: []*types.Error{
 				{

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -47,7 +47,7 @@ func (f *Fetcher) AccountBalance(
 		},
 	)
 	if err != nil {
-		return nil, nil, nil, nil, f.CreateError(clientErr, err, "/account/balance")
+		return nil, nil, nil, nil, f.RequestFailedError(clientErr, err, "/account/balance")
 	}
 
 	if err := asserter.AccountBalanceResponse(

--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -47,11 +47,7 @@ func (f *Fetcher) AccountBalance(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /account/balance %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, nil, nil, nil, fetcherErr
+		return nil, nil, nil, nil, f.CreateError(clientErr, err, "/account/balance")
 	}
 
 	if err := asserter.AccountBalanceResponse(

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -103,7 +103,7 @@ func (f *Fetcher) fetchChannelTransactions(
 				return &Error{Err: ctx.Err()}
 			}
 
-			fetchErr := f.CreateError(clientErr, err, fmt.Sprintf(
+			fetchErr := f.RequestFailedError(clientErr, err, fmt.Sprintf(
 				"/block/transaction %s at block %d:%s",
 				transactionIdentifier.Hash,
 				block.Index,
@@ -225,7 +225,7 @@ func (f *Fetcher) UnsafeBlock(
 		BlockIdentifier:   blockIdentifier,
 	})
 	if err != nil {
-		return nil, f.CreateError(clientErr, err, fmt.Sprintf(
+		return nil, f.RequestFailedError(clientErr, err, fmt.Sprintf(
 			"/block %s",
 			types.PrintStruct(blockIdentifier),
 		))

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -103,17 +103,12 @@ func (f *Fetcher) fetchChannelTransactions(
 				return &Error{Err: ctx.Err()}
 			}
 
-			fetchErr := &Error{
-				Err: fmt.Errorf(
-					"%w: /block/transaction %s at block %d:%s %s",
-					ErrRequestFailed,
-					transactionIdentifier.Hash,
-					block.Index,
-					block.Hash,
-					err.Error(),
-				),
-				ClientErr: clientErr,
-			}
+			fetchErr := f.CreateError(clientErr, err, fmt.Sprintf(
+				"/block/transaction %s at block %d:%s",
+				transactionIdentifier.Hash,
+				block.Index,
+				block.Hash,
+			))
 
 			txFetchErr := fmt.Sprintf("transaction %s", types.PrintStruct(transactionIdentifier))
 			if err := tryAgain(txFetchErr, backoffRetries, fetchErr); err != nil {
@@ -230,16 +225,10 @@ func (f *Fetcher) UnsafeBlock(
 		BlockIdentifier:   blockIdentifier,
 	})
 	if err != nil {
-		fetcherErr := &Error{
-			Err: fmt.Errorf(
-				"%w: /block %s %s",
-				ErrRequestFailed,
-				types.PrintStruct(blockIdentifier),
-				err.Error(),
-			),
-			ClientErr: clientErr,
-		}
-		return nil, fetcherErr
+		return nil, f.CreateError(clientErr, err, fmt.Sprintf(
+			"/block %s",
+			types.PrintStruct(blockIdentifier),
+		))
 	}
 
 	// Exit early if no need to fetch txs

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -49,7 +49,7 @@ func (f *Fetcher) ConstructionCombine(
 		},
 	)
 	if err != nil {
-		return "", f.CreateError(clientErr, err, "/construction/combine")
+		return "", f.RequestFailedError(clientErr, err, "/construction/combine")
 	}
 
 	if err := asserter.ConstructionCombineResponse(response); err != nil {
@@ -88,7 +88,7 @@ func (f *Fetcher) ConstructionDerive(
 		},
 	)
 	if err != nil {
-		return nil, nil, f.CreateError(clientErr, err, "/construction/derive")
+		return nil, nil, f.RequestFailedError(clientErr, err, "/construction/derive")
 	}
 
 	if err := asserter.ConstructionDeriveResponse(response); err != nil {
@@ -122,7 +122,7 @@ func (f *Fetcher) ConstructionHash(
 		},
 	)
 	if err != nil {
-		return nil, f.CreateError(clientErr, err, "/construction/hash")
+		return nil, f.RequestFailedError(clientErr, err, "/construction/hash")
 	}
 
 	if err := asserter.TransactionIdentifierResponse(response); err != nil {
@@ -158,7 +158,7 @@ func (f *Fetcher) ConstructionMetadata(
 		},
 	)
 	if err != nil {
-		return nil, nil, f.CreateError(clientErr, err, "/construction/metadata")
+		return nil, nil, f.RequestFailedError(clientErr, err, "/construction/metadata")
 	}
 
 	if err := asserter.ConstructionMetadataResponse(metadata); err != nil {
@@ -197,7 +197,7 @@ func (f *Fetcher) ConstructionParse(
 		},
 	)
 	if err != nil {
-		return nil, nil, nil, f.CreateError(clientErr, err, "/construction/parse")
+		return nil, nil, nil, f.RequestFailedError(clientErr, err, "/construction/parse")
 	}
 
 	if err := f.Asserter.ConstructionParseResponse(response, signed); err != nil {
@@ -245,7 +245,7 @@ func (f *Fetcher) ConstructionPayloads(
 	)
 
 	if err != nil {
-		return "", nil, f.CreateError(clientErr, err, "/construction/payloads")
+		return "", nil, f.RequestFailedError(clientErr, err, "/construction/payloads")
 	}
 
 	if err := asserter.ConstructionPayloadsResponse(response); err != nil {
@@ -287,7 +287,7 @@ func (f *Fetcher) ConstructionPreprocess(
 	)
 
 	if err != nil {
-		return nil, nil, f.CreateError(clientErr, err, "/construction/preprocess")
+		return nil, nil, f.RequestFailedError(clientErr, err, "/construction/preprocess")
 	}
 
 	if err := asserter.ConstructionPreprocessResponse(response); err != nil {
@@ -322,7 +322,7 @@ func (f *Fetcher) ConstructionSubmit(
 		},
 	)
 	if err != nil {
-		return nil, nil, f.CreateError(clientErr, err, "/construction/submit")
+		return nil, nil, f.RequestFailedError(clientErr, err, "/construction/submit")
 	}
 
 	if err := asserter.TransactionIdentifierResponse(submitResponse); err != nil {

--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -49,11 +49,7 @@ func (f *Fetcher) ConstructionCombine(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /construction/combine %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return "", fetcherErr
+		return "", f.CreateError(clientErr, err, "/construction/combine")
 	}
 
 	if err := asserter.ConstructionCombineResponse(response); err != nil {
@@ -92,11 +88,7 @@ func (f *Fetcher) ConstructionDerive(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /construction/derive %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, nil, fetcherErr
+		return nil, nil, f.CreateError(clientErr, err, "/construction/derive")
 	}
 
 	if err := asserter.ConstructionDeriveResponse(response); err != nil {
@@ -130,11 +122,7 @@ func (f *Fetcher) ConstructionHash(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /construction/hash %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, fetcherErr
+		return nil, f.CreateError(clientErr, err, "/construction/hash")
 	}
 
 	if err := asserter.TransactionIdentifierResponse(response); err != nil {
@@ -170,11 +158,7 @@ func (f *Fetcher) ConstructionMetadata(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /construction/metadata %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, nil, fetcherErr
+		return nil, nil, f.CreateError(clientErr, err, "/construction/metadata")
 	}
 
 	if err := asserter.ConstructionMetadataResponse(metadata); err != nil {
@@ -213,11 +197,7 @@ func (f *Fetcher) ConstructionParse(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /construction/parse %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, nil, nil, fetcherErr
+		return nil, nil, nil, f.CreateError(clientErr, err, "/construction/parse")
 	}
 
 	if err := f.Asserter.ConstructionParseResponse(response, signed); err != nil {
@@ -265,11 +245,7 @@ func (f *Fetcher) ConstructionPayloads(
 	)
 
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /construction/payloads %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return "", nil, fetcherErr
+		return "", nil, f.CreateError(clientErr, err, "/construction/payloads")
 	}
 
 	if err := asserter.ConstructionPayloadsResponse(response); err != nil {
@@ -311,11 +287,7 @@ func (f *Fetcher) ConstructionPreprocess(
 	)
 
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /construction/preprocess %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, nil, fetcherErr
+		return nil, nil, f.CreateError(clientErr, err, "/construction/preprocess")
 	}
 
 	if err := asserter.ConstructionPreprocessResponse(response); err != nil {
@@ -350,11 +322,7 @@ func (f *Fetcher) ConstructionSubmit(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /construction/submit %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, nil, fetcherErr
+		return nil, nil, f.CreateError(clientErr, err, "/construction/submit")
 	}
 
 	if err := asserter.TransactionIdentifierResponse(submitResponse); err != nil {

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -30,8 +30,8 @@ type Error struct {
 	ClientErr *types.Error `json:"client_err"`
 }
 
-// CreateError creates a new *Error and asserts the provided
-// rosettaErr
+// RequestFailedError creates a new *Error and asserts the provided
+// rosettaErr was provided in /network/options.
 func (f *Fetcher) RequestFailedError(
 	rosettaErr *types.Error,
 	err error,

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -39,10 +39,8 @@ func (f *Fetcher) RequestFailedError(
 ) *Error {
 	// If there is a *types.Error assertion error, we log it instead
 	// of exiting. Exiting abruptly here may cause unintended consequences.
-	if rosettaErr != nil {
-		if assertionErr := f.Asserter.Error(rosettaErr); err != nil {
-			log.Printf("error %s assertion failed: %s", types.PrintStruct(rosettaErr), assertionErr)
-		}
+	if assertionErr := f.Asserter.Error(rosettaErr); err != nil {
+		log.Printf("error %s assertion failed: %s", types.PrintStruct(rosettaErr), assertionErr)
 	}
 
 	return &Error{

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -43,11 +43,7 @@ func (f *Fetcher) Mempool(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /mempool %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, fetcherErr
+		return nil, f.CreateError(clientErr, err, "/mempool")
 	}
 
 	mempool := response.TransactionIdentifiers
@@ -83,11 +79,7 @@ func (f *Fetcher) MempoolTransaction(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /mempool/transaction %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, nil, fetcherErr
+		return nil, nil, f.CreateError(clientErr, err, "/mempool/transaction")
 	}
 
 	mempoolTransaction := response.Transaction

--- a/fetcher/mempool.go
+++ b/fetcher/mempool.go
@@ -43,7 +43,7 @@ func (f *Fetcher) Mempool(
 		},
 	)
 	if err != nil {
-		return nil, f.CreateError(clientErr, err, "/mempool")
+		return nil, f.RequestFailedError(clientErr, err, "/mempool")
 	}
 
 	mempool := response.TransactionIdentifiers
@@ -79,7 +79,7 @@ func (f *Fetcher) MempoolTransaction(
 		},
 	)
 	if err != nil {
-		return nil, nil, f.CreateError(clientErr, err, "/mempool/transaction")
+		return nil, nil, f.RequestFailedError(clientErr, err, "/mempool/transaction")
 	}
 
 	mempoolTransaction := response.Transaction

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -45,11 +45,7 @@ func (f *Fetcher) NetworkStatus(
 		},
 	)
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /network/status %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, fetcherErr
+		return nil, f.CreateError(clientErr, err, "/network/status")
 	}
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
@@ -129,11 +125,7 @@ func (f *Fetcher) NetworkList(
 	)
 
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /network/list %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, fetcherErr
+		return nil, f.CreateError(clientErr, err, "/network/list")
 	}
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
@@ -209,11 +201,7 @@ func (f *Fetcher) NetworkOptions(
 	)
 
 	if err != nil {
-		fetcherErr := &Error{
-			Err:       fmt.Errorf("%w: /network/options %s", ErrRequestFailed, err.Error()),
-			ClientErr: clientErr,
-		}
-		return nil, fetcherErr
+		return nil, f.CreateError(clientErr, err, "/network/options")
 	}
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -45,7 +45,7 @@ func (f *Fetcher) NetworkStatus(
 		},
 	)
 	if err != nil {
-		return nil, f.CreateError(clientErr, err, "/network/status")
+		return nil, f.RequestFailedError(clientErr, err, "/network/status")
 	}
 
 	if err := asserter.NetworkStatusResponse(networkStatus); err != nil {
@@ -125,7 +125,7 @@ func (f *Fetcher) NetworkList(
 	)
 
 	if err != nil {
-		return nil, f.CreateError(clientErr, err, "/network/list")
+		return nil, f.RequestFailedError(clientErr, err, "/network/list")
 	}
 
 	if err := asserter.NetworkListResponse(networkList); err != nil {
@@ -201,7 +201,7 @@ func (f *Fetcher) NetworkOptions(
 	)
 
 	if err != nil {
-		return nil, f.CreateError(clientErr, err, "/network/options")
+		return nil, f.RequestFailedError(clientErr, err, "/network/options")
 	}
 
 	if err := asserter.NetworkOptionsResponse(networkOptions); err != nil {

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
 	"github.com/cenkalti/backoff"
@@ -75,9 +76,11 @@ func transientError(err error) bool {
 // on the fetchMsg.
 func tryAgain(fetchMsg string, thisBackoff *Backoff, err *Error) *Error {
 	// Only retry if an error is explicitly retriable or the server
-	// returned a transient error.
+	// returned a transient error. If the error fails assertion, we should
+	// not retry!
+	asserterErr, _ := asserter.Err(err.Err)
 	if !transientError(err.Err) &&
-		(err.ClientErr == nil || !err.ClientErr.Retriable) {
+		(err.ClientErr == nil || !err.ClientErr.Retriable || asserterErr) {
 		return err
 	}
 

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/types"
 
 	"github.com/cenkalti/backoff"
@@ -76,11 +75,9 @@ func transientError(err error) bool {
 // on the fetchMsg.
 func tryAgain(fetchMsg string, thisBackoff *Backoff, err *Error) *Error {
 	// Only retry if an error is explicitly retriable or the server
-	// returned a transient error. If the error fails assertion, we should
-	// not retry!
-	asserterErr, _ := asserter.Err(err.Err)
+	// returned a transient error.
 	if !transientError(err.Err) &&
-		(err.ClientErr == nil || !err.ClientErr.Retriable || asserterErr) {
+		(err.ClientErr == nil || !err.ClientErr.Retriable) {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds `*types.Error` assertion to the `asserter` and `fetcher`. Importantly, we do not exit if we detect a mismatch and instead log the assertion failure so that we don't silence the error returned by the Rosetta implementation.

### Changes
- [x] Add new `asserter.Error` method that compares returned `*types.Error`  with `*types.Errors` returned in `/network/options`
- [x] Check all response errors for correctness