### PR TITLE
[reconciler] Use buffered channel

### DIFF
--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -17,7 +17,6 @@ package reconciler
 import (
 	"fmt"
 
-	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
@@ -74,13 +73,6 @@ func WithSeenAccounts(seen []*AccountCurrency) Option {
 // and instantiates the correct changeQueue.
 func WithLookupBalanceByBlock(lookup bool) Option {
 	return func(r *Reconciler) {
-		// When lookupBalanceByBlock is disabled, we must check
-		// balance changes asynchronously. Using a buffered
-		// channel allows us to add balance changes without blocking.
-		if !lookup {
-			r.changeQueue = make(chan *parser.BalanceChange, backlogThreshold)
-		}
-
 		// We don't do anything if lookup == true because the default
 		// is already to create a non-buffered channel.
 		r.lookupBalanceByBlock = lookup

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -69,8 +69,7 @@ func WithSeenAccounts(seen []*AccountCurrency) Option {
 	}
 }
 
-// WithLookupBalanceByBlock sets lookupBlockByBalance
-// and instantiates the correct changeQueue.
+// WithLookupBalanceByBlock sets lookupBlockByBalance.
 func WithLookupBalanceByBlock(lookup bool) Option {
 	return func(r *Reconciler) {
 		// We don't do anything if lookup == true because the default

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -206,6 +206,10 @@ type Reconciler struct {
 	// exemptions allows for certain reconciliation failures
 	// to be skipped.
 	exemptions []*types.BalanceExemption
+
+	// LastIndexChecked is the last block index reconciled actively.
+	lastIndexMutex   sync.Mutex
+	lastIndexChecked int64
 }
 
 // New creates a new Reconciler.
@@ -215,19 +219,17 @@ func New(
 	options ...Option,
 ) *Reconciler {
 	r := &Reconciler{
-		helper:              helper,
-		handler:             handler,
-		inactiveFrequency:   defaultInactiveFrequency,
-		activeConcurrency:   defaultReconcilerConcurrency,
-		inactiveConcurrency: defaultReconcilerConcurrency,
-		highWaterMark:       -1,
-		seenAccounts:        map[string]struct{}{},
-		inactiveQueue:       []*InactiveEntry{},
-
-		// When lookupBalanceByBlock is enabled, we check
-		// balance changes synchronously.
+		helper:               helper,
+		handler:              handler,
+		inactiveFrequency:    defaultInactiveFrequency,
+		activeConcurrency:    defaultReconcilerConcurrency,
+		inactiveConcurrency:  defaultReconcilerConcurrency,
+		highWaterMark:        -1,
+		seenAccounts:         map[string]struct{}{},
+		inactiveQueue:        []*InactiveEntry{},
 		lookupBalanceByBlock: defaultLookupBalanceByBlock,
 		changeQueue:          make(chan *parser.BalanceChange, backlogThreshold),
+		lastIndexChecked:     -1,
 	}
 
 	for _, opt := range options {
@@ -310,6 +312,14 @@ func (r *Reconciler) QueueChanges(
 // reconciliation.
 func (r *Reconciler) QueueSize() int {
 	return len(r.changeQueue)
+}
+
+// LastIndexReconciled is the last block index
+// reconciled. This is used to ensure all the
+// enqueued accounts for a particular block have
+// been reconciled.
+func (r *Reconciler) LastIndexReconciled() int64 {
+	return r.lastIndexChecked
 }
 
 // CompareBalance checks to see if the computed balance of an account
@@ -677,6 +687,22 @@ func (r *Reconciler) reconcileActiveAccounts(
 			)
 			if err != nil {
 				return err
+			}
+
+			// Update the lastIndexChecked value if the block
+			// index is greater. We don't acquire the lock
+			// to make this check to improve performance.
+			if balanceChange.Block.Index > r.lastIndexChecked {
+				r.lastIndexMutex.Lock()
+
+				// In the time since making the check and acquiring
+				// the lock, the lastIndexChecked could've increased
+				// so we check it again.
+				if balanceChange.Block.Index > r.lastIndexChecked {
+					r.lastIndexChecked = balanceChange.Block.Index
+				}
+
+				r.lastIndexMutex.Unlock()
 			}
 		}
 	}

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -284,15 +284,10 @@ func (r *Reconciler) QueueChanges(
 			return err
 		}
 
-		if !r.lookupBalanceByBlock {
-			// All changes will have the same block. Continue
-			// if we are too far behind to start reconciling.
-			//
-			// Note: we don't return here so that we can ensure
-			// all seen accounts are added to the inactiveAccountQueue.
-			if block.Index < r.highWaterMark {
-				continue
-			}
+		// All changes will have the same block. Continue
+		// if we are too far behind to start reconciling.
+		if block.Index < r.highWaterMark {
+			continue
 		}
 
 		select {

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -305,6 +305,13 @@ func (r *Reconciler) QueueChanges(
 	return nil
 }
 
+// QueueSize is a helper that returns the total
+// number of items currently enqueued for active
+// reconciliation.
+func (r *Reconciler) QueueSize() int {
+	return len(r.changeQueue)
+}
+
 // CompareBalance checks to see if the computed balance of an account
 // is equal to the live balance of an account. This function ensures
 // balance is checked correctly in the case of orphaned blocks.

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -831,6 +831,8 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 				false,
 			)
 
+			assert.Equal(t, int64(-1), r.LastIndexReconciled())
+
 			go func() {
 				err := r.Reconcile(ctx)
 				assert.Contains(t, context.Canceled.Error(), err.Error())
@@ -856,6 +858,7 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 			time.Sleep(1 * time.Second)
 			cancel()
 
+			assert.Equal(t, block2.Index, r.LastIndexReconciled())
 			mockHelper.AssertExpectations(t)
 			mockHandler.AssertExpectations(t)
 		})

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -853,6 +853,8 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
+			assert.Equal(t, r.QueueSize(), 2)
+
 			time.Sleep(1 * time.Second)
 			cancel()
 


### PR DESCRIPTION
After some performance analysis, we discovered that one of the biggest syncing bottlenecks for `rosetta-cli` is waiting on the unbuffered reconciliation queue channel. This PR ensures the reconciliation queue is always buffered so we don't block.

If clearing the reconciliation queue is important for your application, make sure the value of `reconciler.QueueSize()` is below some value before exiting.

### Changes
- [x] Use buffered channel for queue
- [x] Add `QueueSize` method
- [x] Add `LastIndexReconciled` method