### PR TITLE
[reconciler] Add support for types.BalanceExemption

### DIFF
--- a/mocks/reconciler/handler.go
+++ b/mocks/reconciler/handler.go
@@ -15,6 +15,20 @@ type Handler struct {
 	mock.Mock
 }
 
+// ReconciliationExempt provides a mock function with given fields: ctx, reconciliationType, account, currency, computedBalance, liveBalance, block, exemption
+func (_m *Handler) ReconciliationExempt(ctx context.Context, reconciliationType string, account *types.AccountIdentifier, currency *types.Currency, computedBalance string, liveBalance string, block *types.BlockIdentifier, exemption *types.BalanceExemption) error {
+	ret := _m.Called(ctx, reconciliationType, account, currency, computedBalance, liveBalance, block, exemption)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *types.AccountIdentifier, *types.Currency, string, string, *types.BlockIdentifier, *types.BalanceExemption) error); ok {
+		r0 = rf(ctx, reconciliationType, account, currency, computedBalance, liveBalance, block, exemption)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ReconciliationFailed provides a mock function with given fields: ctx, reconciliationType, account, currency, computedBalance, liveBalance, block
 func (_m *Handler) ReconciliationFailed(ctx context.Context, reconciliationType string, account *types.AccountIdentifier, currency *types.Currency, computedBalance string, liveBalance string, block *types.BlockIdentifier) error {
 	ret := _m.Called(ctx, reconciliationType, account, currency, computedBalance, liveBalance, block)

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -102,3 +102,9 @@ func WithDebugLogging(debug bool) Option {
 		r.debugLogging = debug
 	}
 }
+
+func WithBalanceExemptions(exemptions []*types.BalanceExemption) Option {
+	return func(r *Reconciler) {
+		r.exemptions = exemptions
+	}
+}

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -103,6 +103,8 @@ func WithDebugLogging(debug bool) Option {
 	}
 }
 
