### PR TITLE
[Chore] Update to rosetta-specifications@v1.4.6

### DIFF
--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -116,7 +116,7 @@ type Configuration struct {
 	AllowedOperationTypes      []string                 `json:"allowed_operation_types"`
 	AllowedOperationStatuses   []*types.OperationStatus `json:"allowed_operation_statuses"`
 	AllowedErrors              []*types.Error           `json:"allowed_errors"`
-	AllowedTimestampStartIndex int64                    `json:"allowed_timestamp_start_index,omitempty"`
+	AllowedTimestampStartIndex int64                    `json:"allowed_timestamp_start_index"`
 }
 
 // NewClientWithFile constructs a new Asserter using a specification
@@ -179,7 +179,11 @@ func NewClientWithOptions(
 	parsedTimestampStartIndex := genesisBlockIdentifier.Index + 1
 	if timestampStartIndex != nil {
 		if *timestampStartIndex < 0 {
-			return nil, ErrTimestampStartIndexInvalid
+			return nil, fmt.Errorf(
+				"%w: %d",
+				ErrTimestampStartIndexInvalid,
+				*timestampStartIndex,
+			)
 		}
 
 		parsedTimestampStartIndex = *timestampStartIndex

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -27,11 +27,12 @@ import (
 // validation on Rosetta Server responses.
 type Asserter struct {
 	// These variables are used for response assertion.
-	network            *types.NetworkIdentifier
-	operationTypes     []string
-	operationStatusMap map[string]bool
-	errorTypeMap       map[int32]*types.Error
-	genesisBlock       *types.BlockIdentifier
+	network             *types.NetworkIdentifier
+	operationTypes      []string
+	operationStatusMap  map[string]bool
+	errorTypeMap        map[int32]*types.Error
+	genesisBlock        *types.BlockIdentifier
+	timestampStartIndex *int64
 
 	// These variables are used for request assertion.
 	historicalBalanceLookup bool
@@ -102,6 +103,7 @@ func NewClientWithResponses(
 		networkOptions.Allow.OperationTypes,
 		networkOptions.Allow.OperationStatuses,
 		networkOptions.Allow.Errors,
+		networkOptions.Allow.TimestampStartIndex,
 	)
 }
 
@@ -109,11 +111,12 @@ func NewClientWithResponses(
 // configuration can be exported by the Asserter and used to instantiate an
 // Asserter.
 type Configuration struct {
-	NetworkIdentifier        *types.NetworkIdentifier `json:"network_identifier"`
-	GenesisBlockIdentifier   *types.BlockIdentifier   `json:"genesis_block_identifier"`
-	AllowedOperationTypes    []string                 `json:"allowed_operation_types"`
-	AllowedOperationStatuses []*types.OperationStatus `json:"allowed_operation_statuses"`
-	AllowedErrors            []*types.Error           `json:"allowed_errors"`
+	NetworkIdentifier          *types.NetworkIdentifier `json:"network_identifier"`
+	GenesisBlockIdentifier     *types.BlockIdentifier   `json:"genesis_block_identifier"`
+	AllowedOperationTypes      []string                 `json:"allowed_operation_types"`
+	AllowedOperationStatuses   []*types.OperationStatus `json:"allowed_operation_statuses"`
+	AllowedErrors              []*types.Error           `json:"allowed_errors"`
+	AllowedTimestampStartIndex *int64                   `json:"allowed_timestamp_start_index,omitempty"`
 }
 
 // NewClientWithFile constructs a new Asserter using a specification
@@ -140,6 +143,7 @@ func NewClientWithFile(
 		config.AllowedOperationTypes,
 		config.AllowedOperationStatuses,
 		config.AllowedErrors,
+		config.AllowedTimestampStartIndex,
 	)
 }
 
@@ -152,6 +156,7 @@ func NewClientWithOptions(
 	operationTypes []string,
 	operationStatuses []*types.OperationStatus,
 	errors []*types.Error,
+	timestampStartIndex *int64,
 ) (*Asserter, error) {
 	if err := NetworkIdentifier(network); err != nil {
 		return nil, err
@@ -169,10 +174,15 @@ func NewClientWithOptions(
 		return nil, err
 	}
 
+	if timestampStartIndex != nil && *timestampStartIndex < 0 {
+		return nil, ErrTimestampStartIndexInvalid
+	}
+
 	asserter := &Asserter{
-		network:        network,
-		operationTypes: operationTypes,
-		genesisBlock:   genesisBlockIdentifier,
+		network:             network,
+		operationTypes:      operationTypes,
+		genesisBlock:        genesisBlockIdentifier,
+		timestampStartIndex: timestampStartIndex,
 	}
 
 	asserter.operationStatusMap = map[string]bool{}
@@ -209,11 +219,12 @@ func (a *Asserter) ClientConfiguration() (*Configuration, error) {
 	}
 
 	return &Configuration{
-		NetworkIdentifier:        a.network,
-		GenesisBlockIdentifier:   a.genesisBlock,
-		AllowedOperationTypes:    a.operationTypes,
-		AllowedOperationStatuses: operationStatuses,
-		AllowedErrors:            errors,
+		NetworkIdentifier:          a.network,
+		GenesisBlockIdentifier:     a.genesisBlock,
+		AllowedOperationTypes:      a.operationTypes,
+		AllowedOperationStatuses:   operationStatuses,
+		AllowedErrors:              errors,
+		AllowedTimestampStartIndex: a.timestampStartIndex,
 	}, nil
 }
 

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -313,7 +313,11 @@ func TestNew(t *testing.T) {
 			)
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, configuration.AllowedErrors)
 			if test.networkOptions.Allow.TimestampStartIndex != nil {
-				assert.Equal(t, *test.networkOptions.Allow.TimestampStartIndex, configuration.AllowedTimestampStartIndex)
+				assert.Equal(
+					t,
+					*test.networkOptions.Allow.TimestampStartIndex,
+					configuration.AllowedTimestampStartIndex,
+				)
 			} else {
 				assert.Equal(t, test.networkStatus.GenesisBlockIdentifier.Index+1, configuration.AllowedTimestampStartIndex)
 			}
@@ -329,10 +333,8 @@ func TestNew(t *testing.T) {
 			}
 			if test.networkOptions.Allow.TimestampStartIndex != nil {
 				fileConfig.AllowedTimestampStartIndex = *test.networkOptions.Allow.TimestampStartIndex
-			} else {
-				if fileConfig.GenesisBlockIdentifier != nil {
-					fileConfig.AllowedTimestampStartIndex = fileConfig.GenesisBlockIdentifier.Index + 1
-				}
+			} else if fileConfig.GenesisBlockIdentifier != nil {
+				fileConfig.AllowedTimestampStartIndex = fileConfig.GenesisBlockIdentifier.Index + 1
 			}
 
 			tmpfile, err := ioutil.TempFile("", "test.json")
@@ -378,7 +380,11 @@ func TestNew(t *testing.T) {
 			)
 			assert.ElementsMatch(t, test.networkOptions.Allow.Errors, configuration.AllowedErrors)
 			if test.networkOptions.Allow.TimestampStartIndex != nil {
-				assert.Equal(t, *test.networkOptions.Allow.TimestampStartIndex, configuration.AllowedTimestampStartIndex)
+				assert.Equal(
+					t,
+					*test.networkOptions.Allow.TimestampStartIndex,
+					configuration.AllowedTimestampStartIndex,
+				)
 			} else {
 				assert.Equal(t, test.networkStatus.GenesisBlockIdentifier.Index+1, configuration.AllowedTimestampStartIndex)
 			}

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -381,7 +381,7 @@ func (a *Asserter) Block(
 		return err
 	}
 
-	// Only apply some assertions if the block index is not the
+	// Only apply duplicate hash and index checks if the block index is not the
 	// genesis index.
 	if a.genesisBlock.Index != block.BlockIdentifier.Index {
 		if block.BlockIdentifier.Hash == block.ParentBlockIdentifier.Hash {
@@ -391,7 +391,12 @@ func (a *Asserter) Block(
 		if block.BlockIdentifier.Index <= block.ParentBlockIdentifier.Index {
 			return ErrBlockIndexPrecedesParentBlockIndex
 		}
+	}
 
+	// Only check for timestamp validity if timestamp start index is nil
+	// or if timestamp start index is <+ the current block index.
+	if a.timestampStartIndex == nil ||
+		*a.timestampStartIndex <= block.BlockIdentifier.Index {
 		if err := Timestamp(block.Timestamp); err != nil {
 			return err
 		}

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -393,10 +393,9 @@ func (a *Asserter) Block(
 		}
 	}
 
-	// Only check for timestamp validity if timestamp start index is nil
-	// or if timestamp start index is <+ the current block index.
-	if a.timestampStartIndex == nil ||
-		*a.timestampStartIndex <= block.BlockIdentifier.Index {
+	// Only check for timestamp validity if timestamp start index is <=
+	// the current block index.
+	if a.timestampStartIndex <= block.BlockIdentifier.Index {
 		if err := Timestamp(block.Timestamp); err != nil {
 			return err
 		}

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -487,6 +487,10 @@ func TestOperation(t *testing.T) {
 }
 
 func TestBlock(t *testing.T) {
+	genesisIdentifier := &types.BlockIdentifier{
+		Hash:  "gen",
+		Index: 0,
+	}
 	validBlockIdentifier := &types.BlockIdentifier{
 		Hash:  "blah",
 		Index: 100,
@@ -654,6 +658,7 @@ func TestBlock(t *testing.T) {
 			},
 		},
 	}
+	timestampStartIndex := int64(1)
 	var tests = map[string]struct {
 		block        *types.Block
 		genesisIndex int64
@@ -670,11 +675,11 @@ func TestBlock(t *testing.T) {
 		},
 		"genesis block": {
 			block: &types.Block{
-				BlockIdentifier:       validBlockIdentifier,
-				ParentBlockIdentifier: validBlockIdentifier,
+				BlockIdentifier:       genesisIdentifier,
+				ParentBlockIdentifier: genesisIdentifier,
 				Transactions:          []*types.Transaction{validTransaction},
 			},
-			genesisIndex: validBlockIdentifier.Index,
+			genesisIndex: genesisIdentifier.Index,
 			err:          nil,
 		},
 		"out of order transaction operations": {
@@ -840,6 +845,7 @@ func TestBlock(t *testing.T) {
 						OperationTypes: []string{
 							"PAYMENT",
 						},
+						TimestampStartIndex: &timestampStartIndex,
 					},
 				},
 			)

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -486,6 +486,10 @@ func TestOperation(t *testing.T) {
 	}
 }
 
+func int64Pointer(a int64) *int64 {
+	return &a
+}
+
 func TestBlock(t *testing.T) {
 	genesisIdentifier := &types.BlockIdentifier{
 		Hash:  "gen",
@@ -658,10 +662,10 @@ func TestBlock(t *testing.T) {
 			},
 		},
 	}
-	timestampStartIndex := int64(1)
 	var tests = map[string]struct {
 		block        *types.Block
 		genesisIndex int64
+		startIndex   *int64
 		err          error
 	}{
 		"valid block": {
@@ -673,14 +677,43 @@ func TestBlock(t *testing.T) {
 			},
 			err: nil,
 		},
-		"genesis block": {
+		"valid block (before start index)": {
+			block: &types.Block{
+				BlockIdentifier:       validBlockIdentifier,
+				ParentBlockIdentifier: validParentBlockIdentifier,
+				Transactions:          []*types.Transaction{validTransaction},
+			},
+			startIndex: int64Pointer(validBlockIdentifier.Index + 1),
+			err:        nil,
+		},
+		"genesis block (without start index)": {
+			block: &types.Block{
+				BlockIdentifier:       validBlockIdentifier,
+				ParentBlockIdentifier: validBlockIdentifier,
+				Transactions:          []*types.Transaction{validTransaction},
+			},
+			genesisIndex: validBlockIdentifier.Index,
+			err:          nil,
+		},
+		"genesis block (with start index)": {
 			block: &types.Block{
 				BlockIdentifier:       genesisIdentifier,
 				ParentBlockIdentifier: genesisIdentifier,
 				Transactions:          []*types.Transaction{validTransaction},
 			},
 			genesisIndex: genesisIdentifier.Index,
+			startIndex:   int64Pointer(genesisIdentifier.Index + 1),
 			err:          nil,
+		},
+		"invalid genesis block (with start index)": {
+			block: &types.Block{
+				BlockIdentifier:       genesisIdentifier,
+				ParentBlockIdentifier: genesisIdentifier,
+				Transactions:          []*types.Transaction{validTransaction},
+			},
+			genesisIndex: genesisIdentifier.Index,
+			startIndex:   int64Pointer(genesisIdentifier.Index),
+			err:          ErrTimestampBeforeMin,
 		},
 		"out of order transaction operations": {
 			block: &types.Block{
@@ -845,7 +878,7 @@ func TestBlock(t *testing.T) {
 						OperationTypes: []string{
 							"PAYMENT",
 						},
-						TimestampStartIndex: &timestampStartIndex,
+						TimestampStartIndex: test.startIndex,
 					},
 				},
 			)

--- a/asserter/error_test.go
+++ b/asserter/error_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestErrorMap(t *testing.T) {
+	emptyString := ""
 	var tests = map[string]struct {
 		err         *types.Error
 		expectedErr error
@@ -37,6 +38,18 @@ func TestErrorMap(t *testing.T) {
 					"hello": "goodbye",
 				},
 			},
+		},
+		"empty description": {
+			err: &types.Error{
+				Code:        10,
+				Message:     "error 10",
+				Description: &emptyString,
+				Retriable:   true,
+				Details: map[string]interface{}{
+					"hello": "goodbye",
+				},
+			},
+			expectedErr: ErrErrorDescriptionEmpty,
 		},
 		"negative error": {
 			err: &types.Error{

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -289,6 +289,9 @@ var (
 	ErrBalanceExemptionNoHistoricalLookup = errors.New(
 		"BalanceExemptions only supported when HistoricalBalanceLookup supported",
 	)
+	ErrTimestampStartIndexInvalid = errors.New(
+		"TimestampStartIndex is invalid",
+	)
 
 	NetworkErrs = []error{
 		ErrSubNetworkIdentifierInvalid,
@@ -313,6 +316,7 @@ var (
 		ErrBalanceExemptionMissingSubject,
 		ErrBalanceExemptionSubAccountAddressEmpty,
 		ErrBalanceExemptionNoHistoricalLookup,
+		ErrTimestampStartIndexInvalid,
 	}
 
 	///////////////////

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -412,6 +412,9 @@ var (
 		"Error.Message does not match message from /network/options",
 	)
 	ErrErrorRetriableMismatch = errors.New("Error.Retriable mismatch")
+	ErrErrorDescriptionEmpty  = errors.New(
+		"Error.Description is provided but is empty",
+	)
 
 	ErrorErrs = []error{
 		ErrErrorIsNil,
@@ -420,6 +423,7 @@ var (
 		ErrErrorUnexpectedCode,
 		ErrErrorMessageMismatch,
 		ErrErrorRetriableMismatch,
+		ErrErrorDescriptionEmpty,
 	}
 )
 

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -269,6 +269,10 @@ func Allow(allowed *types.Allow) error {
 		return ErrBalanceExemptionNoHistoricalLookup
 	}
 
+	if allowed.TimestampStartIndex != nil && *allowed.TimestampStartIndex < 0 {
+		return ErrTimestampStartIndexInvalid
+	}
+
 	return nil
 }
 

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -270,7 +270,11 @@ func Allow(allowed *types.Allow) error {
 	}
 
 	if allowed.TimestampStartIndex != nil && *allowed.TimestampStartIndex < 0 {
-		return ErrTimestampStartIndexInvalid
+		return fmt.Errorf(
+			"%w: %d",
+			ErrTimestampStartIndexInvalid,
+			*allowed.TimestampStartIndex,
+		)
 	}
 
 	return nil

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -150,8 +150,12 @@ func Error(err *types.Error) error {
 		return ErrErrorCodeIsNeg
 	}
 
-	if err.Message == "" {
+	if len(err.Message) == 0 {
 		return ErrErrorMessageMissing
+	}
+
+	if err.Description != nil && len(*err.Description) == 0 {
+		return ErrErrorDescriptionEmpty
 	}
 
 	return nil

--- a/asserter/network_test.go
+++ b/asserter/network_test.go
@@ -172,6 +172,9 @@ func TestAllow(t *testing.T) {
 				},
 			},
 		}
+
+		negativeIndex = int64(-1)
+		positiveIndex = int64(100)
 	)
 
 	var tests = map[string]struct {
@@ -191,6 +194,7 @@ func TestAllow(t *testing.T) {
 				CallMethods:             callMethods,
 				BalanceExemptions:       balanceExemptions,
 				HistoricalBalanceLookup: true,
+				TimestampStartIndex:     &positiveIndex,
 			},
 		},
 		"invalid Allow with exemptions and no historical": {
@@ -201,6 +205,14 @@ func TestAllow(t *testing.T) {
 				BalanceExemptions: balanceExemptions,
 			},
 			err: ErrBalanceExemptionNoHistoricalLookup,
+		},
+		"invalid timestamp start index": {
+			allow: &types.Allow{
+				OperationStatuses:   operationStatuses,
+				OperationTypes:      operationTypes,
+				TimestampStartIndex: &negativeIndex,
+			},
+			err: ErrTimestampStartIndexInvalid,
 		},
 		"nil Allow": {
 			allow: nil,

--- a/client/client.go
+++ b/client/client.go
@@ -35,7 +35,7 @@ var (
 	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
 )
 
-// APIClient manages communication with the Rosetta API v1.4.5
+// APIClient manages communication with the Rosetta API v1.4.6
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,8 +53,8 @@ done
 rm -rf tmp;
 
 # Download spec file from releases
-ROSETTA_SPEC_VERSION=v1.4.5
-curl -L https://github.com/coinbase/rosetta-specifications/releases/download/${ROSETTA_SPEC_VERSION}/api.json -o api.json;
+ROSETTA_SPEC_VERSION=1.4.6
+curl -L https://github.com/coinbase/rosetta-specifications/releases/download/v${ROSETTA_SPEC_VERSION}/api.json -o api.json;
 
 # Generate client + types code
 GENERATOR_VERSION=v4.3.0
@@ -165,6 +165,11 @@ done
 
 # Change model files to correct package
 sed "${SED_IFLAG[@]}" 's/package client/package types/g' types/*;
+
+# Add version file
+VERSION_CONTENTS=$(sed "s/VERSION/${ROSETTA_SPEC_VERSION}/g" < templates/types.txt);
+echo "${VERSION_CONTENTS}" >> "types/types.go";
+
 
 # Inject Custom Marshaling Logic
 # shellcheck disable=SC2013

--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -61,6 +61,7 @@ func simpleAsserterConfiguration() (*asserter.Asserter, error) {
 			},
 		},
 		[]*types.Error{},
+		nil,
 	)
 }
 

--- a/fetcher/block_test.go
+++ b/fetcher/block_test.go
@@ -238,6 +238,7 @@ func TestBlockRetry(t *testing.T) {
 				basicNetworkOptions.Allow.OperationTypes,
 				basicNetworkOptions.Allow.OperationStatuses,
 				nil,
+				nil,
 			)
 			assert.NoError(err)
 

--- a/parser/balance_changes_test.go
+++ b/parser/balance_changes_test.go
@@ -322,5 +322,6 @@ func simpleAsserterConfiguration(
 		[]string{"Transfer"},
 		allowedStatus,
 		[]*types.Error{},
+		nil,
 	)
 }

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -931,6 +931,7 @@ func (h *MockBalanceStorageHelper) Asserter() *asserter.Asserter {
 			},
 		},
 		[]*types.Error{},
+		nil,
 	)
 	return a
 }

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -416,6 +416,7 @@ func TestCoinStorage(t *testing.T) {
 			},
 		},
 		[]*types.Error{},
+		nil,
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, a)

--- a/templates/types.txt
+++ b/templates/types.txt
@@ -1,0 +1,8 @@
+package types
+
+const (
+  // RosettaAPIVersion is the version of the Rosetta API
+  // specification used to generate code for this release
+  // of the SDK.
+  RosettaAPIVersion = "VERSION"
+)

--- a/types/allow.go
+++ b/types/allow.go
@@ -33,6 +33,11 @@ type Allow struct {
 	// Any Rosetta implementation that supports querying the balance of an account at any height in
 	// the past should set this to true.
 	HistoricalBalanceLookup bool `json:"historical_balance_lookup"`
+	// If populated, `timestamp_start_index` indicates the first block index where block timestamps
+	// are considered valid (i.e. all blocks less than `timestamp_start_index` could have invalid
+	// timestamps). This is useful when the genesis block (or blocks) of a network have timestamp 0.
+	// If not populated, block timestamps are assumed to be valid for all available blocks.
+	TimestampStartIndex *int64 `json:"timestamp_start_index,omitempty"`
 	// All methods that are supported by the /call endpoint. Communicating which parameters should
 	// be provided to /call is the responsibility of the implementer (this is en lieu of defining an
 	// entire type system and requiring the implementer to define that in Allow).

--- a/types/error.go
+++ b/types/error.go
@@ -28,6 +28,15 @@ type Error struct {
 	// particular, this means that any contextual information should be included in the details
 	// field.
 	Message string `json:"message"`
+	// Description allows the implementer to optionally provide additional information about an
+	// error. In many cases, the content of this field will be a copy-and-paste from existing
+	// developer documentation. Description can ONLY be populated with generic information about a
+	// particular type of error. It MUST NOT be populated with information about a particular
+	// instantiation of an error (use `details` for this). Whereas the content of Error.Message
+	// should stay stable across releases, the content of Error.Description will likely change
+	// across releases (as implementers improve error documentation). For this reason, the content
+	// in this field is not part of any type assertion (unlike Error.Message).
+	Description *string `json:"description,omitempty"`
 	// An error is retriable if the same request may succeed if submitted again.
 	Retriable bool `json:"retriable"`
 	// Often times it is useful to return context specific to the request that caused the error

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	// RosettaAPIVersion is the version of the Rosetta API
+	// specification used to generate code for this release
+	// of the SDK.
+	RosettaAPIVersion = "1.4.6"
+)


### PR DESCRIPTION
This PR updates `rosetta-sdk-go` to use [`rosetta-specifications@v1.4.6`](https://github.com/coinbase/rosetta-specifications/releases/tag/v1.4.6).

### Changes
- [x] Create a constant for the current version (`RosettaAPIVersion`)
- [x] Respect `timestamp_start_index`
  - [x] Provides backwards compatibility for implementations that relied on `rosetta-cli` non-enforcement of genesis index timestamp
- [x] Ensure non-nil `Error.Description` has length > 0