### PR TITLE
Replace broken link for commit guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,5 +49,5 @@ be locked to prevent further discussion.
 All support requests must be made via [our support team][3].
 
 [1]: https://github.com/coinbase/rosetta-sdk-go/issues
-[2]: https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25
+[2]: https://chris.beams.io/posts/git-commit/#seven-rules
 [3]: https://support.coinbase.com/customer/en/portal/articles/2288496-how-can-i-contact-coinbase-support-


### PR DESCRIPTION
### Motivation

The contribution guidelines suggest that contributors
`Ensure your [commit messages are well-written](https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25).
`
The medium link redirects to an expired domain.

### Solution

This PR replaces the broken link with a link to similar guidelines [suggested](https://github.com/coinbase/rosetta-specifications/pull/58#issuecomment-703758419) by patrick-ogrady :  https://chris.beams.io/posts/git-commit/#seven-rules

I'm opening PRs to make this fix in these repos: rosetta-specifications, rosetta-cli, rosetta-sdk-go and rosetta-bitcoin.