### PR TITLE
[reconciler] Re-enqueue accounts when context canceled

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -239,6 +239,21 @@ func New(
 	return r
 }
 
+func (r *Reconciler) wrappedActiveEnqueue(
+	change *parser.BalanceChange,
+) {
+	select {
+	case r.changeQueue <- change:
+	default:
+		if r.debugLogging {
+			log.Printf(
+				"skipping active enqueue because backlog has %d items",
+				backlogThreshold,
+			)
+		}
+	}
+}
+
 // QueueChanges enqueues a slice of *BalanceChanges
 // for reconciliation.
 func (r *Reconciler) QueueChanges(
@@ -274,6 +289,12 @@ func (r *Reconciler) QueueChanges(
 		})
 	}
 
+	// All changes will have the same block. Continue
+	// if we are too far behind to start reconciling.
+	if block.Index < r.highWaterMark {
+		return nil
+	}
+
 	for _, change := range balanceChanges {
 		// Add all seen accounts to inactive reconciler queue.
 		//
@@ -286,22 +307,7 @@ func (r *Reconciler) QueueChanges(
 			return err
 		}
 
-		// All changes will have the same block. Continue
-		// if we are too far behind to start reconciling.
-		if block.Index < r.highWaterMark {
-			continue
-		}
-
-		select {
-		case r.changeQueue <- change:
-		default:
-			if r.debugLogging {
-				log.Printf(
-					"skipping active enqueue because backlog has %d items",
-					backlogThreshold,
-				)
-			}
-		}
+		r.wrappedActiveEnqueue(change)
 	}
 
 	return nil
@@ -620,6 +626,15 @@ func (r *Reconciler) accountReconciliation(
 	return nil
 }
 
+func (r *Reconciler) wrappedInactiveEnqueue(
+	accountCurrency *AccountCurrency,
+	liveBlock *types.BlockIdentifier,
+) {
+	if err := r.inactiveAccountQueue(true, accountCurrency, liveBlock); err != nil {
+		log.Printf("%s: unable to queue account %s", err.Error(), types.PrintStruct(accountCurrency))
+	}
+}
+
 func (r *Reconciler) inactiveAccountQueue(
 	inactive bool,
 	accountCurrency *AccountCurrency,
@@ -672,8 +687,13 @@ func (r *Reconciler) reconcileActiveAccounts(
 			if errors.Is(err, ErrBlockGone) {
 				continue
 			}
-
 			if err != nil {
+				// Ensure we don't leak reconciliations if
+				// context is canceled.
+				if errors.Is(err, context.Canceled) {
+					r.wrappedActiveEnqueue(balanceChange)
+				}
+
 				return fmt.Errorf("%w: %v", ErrLiveBalanceLookupFailed, err)
 			}
 
@@ -686,6 +706,12 @@ func (r *Reconciler) reconcileActiveAccounts(
 				false,
 			)
 			if err != nil {
+				// Ensure we don't leak reconciliations if
+				// context is canceled.
+				if errors.Is(err, context.Canceled) {
+					r.wrappedActiveEnqueue(balanceChange)
+				}
+
 				return err
 			}
 
@@ -795,9 +821,11 @@ func (r *Reconciler) reconcileInactiveAccounts(
 					true,
 				)
 				if err != nil {
+					r.wrappedInactiveEnqueue(nextAcct.Entry, block)
 					return err
 				}
 			case !errors.Is(err, ErrBlockGone):
+				r.wrappedInactiveEnqueue(nextAcct.Entry, block)
 				return fmt.Errorf("%w: %v", ErrLiveBalanceLookupFailed, err)
 			}
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -457,7 +457,7 @@ func (r *Reconciler) bestLiveBalance(
 	// lookup can fail if we try to query an orphaned block.
 	// If this is the case, we continue reconciling.
 	canonical, canonicalErr := r.helper.CanonicalBlock(ctx, lookupBlock)
-	if err != nil {
+	if canonicalErr != nil {
 		return nil, nil, fmt.Errorf(
 			"%w: unable to check canonical block %s",
 			canonicalErr,

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -631,7 +631,11 @@ func (r *Reconciler) wrappedInactiveEnqueue(
 	liveBlock *types.BlockIdentifier,
 ) {
 	if err := r.inactiveAccountQueue(true, accountCurrency, liveBlock); err != nil {
-		log.Printf("%s: unable to queue account %s", err.Error(), types.PrintStruct(accountCurrency))
+		log.Printf(
+			"%s: unable to queue account %s",
+			err.Error(),
+			types.PrintStruct(accountCurrency),
+		)
 	}
 }
 

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -1029,7 +1029,7 @@ func TestReconcile_Orphan(t *testing.T) {
 
 	go func() {
 		err := r.Reconcile(ctx)
-		assert.Contains(t, context.Canceled.Error(), err.Error())
+		assert.True(t, errors.Is(err, context.Canceled))
 	}()
 
 	err := r.QueueChanges(ctx, block, []*parser.BalanceChange{

--- a/storage/counter_storage.go
+++ b/storage/counter_storage.go
@@ -62,6 +62,10 @@ const (
 	// failures that were exempt.
 	ExemptReconciliationCounter = "exempt_reconciliations"
 
+	// FailedReconciliationCounter is the number of reconciliation
+	// failures that were not exempt.
+	FailedReconciliationCounter = "failed_reconciliations"
+
 	// counterNamespace is preprended to any counter.
 	counterNamespace = "counter"
 )


### PR DESCRIPTION
This PR ensures that accounts being reconciled when context is canceled are re-added to their respective reconciliation queue instead of being dropped (this can lead to a < 100% coverage with certain `rosetta-cli` end conditions).

### Changes
- [x] Create constant for inactive reconciliations
- [x] re-enqueue balance changes if context canceled
- [x] add tests