### PR TITLE
[statefulsyncer/storage] Support dynamic pruning depth

### DIFF
--- a/statefulsyncer/stateful_syncer.go
+++ b/statefulsyncer/stateful_syncer.go
@@ -72,7 +72,7 @@ type Logger interface {
 // pruneable index is often a function of the state
 // of some number of structs.
 type PruneHelper interface {
-	//PruneableIndex is the largest block
+	// PruneableIndex is the largest block
 	// index that is considered safe to prune.
 	PruneableIndex(ctx context.Context, headIndex int64) (int64, error)
 }

--- a/statefulsyncer/stateful_syncer.go
+++ b/statefulsyncer/stateful_syncer.go
@@ -177,14 +177,11 @@ func (s *StatefulSyncer) Prune(ctx context.Context, helper PruneHelper) error {
 		}
 
 		firstPruned, lastPruned, err := s.blockStorage.Prune(ctx, pruneableIndex)
-		if errors.Is(err, storage.ErrNothingToPrune) {
-			time.Sleep(pruneSleepTime)
-			continue
-		}
 		if err != nil {
 			return err
 		}
 
+		// firstPruned and lastPruned are -1 if there is nothing to prune
 		if firstPruned != -1 && lastPruned != -1 {
 			pruneMessage := fmt.Sprintf("pruned blocks %d-%d", firstPruned, lastPruned)
 			if firstPruned == lastPruned {

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -198,8 +198,10 @@ func (b *BlockStorage) pruneBlock(
 		return -1, fmt.Errorf("%w: cannot get head block identifier", err)
 	}
 
+	// Ensure we are only pruning blocks that could not be
+	// accessed later in a reorg.
 	if oldestIndex > head.Index-syncer.PastBlockSize*2 {
-		return -1, ErrPruningDepthInsufficient
+		return -1, ErrNothingToPrune
 	}
 
 	blockResponse, err := b.getBlockResponse(

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -571,12 +571,12 @@ func TestBlock(t *testing.T) {
 		firstPruned, lastPruned, err := storage.Prune(ctx, 2)
 		assert.Equal(t, int64(-1), firstPruned)
 		assert.Equal(t, int64(-1), lastPruned)
-		assert.Contains(t, err.Error(), ErrNothingToPrune.Error())
+		assert.NoError(t, err)
 
 		firstPruned, lastPruned, err = storage.Prune(ctx, 100)
 		assert.Equal(t, int64(-1), firstPruned)
 		assert.Equal(t, int64(-1), lastPruned)
-		assert.Contains(t, err.Error(), ErrNothingToPrune.Error())
+		assert.NoError(t, err)
 
 		// Attempt to sync sufficient blocks so we can test pruning
 		for i := gapBlock.BlockIdentifier.Index + 1; i < 200; i++ {

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -571,12 +571,12 @@ func TestBlock(t *testing.T) {
 		firstPruned, lastPruned, err := storage.Prune(ctx, 2)
 		assert.Equal(t, int64(-1), firstPruned)
 		assert.Equal(t, int64(-1), lastPruned)
-		assert.Contains(t, err.Error(), ErrPruningDepthInsufficient.Error())
+		assert.Contains(t, err.Error(), ErrNothingToPrune.Error())
 
 		firstPruned, lastPruned, err = storage.Prune(ctx, 100)
 		assert.Equal(t, int64(-1), firstPruned)
 		assert.Equal(t, int64(-1), lastPruned)
-		assert.Contains(t, err.Error(), ErrPruningDepthInsufficient.Error())
+		assert.Contains(t, err.Error(), ErrNothingToPrune.Error())
 
 		// Attempt to sync sufficient blocks so we can test pruning
 		for i := gapBlock.BlockIdentifier.Index + 1; i < 200; i++ {

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -375,7 +375,6 @@ var (
 	ErrCannotAccessPrunedData         = errors.New("cannot access pruned data")
 	ErrNothingToPrune                 = errors.New("nothing to prune")
 	ErrPruningFailed                  = errors.New("pruning failed")
-	ErrPruningDepthInsufficient       = errors.New("pruning depth insufficient")
 	ErrCannotPruneTransaction         = errors.New("cannot prune transaction")
 
 	BlockStorageErrs = []error{
@@ -411,7 +410,6 @@ var (
 		ErrCannotAccessPrunedData,
 		ErrNothingToPrune,
 		ErrPruningFailed,
-		ErrPruningDepthInsufficient,
 		ErrCannotPruneTransaction,
 	}
 )


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/pull/187

To avoid accessing pruned blocks, we need to set the pruneable index to be less than the last reconciled index.

### Changes
- [x] Add `PruneHelper`
- [x] Remove `ErrPruningDepthInsufficient`