### PR TITLE
[asserter] Error if no historical balance lookup with exemptions

### DIFF
--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -286,6 +286,7 @@ var (
 	ErrBalanceExemptionSubAccountAddressEmpty = errors.New(
 		"BalanceExemption.SubAccountAddress is empty",
 	)
+	ErrBalanceExemptionNoHistoricalLookup = errors.New("BalanceExemptions only supported when HistoricalBalanceLookup supported")
 
 	NetworkErrs = []error{
 		ErrSubNetworkIdentifierInvalid,
@@ -309,6 +310,7 @@ var (
 		ErrBalanceExemptionTypeInvalid,
 		ErrBalanceExemptionMissingSubject,
 		ErrBalanceExemptionSubAccountAddressEmpty,
+		ErrBalanceExemptionNoHistoricalLookup,
 	}
 
 	///////////////////

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -286,7 +286,9 @@ var (
 	ErrBalanceExemptionSubAccountAddressEmpty = errors.New(
 		"BalanceExemption.SubAccountAddress is empty",
 	)
-	ErrBalanceExemptionNoHistoricalLookup = errors.New("BalanceExemptions only supported when HistoricalBalanceLookup supported")
+	ErrBalanceExemptionNoHistoricalLookup = errors.New(
+		"BalanceExemptions only supported when HistoricalBalanceLookup supported",
+	)
 
 	NetworkErrs = []error{
 		ErrSubNetworkIdentifierInvalid,

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -261,6 +261,10 @@ func Allow(allowed *types.Allow) error {
 		return err
 	}
 
+	if len(allowed.BalanceExemptions) > 0 && !allowed.HistoricalBalanceLookup {
+		return ErrBalanceExemptionNoHistoricalLookup
+	}
+
 	return nil
 }
 

--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -186,11 +186,21 @@ func TestAllow(t *testing.T) {
 		},
 		"valid Allow with call methods and exemptions": {
 			allow: &types.Allow{
+				OperationStatuses:       operationStatuses,
+				OperationTypes:          operationTypes,
+				CallMethods:             callMethods,
+				BalanceExemptions:       balanceExemptions,
+				HistoricalBalanceLookup: true,
+			},
+		},
+		"invalid Allow with exemptions and no historical": {
+			allow: &types.Allow{
 				OperationStatuses: operationStatuses,
 				OperationTypes:    operationTypes,
 				CallMethods:       callMethods,
 				BalanceExemptions: balanceExemptions,
 			},
+			err: ErrBalanceExemptionNoHistoricalLookup,
 		},
 		"nil Allow": {
 			allow: nil,


### PR DESCRIPTION
This PR ensures an error is returned by the `asserter` if a `types.BalanceExemption` is provided by an implementation but `HistoricalBalanceLookup` is not supported.