### PR TITLE
[constructor/dsl] Fix Variable Parsing

### DIFF
--- a/constructor/dsl/dsl_test.go
+++ b/constructor/dsl/dsl_test.go
@@ -68,6 +68,31 @@ func TestParse(t *testing.T) {
 									Input: `{{find_account.suggested_fee}}`,
 								},
 								{
+									Type:       job.SetVariable,
+									Input:      `"hello"`,
+									OutputPath: "varA",
+								},
+								{
+									Type:       job.SetVariable,
+									Input:      `10`,
+									OutputPath: "varB",
+								},
+								{
+									Type:       job.SetVariable,
+									Input:      `[{"type":"transfer"}]`,
+									OutputPath: "varC",
+								},
+								{
+									Type:       job.SetVariable,
+									Input:      `"10"`,
+									OutputPath: "varD",
+								},
+								{
+									Type:       job.SetVariable,
+									Input:      `{{find_account}}`,
+									OutputPath: "varE",
+								},
+								{
 									Type:       job.FindBalance,
 									Input:      `{"account_identifier": {{random_account.account_identifier}},"minimum_balance":{"value": "10000000000000000","currency": {{currency}}}}`, // nolint
 									OutputPath: "loaded_account",
@@ -262,7 +287,7 @@ func TestParse(t *testing.T) {
 		},
 		"action error: invalid math symbol": {
 			file:                "action_invalid_math.ros",
-			expectedErr:         ErrSyntax,
+			expectedErr:         ErrInvalidMathSymbol,
 			expectedErrLine:     8,
 			expectedErrContents: "math = 1 * 10;",
 		},

--- a/constructor/dsl/errors.go
+++ b/constructor/dsl/errors.go
@@ -43,6 +43,7 @@ var (
 	ErrInvalidActionType              = errors.New("invalid action type")
 	ErrCannotSetVariableWithoutOutput = errors.New("cannot set variable without output path")
 	ErrVariableUndefined              = errors.New("variable undefined")
+	ErrInvalidMathSymbol              = errors.New("invalid math symbol")
 )
 
 // Error contains a parsing error and context about

--- a/constructor/dsl/errors.go
+++ b/constructor/dsl/errors.go
@@ -48,9 +48,9 @@ var (
 // Error contains a parsing error and context about
 // where the error occurred in the file.
 type Error struct {
-	Line         int
-	LineContents string
-	Err          error
+	Line         int    `json:"line"`
+	LineContents string `json:"line_contents"`
+	Err          error  `json:"err"`
 }
 
 // Log prints the *Error to the console in red.

--- a/constructor/dsl/parser.go
+++ b/constructor/dsl/parser.go
@@ -37,6 +37,8 @@ const (
 	equal               = "="
 	add                 = "+"
 	subtract            = "-"
+	multiply            = "*"
+	divide              = "/"
 	openParens          = "("
 	closeParens         = ")"
 	endLine             = ";"
@@ -140,9 +142,15 @@ func parseActionType(line string) (job.ActionType, string, string, error) {
 	for symbol, mathOperation := range map[string]job.MathOperation{
 		add:      job.Addition,
 		subtract: job.Subtraction,
+		multiply: "",
+		divide:   "",
 	} {
 		tokens = strings.SplitN(remaining, symbol, split2)
 		if len(tokens) == split2 {
+			if len(mathOperation) == 0 {
+				return "", "", "", ErrInvalidMathSymbol
+			}
+
 			syntheticOutput := fmt.Sprintf(
 				`{"operation": "%s","left_value": %s,"right_value": %s};`,
 				mathOperation,
@@ -155,15 +163,11 @@ func parseActionType(line string) (job.ActionType, string, string, error) {
 	}
 
 	// Attempt to parse native SetVariable
-	if strings.HasPrefix(tokens[0], openBrakcet) {
-		if len(outputPath) > 0 {
-			return job.SetVariable, outputPath, tokens[0], nil
-		}
-
-		return "", "", "", ErrCannotSetVariableWithoutOutput
+	if len(outputPath) > 0 {
+		return job.SetVariable, outputPath, tokens[0], nil
 	}
 
-	return "", "", "", ErrSyntax
+	return "", "", "", ErrCannotSetVariableWithoutOutput
 }
 
 func (p *parser) parseAction(

--- a/constructor/dsl/testdata/simple.ros
+++ b/constructor/dsl/testdata/simple.ros
@@ -18,6 +18,11 @@ request_funds(1){
   // test comment
   request{
     print_message({{find_account.suggested_fee}}); // test variables that could be injected from other scenarios
+    varA = "hello";
+    varB = 10;
+    varC = [{"type":"transfer"}];
+    varD = "10";
+    varE = {{find_account}};
     loaded_account = find_balance({ // test comment 2 // blah
       "account_identifier": {{random_account.account_identifier}},
       "minimum_balance":{


### PR DESCRIPTION
This PR adds parsing support for any variable type, instead of just objects.

### Changes
- [x] Fix `set_variable` for non-object variables (ex: `"1"` or `[ops...]`)
- [x] Add JSON to `dsl.Error`