### PR TITLE
[constructor] Remove required workflows

### DIFF
--- a/constructor/README.md
+++ b/constructor/README.md
@@ -65,10 +65,12 @@ other `Scenarios` in the same `Job`. You can find an example of this in the
 will be constructed, signed, and broadcast.*
 
 ### Using with rosetta-cli
-If you use the `constructor` for automated Construction API testing, you must implement 2
-required `Workflows`:
+If you use the `constructor` for automated Construction API testing (without prefunded
+accounts), you MUST implement 2 required `Workflows`:
 * `create_account`
 * `request_funds`
+
+_If you don't implement these 2 `Workflows`, processing could stall._
 
 Please note that `create_account` can contain a transaction broadcast if
 on-chain origination is required for new accounts on your blockchain.

--- a/constructor/coordinator/coordinator.go
+++ b/constructor/coordinator/coordinator.go
@@ -40,6 +40,10 @@ func New(
 	parser *parser.Parser,
 	inputWorkflows []*job.Workflow,
 ) (*Coordinator, error) {
+	if len(inputWorkflows) == 0 {
+		return nil, ErrNoWorkflows
+	}
+
 	workflowNames := make([]string, len(inputWorkflows))
 	workflows := []*job.Workflow{}
 	var createAccountWorkflow *job.Workflow
@@ -193,7 +197,7 @@ func (c *Coordinator) findJob(
 		return nil, ErrReturnFundsComplete
 	}
 
-	if c.returnFundsWorkflow != nil {
+	if c.requestFundsWorkflow != nil {
 		processing, err := c.storage.Processing(ctx, dbTx, string(job.RequestFunds))
 		if err != nil {
 			return nil, fmt.Errorf(

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -1224,8 +1224,8 @@ func TestInitialization_OnlyCreateAccountWorkflows(t *testing.T) {
 		p,
 		workflows,
 	)
-	assert.Nil(t, c)
-	assert.True(t, errors.Is(err, ErrRequestFundsWorkflowMissing))
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
 	helper.AssertExpectations(t)
 	handler.AssertExpectations(t)
 }
@@ -1283,8 +1283,8 @@ func TestInitialization_OnlyRequestFundsWorkflows(t *testing.T) {
 		workflows,
 	)
 
-	assert.Nil(t, c)
-	assert.True(t, errors.Is(err, ErrCreateAccountWorkflowMissing))
+	assert.NotNil(t, c)
+	assert.NoError(t, err)
 	helper.AssertExpectations(t)
 	handler.AssertExpectations(t)
 }

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -216,6 +216,8 @@ func TestProcess(t *testing.T) {
 		workflows,
 	)
 	assert.NotNil(t, c)
+	assert.NotNil(t, c.requestFundsWorkflow)
+	assert.NotNil(t, c.createAccountWorkflow)
 	assert.NoError(t, err)
 
 	// Create coordination channels
@@ -1199,7 +1201,7 @@ func TestInitialization_NoWorkflows(t *testing.T) {
 		workflows,
 	)
 	assert.Nil(t, c)
-	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNoWorkflows))
 
 	helper.AssertExpectations(t)
 	handler.AssertExpectations(t)

--- a/constructor/coordinator/errors.go
+++ b/constructor/coordinator/errors.go
@@ -58,4 +58,8 @@ var (
 	// a CreateAccount and/or RequestFunds workflow and we run out
 	// of available options (i.e. we can't do anything).
 	ErrStalled = errors.New("processing stalled")
+
+	// ErrNoWorkflows is returned when no workflows are provided
+	// during initialization.
+	ErrNoWorkflows = errors.New("no workflows")
 )

--- a/constructor/coordinator/errors.go
+++ b/constructor/coordinator/errors.go
@@ -54,7 +54,8 @@ var (
 	// is <= 0.
 	ErrInvalidConcurrency = errors.New("invalid concurrency")
 
-	// ErrNoRemainingJobs is returned when the caller does not define
-	// a RequestFunds workflow and we run out of funds.
-	ErrNoRemainingJobs = errors.New("no remaining jobs")
+	// ErrStalled is returned when the caller does not define
+	// a CreateAccount and/or RequestFunds workflow and we run out
+	// of available options (i.e. we can't do anything).
+	ErrStalled = errors.New("processing stalled")
 )

--- a/constructor/coordinator/errors.go
+++ b/constructor/coordinator/errors.go
@@ -37,14 +37,6 @@ var (
 	// ReturnsFundsWorkflow.
 	ErrReturnFundsComplete = errors.New("return funds complete")
 
-	// ErrCreateAccountWorkflowMissing is returned when we want
-	// to create an account but the create account workflow is missing.
-	ErrCreateAccountWorkflowMissing = errors.New("create account workflow missing")
-
-	// ErrRequestFundsWorkflowMissing is returned when we want
-	// to request funds but the request funds workflow is missing.
-	ErrRequestFundsWorkflowMissing = errors.New("request funds workflow missing")
-
 	// ErrJobMissing is returned when the coordinator is invoked with
 	// a broadcast complete call but the job that is affected does
 	// not exist.
@@ -61,4 +53,8 @@ var (
 	// ErrInvalidConcurrency is returned when the concurrency of a Workflow
 	// is <= 0.
 	ErrInvalidConcurrency = errors.New("invalid concurrency")
+
+	// ErrNoRemainingJobs is returned when the caller does not define
+	// a RequestFunds workflow and we run out of funds.
+	ErrNoRemainingJobs = errors.New("no remaining jobs")
 )


### PR DESCRIPTION
Relates: https://github.com/coinbase/rosetta-cli/issues/136

This PR relaxes the requirement that the caller must defined a `create_account` and `request_funds` workflow.

### Changes
- [x] Return an error when no workflows are provided
- [x] Add new error `ErrStalled` to return when we can no longer continue processing (when we otherwise would've created an account or requested funds)
- [x] Ensure existing tests passing
- [x] Add new test to exit when methods not defined