### PR TITLE
[client] Verbose Response Type Error

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -228,17 +227,20 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 	if len(b) == 0 {
 		return nil
 	}
+
 	if s, ok := v.(*string); ok {
 		*s = string(b)
 		return nil
 	}
+
 	if jsonCheck.MatchString(contentType) {
 		if err = json.Unmarshal(b, v); err != nil {
 			return err
 		}
 		return nil
 	}
-	return errors.New("undefined response type")
+
+	return fmt.Errorf("unsupported response type %s with body %s", contentType, string(b))
 }
 
 // Set request body from an interface{}

--- a/client/client.go
+++ b/client/client.go
@@ -240,7 +240,7 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		return nil
 	}
 
-	return fmt.Errorf("unsupported response type %s with body %s", contentType, string(b))
+	return fmt.Errorf("unsupported response content-type: %s body: %s", contentType, string(b))
 }
 
 // Set request body from an interface{}

--- a/templates/client/client.mustache
+++ b/templates/client/client.mustache
@@ -221,7 +221,7 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		return nil
 	}
 
-	return fmt.Errorf("unsupported response type %s with body %s", contentType, string(b))
+	return fmt.Errorf("unsupported response content-type: %s body: %s", contentType, string(b))
 }
 
 // Set request body from an interface{}

--- a/templates/client/client.mustache
+++ b/templates/client/client.mustache
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -209,17 +208,20 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 	if len(b) == 0 {
 		return nil
 	}
+
 	if s, ok := v.(*string); ok {
 		*s = string(b)
 		return nil
 	}
+
 	if jsonCheck.MatchString(contentType) {
 		if err = json.Unmarshal(b, v); err != nil {
 			return err
 		}
 		return nil
 	}
-	return errors.New("undefined response type")
+
+	return fmt.Errorf("unsupported response type %s with body %s", contentType, string(b))
 }
 
 // Set request body from an interface{}


### PR DESCRIPTION
The `client` package returns an extremely unhelpful error when a Rosetta API implementation returns a non-JSON response:
```text
Error: unable to fetch block 642926: request failed: /block {“index”:642926} undefined response type: unable to sync to 23786798: unable to sync to 23786798
```

This PR ensures the `client` prints a verbose error when the `response type` is not supported.