### PR TITLE
[storage] Only update last reconciled if index >

### DIFF
--- a/mocks/reconciler/helper.go
+++ b/mocks/reconciler/helper.go
@@ -15,8 +15,8 @@ type Helper struct {
 	mock.Mock
 }
 
-// BlockExists provides a mock function with given fields: ctx, block
-func (_m *Helper) BlockExists(ctx context.Context, block *types.BlockIdentifier) (bool, error) {
+// CanonicalBlock provides a mock function with given fields: ctx, block
+func (_m *Helper) CanonicalBlock(ctx context.Context, block *types.BlockIdentifier) (bool, error) {
 	ret := _m.Called(ctx, block)
 
 	var r0 bool

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -88,7 +88,7 @@ const (
 // what sort of storage layer they want to use to provide the required
 // information.
 type Helper interface {
-	BlockExists(
+	CanonicalBlock(
 		ctx context.Context,
 		block *types.BlockIdentifier,
 	) (bool, error)
@@ -353,7 +353,7 @@ func (r *Reconciler) CompareBalance(
 	}
 
 	// Check if live block is in store (ensure not reorged)
-	exists, err := r.helper.BlockExists(ctx, liveBlock)
+	canonical, err := r.helper.CanonicalBlock(ctx, liveBlock)
 	if err != nil {
 		return zeroString, "", 0, fmt.Errorf(
 			"%w: %v: on live block %+v",
@@ -362,7 +362,7 @@ func (r *Reconciler) CompareBalance(
 			liveBlock,
 		)
 	}
-	if !exists {
+	if !canonical {
 		return zeroString, "", head.Index, fmt.Errorf(
 			"%w %+v",
 			ErrBlockGone,
@@ -435,8 +435,8 @@ func (r *Reconciler) bestLiveBalance(
 	// If there is a reorg, there is a chance that balance
 	// lookup can fail if we try to query an orphaned block.
 	// If this is the case, we continue reconciling.
-	exists, existsErr := r.helper.BlockExists(ctx, block)
-	if existsErr != nil || !exists {
+	canonical, canonicalErr := r.helper.CanonicalBlock(ctx, block)
+	if canonicalErr != nil || !canonical {
 		return nil, nil, ErrBlockGone
 	}
 

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -346,7 +346,7 @@ func TestCompareBalance(t *testing.T) {
 	})
 
 	mh.On("CurrentBlock", ctx).Return(block2, nil).Once()
-	mh.On("BlockExists", ctx, block1).Return(false, nil).Once()
+	mh.On("CanonicalBlock", ctx, block1).Return(false, nil).Once()
 	t.Run("Live block is not in store", func(t *testing.T) {
 		difference, cachedBalance, headIndex, err := reconciler.CompareBalance(
 			ctx,
@@ -362,7 +362,7 @@ func TestCompareBalance(t *testing.T) {
 	})
 
 	mh.On("CurrentBlock", ctx).Return(block2, nil).Once()
-	mh.On("BlockExists", ctx, block0).Return(true, nil).Once()
+	mh.On("CanonicalBlock", ctx, block0).Return(true, nil).Once()
 	mh.On(
 		"ComputedBalance",
 		ctx,
@@ -389,7 +389,7 @@ func TestCompareBalance(t *testing.T) {
 	})
 
 	mh.On("CurrentBlock", ctx).Return(block2, nil).Once()
-	mh.On("BlockExists", ctx, block1).Return(true, nil).Once()
+	mh.On("CanonicalBlock", ctx, block1).Return(true, nil).Once()
 	mh.On(
 		"ComputedBalance",
 		ctx,
@@ -416,7 +416,7 @@ func TestCompareBalance(t *testing.T) {
 	})
 
 	mh.On("CurrentBlock", ctx).Return(block2, nil).Once()
-	mh.On("BlockExists", ctx, block2).Return(true, nil).Once()
+	mh.On("CanonicalBlock", ctx, block2).Return(true, nil).Once()
 	mh.On(
 		"ComputedBalance",
 		ctx,
@@ -443,7 +443,7 @@ func TestCompareBalance(t *testing.T) {
 	})
 
 	mh.On("CurrentBlock", ctx).Return(block2, nil).Once()
-	mh.On("BlockExists", ctx, block2).Return(true, nil).Once()
+	mh.On("CanonicalBlock", ctx, block2).Return(true, nil).Once()
 	mh.On(
 		"ComputedBalance",
 		ctx,
@@ -470,7 +470,7 @@ func TestCompareBalance(t *testing.T) {
 	})
 
 	mh.On("CurrentBlock", ctx).Return(block2, nil).Once()
-	mh.On("BlockExists", ctx, block2).Return(true, nil).Once()
+	mh.On("CanonicalBlock", ctx, block2).Return(true, nil).Once()
 	mh.On(
 		"ComputedBalance",
 		ctx,
@@ -673,7 +673,7 @@ func mockReconcilerCalls(
 		headBlock,
 		nil,
 	).Once()
-	mockHelper.On("BlockExists", mock.Anything, headBlock).Return(true, nil).Once()
+	mockHelper.On("CanonicalBlock", mock.Anything, headBlock).Return(true, nil).Once()
 	mockHelper.On(
 		"ComputedBalance",
 		mock.Anything,
@@ -1025,7 +1025,7 @@ func TestReconcile_Orphan(t *testing.T) {
 		nil,
 		errors.New("cannot find block"),
 	).Once()
-	mockHelper.On("BlockExists", mock.Anything, block).Return(false, nil).Once()
+	mockHelper.On("CanonicalBlock", mock.Anything, block).Return(false, nil).Once()
 
 	go func() {
 		err := r.Reconcile(ctx)

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -208,6 +208,13 @@ func (b *BalanceStorage) Reconciled(
 		return fmt.Errorf("%w: unable to decode balance entry", err)
 	}
 
+	// Don't update last reconciled if the most recent reconciliation was
+	// lower than the last reconciliation. This can occur when inactive
+	// reconciliation gets ahead of the active reconciliation backlog.
+	if bal.LastReconciled != nil && bal.LastReconciled.Index > block.Index {
+		return nil
+	}
+
 	bal.LastReconciled = block
 
 	serialBal, err := b.db.Encoder().Encode(namespace, bal)

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -845,6 +845,20 @@ func TestBalanceReconciliation(t *testing.T) {
 		assert.Equal(t, 0.5, coverage)
 	})
 
+	t.Run("update reconciliation to old block", func(t *testing.T) {
+		err := storage.Reconciled(ctx, account, currency, genesisBlock)
+		assert.NoError(t, err)
+
+		coverage, err := storage.ReconciliationCoverage(ctx, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.5, coverage)
+
+		// We should skip update so this stays 0.5
+		coverage, err = storage.ReconciliationCoverage(ctx, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.5, coverage)
+	})
+
 	t.Run("add unreconciled", func(t *testing.T) {
 		txn := storage.db.NewDatabaseTransaction(ctx, true)
 		err = storage.UpdateBalance(

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -405,6 +405,29 @@ func (b *BlockStorage) GetBlockLazy(
 	return b.getBlockResponse(ctx, blockIdentifier, transaction)
 }
 
+// CanonicalBlock returns a boolean indicating if
+// a block with the provided *types.PartialBlockIdentifier
+// is in the canonical chain (regardless if it has
+// been pruned).
+func (b *BlockStorage) CanonicalBlock(
+	ctx context.Context,
+	blockIdentifier *types.PartialBlockIdentifier,
+) (bool, error) {
+	block, err := b.GetBlockLazy(ctx, blockIdentifier)
+	if errors.Is(err, ErrCannotAccessPrunedData) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if block == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 // GetBlockTransactional gets a block in the context of a database
 // transaction.
 func (b *BlockStorage) GetBlockTransactional(

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -406,14 +406,17 @@ func (b *BlockStorage) GetBlockLazy(
 }
 
 // CanonicalBlock returns a boolean indicating if
-// a block with the provided *types.PartialBlockIdentifier
+// a block with the provided *types.BlockIdentifier
 // is in the canonical chain (regardless if it has
 // been pruned).
 func (b *BlockStorage) CanonicalBlock(
 	ctx context.Context,
-	blockIdentifier *types.PartialBlockIdentifier,
+	blockIdentifier *types.BlockIdentifier,
 ) (bool, error) {
-	block, err := b.GetBlockLazy(ctx, blockIdentifier)
+	block, err := b.GetBlockLazy(
+		ctx,
+		types.ConstructPartialBlockIdentifier(blockIdentifier),
+	)
 	if errors.Is(err, ErrCannotAccessPrunedData) {
 		return true, nil
 	}

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -417,6 +417,9 @@ func (b *BlockStorage) CanonicalBlock(
 	if errors.Is(err, ErrCannotAccessPrunedData) {
 		return true, nil
 	}
+	if errors.Is(err, ErrBlockNotFound) {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -391,6 +391,10 @@ func TestBlock(t *testing.T) {
 			errors.Is(err, ErrBlockNotFound),
 		)
 		assert.Nil(t, block)
+
+		canonical, err := storage.CanonicalBlock(ctx, identifier)
+		assert.False(t, canonical)
+		assert.NoError(t, err)
 	})
 
 	t.Run("Get non-existent block index", func(t *testing.T) {

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -602,6 +602,13 @@ func TestBlock(t *testing.T) {
 			head, err := storage.GetHeadBlockIdentifier(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, blockIdentifier, head)
+
+			canonical, err := storage.CanonicalBlock(
+				ctx,
+				&types.PartialBlockIdentifier{Index: &blockIdentifier.Index},
+			)
+			assert.True(t, canonical)
+			assert.NoError(t, err)
 		}
 
 		firstPruned, lastPruned, err = storage.Prune(ctx, 100)
@@ -619,6 +626,13 @@ func TestBlock(t *testing.T) {
 		)
 		assert.True(t, errors.Is(err, ErrCannotAccessPrunedData))
 		assert.Nil(t, block)
+
+		canonical, err := storage.CanonicalBlock(
+			ctx,
+			types.ConstructPartialBlockIdentifier(newBlock.BlockIdentifier),
+		)
+		assert.True(t, canonical)
+		assert.NoError(t, err)
 
 		blockTransaction, err := storage.GetBlockTransaction(
 			ctx,

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -392,7 +392,7 @@ func TestBlock(t *testing.T) {
 		)
 		assert.Nil(t, block)
 
-		canonical, err := storage.CanonicalBlock(ctx, identifier)
+		canonical, err := storage.CanonicalBlock(ctx, badBlockIdentifier)
 		assert.False(t, canonical)
 		assert.NoError(t, err)
 	})
@@ -467,6 +467,10 @@ func TestBlock(t *testing.T) {
 
 	t.Run("Remove block and re-set block of same hash", func(t *testing.T) {
 		err := storage.RemoveBlock(ctx, newBlock2.BlockIdentifier)
+		assert.NoError(t, err)
+
+		canonical, err := storage.CanonicalBlock(ctx, newBlock2.BlockIdentifier)
+		assert.False(t, canonical)
 		assert.NoError(t, err)
 
 		oldestIndex, err := storage.GetOldestBlockIndex(ctx)
@@ -609,7 +613,7 @@ func TestBlock(t *testing.T) {
 
 			canonical, err := storage.CanonicalBlock(
 				ctx,
-				&types.PartialBlockIdentifier{Index: &blockIdentifier.Index},
+				block.BlockIdentifier,
 			)
 			assert.True(t, canonical)
 			assert.NoError(t, err)
@@ -633,7 +637,7 @@ func TestBlock(t *testing.T) {
 
 		canonical, err := storage.CanonicalBlock(
 			ctx,
-			types.ConstructPartialBlockIdentifier(newBlock.BlockIdentifier),
+			newBlock.BlockIdentifier,
 		)
 		assert.True(t, canonical)
 		assert.NoError(t, err)


### PR DESCRIPTION
Related: #187 

As a result of using buffered channels in the reconciler, we need to protect against "out of date" updates to the `last_reconciled` information in storage.

### Changes
- [x] Only update last reconciled if index >
- [x] Add block exists method to block_storage (enables block pruning before reconciliation)
- [x] Change `BlockExists` to `CanonicalBlock` in `reconciler`