### PR TITLE
[fetcher] Only log asserter error if not context.Canceled

### DIFF
--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -15,6 +15,7 @@
 package fetcher
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -37,10 +38,13 @@ func (f *Fetcher) RequestFailedError(
 	err error,
 	message string,
 ) *Error {
-	// If there is a *types.Error assertion error, we log it instead
-	// of exiting. Exiting abruptly here may cause unintended consequences.
-	if assertionErr := f.Asserter.Error(rosettaErr); assertionErr != nil {
-		log.Printf("error %s assertion failed: %s", types.PrintStruct(rosettaErr), assertionErr)
+	// Only check for error correctness if err is not context.Canceled.
+	if !errors.Is(err, context.Canceled) {
+		// If there is a *types.Error assertion error, we log it instead
+		// of exiting. Exiting abruptly here may cause unintended consequences.
+		if assertionErr := f.Asserter.Error(rosettaErr); assertionErr != nil {
+			log.Printf("error %s assertion failed: %s", types.PrintStruct(rosettaErr), assertionErr)
+		}
 	}
 
 	return &Error{

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -39,7 +39,7 @@ func (f *Fetcher) RequestFailedError(
 ) *Error {
 	// If there is a *types.Error assertion error, we log it instead
 	// of exiting. Exiting abruptly here may cause unintended consequences.
-	if assertionErr := f.Asserter.Error(rosettaErr); err != nil {
+	if assertionErr := f.Asserter.Error(rosettaErr); assertionErr != nil {
 		log.Printf("error %s assertion failed: %s", types.PrintStruct(rosettaErr), assertionErr)
 	}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13023275/95247934-6473d380-07cb-11eb-8029-8dec04090f27.png)

When canceling the `fetcher` context, the error assertion check will print a ton of incorrect assertion failures. This PR skips assertion checking if `context.Canceled`.