+// WithBalanceExemptions is which reconciliation errors to
+// skip.
 func WithBalanceExemptions(exemptions []*types.BalanceExemption) Option {
 	return func(r *Reconciler) {
 		r.exemptions = exemptions

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -455,20 +455,13 @@ func (r *Reconciler) handleBalanceMismatch(
 ) error {
 	// Check if the reconciliation was exempt (supports compound exemptions)
 	for _, exemption := range r.exemptions {
-		if exemption.Currency != nil {
-			if types.Hash(currency) != types.Hash(exemption.Currency) {
-				continue
-			}
+		if exemption.Currency != nil && types.Hash(currency) != types.Hash(exemption.Currency) {
+			continue
 		}
 
-		if exemption.SubAccountAddress != nil {
-			if account.SubAccount == nil {
-				continue
-			}
-
-			if *exemption.SubAccountAddress != account.SubAccount.Address {
-				continue
-			}
+		if exemption.SubAccountAddress != nil &&
+			(account.SubAccount == nil || *exemption.SubAccountAddress != account.SubAccount.Address) {
+			continue
 		}
 
 		// This should never error because we check for validity
@@ -494,7 +487,6 @@ func (r *Reconciler) handleBalanceMismatch(
 			if err != nil { // error only returned if we should exit on failure
 				return err
 			}
-
 		}
 	}
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -455,12 +455,20 @@ func (r *Reconciler) handleBalanceMismatch(
 ) error {
 	// Check if the reconciliation was exempt (supports compound exemptions)
 	for _, exemption := range r.exemptions {
-		if exemption.Currency != nil && types.Hash(currency) != types.Hash(exemption.Currency) {
-			continue
+		if exemption.Currency != nil {
+			if types.Hash(currency) != types.Hash(exemption.Currency) {
+				continue
+			}
 		}
 
-		if exemption.SubAccountAddress != nil && account.SubAccount != nil && *exemption.SubAccountAddress != account.SubAccount.Address {
-			continue
+		if exemption.SubAccountAddress != nil {
+			if account.SubAccount == nil {
+				continue
+			}
+
+			if *exemption.SubAccountAddress != account.SubAccount.Address {
+				continue
+			}
 		}
 
 		// This should never error because we check for validity

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -650,6 +650,8 @@ func mockReconcilerCalls(
 	liveBlock *types.BlockIdentifier,
 	success bool,
 	reconciliationType string,
+	exemption *types.BalanceExemption,
+	exemptionHit bool,
 ) {
 	if reconciliationType == ActiveReconciliation {
 		mockHelper.On("CurrentBlock", mock.Anything).Return(headBlock, nil).Once()
@@ -693,16 +695,30 @@ func mockReconcilerCalls(
 			headBlock,
 		).Return(nil).Once()
 	} else {
-		mockHandler.On(
-			"ReconciliationFailed",
-			mock.Anything,
-			reconciliationType,
-			accountCurrency.Account,
-			accountCurrency.Currency,
-			computedValue,
-			liveValue,
-			headBlock,
-		).Return(errors.New("reconciliation failed")).Once()
+		if !exemptionHit {
+			mockHandler.On(
+				"ReconciliationFailed",
+				mock.Anything,
+				reconciliationType,
+				accountCurrency.Account,
+				accountCurrency.Currency,
+				computedValue,
+				liveValue,
+				headBlock,
+			).Return(errors.New("reconciliation failed")).Once()
+		} else {
+			mockHandler.On(
+				"ReconciliationExempt",
+				mock.Anything,
+				reconciliationType,
+				accountCurrency.Account,
+				accountCurrency.Currency,
+				computedValue,
+				liveValue,
+				headBlock,
+				exemption,
+			).Return(errors.New("reconciliation failed")).Once()
+		}
 	}
 }
 
@@ -763,6 +779,8 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 				block,
 				true,
 				ActiveReconciliation,
+				nil,
+				false,
 			)
 
 			mockReconcilerCalls(
@@ -776,6 +794,8 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 				block,
 				true,
 				ActiveReconciliation,
+				nil,
+				false,
 			)
 
 			mockReconcilerCalls(
@@ -789,6 +809,8 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 				block2,
 				true,
 				ActiveReconciliation,
+				nil,
+				false,
 			)
 
 			go func() {
@@ -892,6 +914,8 @@ func TestReconcile_HighWaterMark(t *testing.T) {
 		block200,
 		true,
 		ActiveReconciliation,
+		nil,
+		false,
 	)
 	mockReconcilerCalls(
 		mockHelper,
@@ -904,6 +928,8 @@ func TestReconcile_HighWaterMark(t *testing.T) {
 		block200,
 		true,
 		ActiveReconciliation,
+		nil,
+		false,
 	)
 
 	go func() {
@@ -1044,6 +1070,164 @@ func TestReconcile_FailureOnlyActive(t *testing.T) {
 				block,
 				false,
 				ActiveReconciliation,
+				nil,
+				false,
+			)
+
+			go func() {
+				err := r.Reconcile(ctx)
+				assert.Contains(t, "reconciliation failed", err.Error())
+			}()
+
+			err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
+				{
+					Account:    accountCurrency.Account,
+					Currency:   accountCurrency.Currency,
+					Difference: "100",
+					Block:      block,
+				},
+			})
+			assert.NoError(t, err)
+
+			time.Sleep(1 * time.Second)
+
+			mockHelper.AssertExpectations(t)
+			mockHandler.AssertExpectations(t)
+		})
+	}
+}
+
+func TestReconcile_ExemptOnlyActive(t *testing.T) {
+	var (
+		block = &types.BlockIdentifier{
+			Hash:  "block 1",
+			Index: 1,
+		}
+		accountCurrency = &AccountCurrency{
+			Account: &types.AccountIdentifier{
+				Address: "addr 1",
+			},
+			Currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+		}
+		block2 = &types.BlockIdentifier{
+			Hash:  "block 2",
+			Index: 2,
+		}
+		exemption = &types.BalanceExemption{
+			ExemptionType: types.BalanceGreaterOrEqual,
+			Currency:      accountCurrency.Currency,
+		}
+	)
+
+	lookupBalanceByBlocks := []bool{true, false}
+	for _, lookup := range lookupBalanceByBlocks {
+		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
+			mockHelper := &mocks.Helper{}
+			mockHandler := &mocks.Handler{}
+			r := New(
+				mockHelper,
+				mockHandler,
+				WithActiveConcurrency(1),
+				WithInactiveConcurrency(0),
+				WithLookupBalanceByBlock(lookup),
+				WithBalanceExemptions([]*types.BalanceExemption{exemption}),
+			)
+			ctx := context.Background()
+
+			mockReconcilerCalls(
+				mockHelper,
+				mockHandler,
+				lookup,
+				accountCurrency,
+				"105",
+				"100",
+				block2,
+				block,
+				false,
+				ActiveReconciliation,
+				exemption,
+				true,
+			)
+
+			go func() {
+				err := r.Reconcile(ctx)
+				assert.Contains(t, "reconciliation failed", err.Error())
+			}()
+
+			err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
+				{
+					Account:    accountCurrency.Account,
+					Currency:   accountCurrency.Currency,
+					Difference: "100",
+					Block:      block,
+				},
+			})
+			assert.NoError(t, err)
+
+			time.Sleep(1 * time.Second)
+
+			mockHelper.AssertExpectations(t)
+			mockHandler.AssertExpectations(t)
+		})
+	}
+}
+
+func TestReconcile_NotExemptOnlyActive(t *testing.T) {
+	var (
+		block = &types.BlockIdentifier{
+			Hash:  "block 1",
+			Index: 1,
+		}
+		accountCurrency = &AccountCurrency{
+			Account: &types.AccountIdentifier{
+				Address: "addr 1",
+			},
+			Currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+		}
+		block2 = &types.BlockIdentifier{
+			Hash:  "block 2",
+			Index: 2,
+		}
+		exemption = &types.BalanceExemption{
+			ExemptionType: types.BalanceLessOrEqual,
+			Currency:      accountCurrency.Currency,
+		}
+	)
+
+	lookupBalanceByBlocks := []bool{true, false}
+	for _, lookup := range lookupBalanceByBlocks {
+		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
+			mockHelper := &mocks.Helper{}
+			mockHandler := &mocks.Handler{}
+			r := New(
+				mockHelper,
+				mockHandler,
+				WithActiveConcurrency(1),
+				WithInactiveConcurrency(0),
+				WithLookupBalanceByBlock(lookup),
+				WithBalanceExemptions([]*types.BalanceExemption{exemption}),
+			)
+			ctx := context.Background()
+
+			mockReconcilerCalls(
+				mockHelper,
+				mockHandler,
+				lookup,
+				accountCurrency,
+				"105",
+				"100",
+				block2,
+				block,
+				false,
+				ActiveReconciliation,
+				exemption,
+				false,
 			)
 
 			go func() {
@@ -1120,6 +1304,8 @@ func TestReconcile_SuccessOnlyInactive(t *testing.T) {
 				block,
 				true,
 				InactiveReconciliation,
+				nil,
+				false,
 			)
 
 			go func() {
@@ -1149,6 +1335,8 @@ func TestReconcile_SuccessOnlyInactive(t *testing.T) {
 				block2,
 				true,
 				InactiveReconciliation,
+				nil,
+				false,
 			)
 
 			go func() {
@@ -1213,6 +1401,8 @@ func TestReconcile_FailureOnlyInactive(t *testing.T) {
 				block,
 				false,
 				InactiveReconciliation,
+				nil,
+				false,
 			)
 
 			go func() {

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -1257,6 +1257,88 @@ func TestReconcile_ExemptAddressOnlyActive(t *testing.T) {
 	}
 }
 
+func TestReconcile_ExemptAddressDynamicActive(t *testing.T) {
+	var (
+		block = &types.BlockIdentifier{
+			Hash:  "block 1",
+			Index: 1,
+		}
+		accountCurrency = &AccountCurrency{
+			Account: &types.AccountIdentifier{
+				Address: "addr 1",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "addr",
+				},
+			},
+			Currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+		}
+		block2 = &types.BlockIdentifier{
+			Hash:  "block 2",
+			Index: 2,
+		}
+		subAccountAddress = "addr"
+		exemption         = &types.BalanceExemption{
+			ExemptionType:     types.BalanceDynamic,
+			SubAccountAddress: &subAccountAddress,
+		}
+	)
+
+	lookupBalanceByBlocks := []bool{true, false}
+	for _, lookup := range lookupBalanceByBlocks {
+		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
+			mockHelper := &mocks.Helper{}
+			mockHandler := &mocks.Handler{}
+			r := New(
+				mockHelper,
+				mockHandler,
+				WithActiveConcurrency(1),
+				WithInactiveConcurrency(0),
+				WithLookupBalanceByBlock(lookup),
+				WithBalanceExemptions([]*types.BalanceExemption{exemption}),
+			)
+			ctx := context.Background()
+
+			mockReconcilerCalls(
+				mockHelper,
+				mockHandler,
+				lookup,
+				accountCurrency,
+				"100",
+				"105",
+				block2,
+				block,
+				false,
+				ActiveReconciliation,
+				exemption,
+				true,
+			)
+
+			go func() {
+				err := r.Reconcile(ctx)
+				assert.Contains(t, "reconciliation failed", err.Error())
+			}()
+
+			err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
+				{
+					Account:    accountCurrency.Account,
+					Currency:   accountCurrency.Currency,
+					Difference: "100",
+					Block:      block,
+				},
+			})
+			assert.NoError(t, err)
+
+			time.Sleep(1 * time.Second)
+
+			mockHelper.AssertExpectations(t)
+			mockHandler.AssertExpectations(t)
+		})
+	}
+}
+
 func TestReconcile_NotExemptOnlyActive(t *testing.T) {
 	var (
 		block = &types.BlockIdentifier{

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -97,14 +97,26 @@ func TestNewReconciler(t *testing.T) {
 				return r
 			}(),
 		},
-		"with lookupBalanceByBlock": {
+		"with lookupBalanceByBlock and exemptions": {
 			options: []Option{
 				WithLookupBalanceByBlock(false),
+				WithBalanceExemptions([]*types.BalanceExemption{
+					{
+						ExemptionType: types.BalanceDynamic,
+						Currency:      accountCurrency.Currency,
+					},
+				}),
 			},
 			expected: func() *Reconciler {
 				r := New(nil, nil)
 				r.lookupBalanceByBlock = false
 				r.changeQueue = make(chan *parser.BalanceChange, backlogThreshold)
+				r.exemptions = []*types.BalanceExemption{
+					{
+						ExemptionType: types.BalanceDynamic,
+						Currency:      accountCurrency.Currency,
+					},
+				}
 
 				return r
 			}(),
@@ -121,6 +133,7 @@ func TestNewReconciler(t *testing.T) {
 			assert.Equal(t, test.expected.activeConcurrency, result.activeConcurrency)
 			assert.Equal(t, test.expected.lookupBalanceByBlock, result.lookupBalanceByBlock)
 			assert.Equal(t, cap(test.expected.changeQueue), cap(result.changeQueue))
+			assert.Equal(t, test.expected.exemptions, result.exemptions)
 		})
 	}
 }
@@ -450,7 +463,7 @@ func TestCompareBalance(t *testing.T) {
 			amount2.Value,
 			block2,
 		)
-		assert.Equal(t, "-100", difference)
+		assert.Equal(t, "100", difference)
 		assert.Equal(t, amount1.Value, cachedBalance)
 		assert.Equal(t, int64(2), headIndex)
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR adds support for handling `BalanceExemptions` (added in #178) in the `reconciler`. 

### Changes
- [x] Add new handler method for exemptions
- [x] Ensure `difference` is `live-computed`
- [x] test exemptions