### PR TITLE
[storage] Add Performance Mode Config

### DIFF
--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -161,13 +161,13 @@ func PerformanceBadgerOptions(dir string) badger.Options {
 	opts.Compression = DefaultCompressionMode
 
 	// Load tables into memory and memory map value logs.
-	opts.TableLoadingMode = options.LoadToRAM
+	opts.TableLoadingMode = options.MemoryMap
 	opts.ValueLogLoadingMode = options.MemoryMap
 
 	// This option will have a significant effect the memory. If the level is kept
 	// in-memory, read are faster but the tables will be kept in memory. By default,
 	// this is set to false.
-	opts.KeepL0InMemory = true
+	opts.KeepL0InMemory = false
 
 	// We don't compact L0 on close as this can greatly delay shutdown time.
 	opts.CompactL0OnClose = false

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -160,9 +160,9 @@ func PerformanceBadgerOptions(dir string) badger.Options {
 	// significantly increase memory usage.
 	opts.Compression = DefaultCompressionMode
 
-	// Don't load tables into memory.
+	// Load tables into memory and memory map value logs.
 	opts.TableLoadingMode = options.LoadToRAM
-	opts.ValueLogLoadingMode = options.LoadToRAM
+	opts.ValueLogLoadingMode = options.MemoryMap
 
 	// This option will have a significant effect the memory. If the level is kept
 	// in-memory, read are faster but the tables will be kept in memory. By default,

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -150,6 +150,36 @@ func DefaultBadgerOptions(dir string) badger.Options {
 	return opts
 }
 
+// PerformanceBadgerOptions are performance geared
+// BadgerDB options that use much more RAM than the
+// default settings.
+func PerformanceBadgerOptions(dir string) badger.Options {
+	opts := badger.DefaultOptions(dir)
+
+	// By default, we do not compress the table at all. Doing so can
+	// significantly increase memory usage.
+	opts.Compression = DefaultCompressionMode
+
+	// Don't load tables into memory.
+	opts.TableLoadingMode = options.LoadToRAM
+	opts.ValueLogLoadingMode = options.LoadToRAM
+
+	// This option will have a significant effect the memory. If the level is kept
+	// in-memory, read are faster but the tables will be kept in memory. By default,
+	// this is set to false.
+	opts.KeepL0InMemory = true
+
+	// We don't compact L0 on close as this can greatly delay shutdown time.
+	opts.CompactL0OnClose = false
+
+	// LoadBloomsOnOpen=false will improve the db startup speed. This is also
+	// a waste to enable with a limited index cache size (as many of the loaded bloom
+	// filters will be immediately discarded from the cache).
+	opts.LoadBloomsOnOpen = false
+
+	return opts
+}
+
 // NewBadgerStorage creates a new BadgerStorage.
 func NewBadgerStorage(
 	ctx context.Context,


### PR DESCRIPTION
This PR adds a new "performance" storage mode that uses settings closer to the Badger defaults. This is used in the new "performance" mode on the `rosetta-cli` to improve syncing speed for users with more available RAM.