### PR TITLE
[storage] Automated Computed Balance Updates

### DIFF
--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -69,7 +69,7 @@ func defaultParser(t *testing.T) *parser.Parser {
 	asserter, err := simpleAsserterConfiguration()
 	assert.NoError(t, err)
 
-	return parser.New(asserter, nil)
+	return parser.New(asserter, nil, nil)
 }
 
 func TestProcess(t *testing.T) {

--- a/parser/balance_changes_test.go
+++ b/parser/balance_changes_test.go
@@ -264,6 +264,7 @@ func TestBalanceChanges(t *testing.T) {
 			parser := New(
 				asserter,
 				test.exemptFunc,
+				nil,
 			)
 
 			changes, err := parser.BalanceChanges(

--- a/parser/exemptions.go
+++ b/parser/exemptions.go
@@ -1,12 +1,14 @@
 package parser
 
 import (
+	"math/big"
+
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-// FindExemptions returns all matching *types.BalanceExemption
+// findExemptions returns all matching *types.BalanceExemption
 // for a particular *types.AccountIdentifier and *types.Currency.
-func (p *Parser) FindExemptions(
+func (p *Parser) findExemptions(
 	account *types.AccountIdentifier,
 	currency *types.Currency,
 ) []*types.BalanceExemption {
@@ -25,4 +27,36 @@ func (p *Parser) FindExemptions(
 	}
 
 	return matches
+}
+
+// MatchBalanceExemption returns a *types.BalanceExemption
+// associated with the *types.AccountIdentifier, *types.Currency,
+// and difference, if it exists.
+func (p *Parser) MatchBalanceExemption(
+	account *types.AccountIdentifier,
+	currency *types.Currency,
+	difference string, // live - computed
+) *types.BalanceExemption {
+	exemptions := p.findExemptions(account, currency)
+	if len(exemptions) == 0 {
+		return nil
+	}
+
+	// This should never error because we check for validity
+	// before calling this method.
+	bigDifference, ok := new(big.Int).SetString(difference, 10)
+	if !ok {
+		return nil
+	}
+
+	// Check if the reconciliation was exempt (supports compound exemptions)
+	for _, exemption := range exemptions {
+		if exemption.ExemptionType == types.BalanceDynamic ||
+			(exemption.ExemptionType == types.BalanceGreaterOrEqual && bigDifference.Sign() >= 0) ||
+			(exemption.ExemptionType == types.BalanceLessOrEqual && bigDifference.Sign() <= 0) {
+			return exemption
+		}
+	}
+
+	return nil
 }

--- a/parser/exemptions.go
+++ b/parser/exemptions.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package parser
 
 import (

--- a/parser/exemptions.go
+++ b/parser/exemptions.go
@@ -1,0 +1,28 @@
+package parser
+
+import (
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+// FindExemptions returns all matching *types.BalanceExemption
+// for a particular *types.AccountIdentifier and *types.Currency.
+func (p *Parser) FindExemptions(
+	account *types.AccountIdentifier,
+	currency *types.Currency,
+) []*types.BalanceExemption {
+	matches := []*types.BalanceExemption{}
+	for _, exemption := range p.BalanceExemptions {
+		if exemption.Currency != nil && types.Hash(currency) != types.Hash(exemption.Currency) {
+			continue
+		}
+
+		if exemption.SubAccountAddress != nil &&
+			(account.SubAccount == nil || *exemption.SubAccountAddress != account.SubAccount.Address) {
+			continue
+		}
+
+		matches = append(matches, exemption)
+	}
+
+	return matches
+}

--- a/parser/exemptions.go
+++ b/parser/exemptions.go
@@ -6,9 +6,9 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
-// findExemptions returns all matching *types.BalanceExemption
+// FindExemptions returns all matching *types.BalanceExemption
 // for a particular *types.AccountIdentifier and *types.Currency.
-func (p *Parser) findExemptions(
+func (p *Parser) FindExemptions(
 	account *types.AccountIdentifier,
 	currency *types.Currency,
 ) []*types.BalanceExemption {
@@ -31,26 +31,18 @@ func (p *Parser) findExemptions(
 
 // MatchBalanceExemption returns a *types.BalanceExemption
 // associated with the *types.AccountIdentifier, *types.Currency,
-// and difference, if it exists.
-func (p *Parser) MatchBalanceExemption(
-	account *types.AccountIdentifier,
-	currency *types.Currency,
+// and difference, if it exists. The provided exemptions
+// should be produced using FindExemptions.
+func MatchBalanceExemption(
+	matchedExemptions []*types.BalanceExemption,
 	difference string, // live - computed
 ) *types.BalanceExemption {
-	exemptions := p.findExemptions(account, currency)
-	if len(exemptions) == 0 {
-		return nil
-	}
-
-	// This should never error because we check for validity
-	// before calling this method.
 	bigDifference, ok := new(big.Int).SetString(difference, 10)
 	if !ok {
 		return nil
 	}
 
-	// Check if the reconciliation was exempt (supports compound exemptions)
-	for _, exemption := range exemptions {
+	for _, exemption := range matchedExemptions {
 		if exemption.ExemptionType == types.BalanceDynamic ||
 			(exemption.ExemptionType == types.BalanceGreaterOrEqual && bigDifference.Sign() >= 0) ||
 			(exemption.ExemptionType == types.BalanceLessOrEqual && bigDifference.Sign() <= 0) {

--- a/parser/exemptions_test.go
+++ b/parser/exemptions_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package parser
 
 import (

--- a/parser/exemptions_test.go
+++ b/parser/exemptions_test.go
@@ -182,7 +182,7 @@ func TestFindExemptions(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			parser := New(nil, nil, test.balanceExemptions)
-			assert.Equal(t, test.expected, parser.findExemptions(test.account, test.currency))
+			assert.Equal(t, test.expected, parser.FindExemptions(test.account, test.currency))
 		})
 	}
 }
@@ -443,7 +443,8 @@ func TestMatchBalanceExemption(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			parser := New(nil, nil, test.balanceExemptions)
-			assert.Equal(t, test.expected, parser.MatchBalanceExemption(test.account, test.currency, test.difference))
+			exemptions := parser.FindExemptions(test.account, test.currency)
+			assert.Equal(t, test.expected, MatchBalanceExemption(exemptions, test.difference))
 		})
 	}
 }

--- a/parser/exemptions_test.go
+++ b/parser/exemptions_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func stringPointer(s string) *string {
+	return &s
+}
+
 func TestFindExemptions(t *testing.T) {
 	tests := map[string]struct {
 		balanceExemptions []*types.BalanceExemption
@@ -24,6 +28,154 @@ func TestFindExemptions(t *testing.T) {
 				Decimals: 8,
 			},
 			expected: []*types.BalanceExemption{},
+		},
+		"no matching exemption": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 7,
+					},
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			expected: []*types.BalanceExemption{},
+		},
+		"no matching exemptions": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 7,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "blah",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			expected: []*types.BalanceExemption{},
+		},
+		"currency match": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "blah",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			expected: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+			},
+		},
+		"subaccount match": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 7,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "hello",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			expected: []*types.BalanceExemption{
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+		},
+		"multiple match": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "hello",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			expected: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
 		},
 	}
 

--- a/parser/exemptions_test.go
+++ b/parser/exemptions_test.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/coinbase/rosetta-sdk-go/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindExemptions(t *testing.T) {
+	tests := map[string]struct {
+		balanceExemptions []*types.BalanceExemption
+		account           *types.AccountIdentifier
+		currency          *types.Currency
+		expected          []*types.BalanceExemption
+	}{
+		"no exemptions": {
+			account: &types.AccountIdentifier{
+				Address: "test",
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			expected: []*types.BalanceExemption{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			parser := New(nil, nil, test.balanceExemptions)
+			assert.Equal(t, test.expected, parser.FindExemptions(test.account, test.currency))
+		})
+	}
+}

--- a/parser/exemptions_test.go
+++ b/parser/exemptions_test.go
@@ -182,7 +182,268 @@ func TestFindExemptions(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			parser := New(nil, nil, test.balanceExemptions)
-			assert.Equal(t, test.expected, parser.FindExemptions(test.account, test.currency))
+			assert.Equal(t, test.expected, parser.findExemptions(test.account, test.currency))
+		})
+	}
+}
+
+func TestMatchBalanceExemption(t *testing.T) {
+	tests := map[string]struct {
+		balanceExemptions []*types.BalanceExemption
+		account           *types.AccountIdentifier
+		currency          *types.Currency
+		difference        string
+		expected          *types.BalanceExemption
+	}{
+		"no exemptions": {
+			account: &types.AccountIdentifier{
+				Address: "test",
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "100",
+		},
+		"no matching exemption": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 7,
+					},
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "100",
+		},
+		"no matching exemptions": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 7,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "blah",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "100",
+		},
+		"currency match": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "blah",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "100",
+			expected: &types.BalanceExemption{
+				ExemptionType: types.BalanceDynamic,
+				Currency: &types.Currency{
+					Symbol:   "BTC",
+					Decimals: 8,
+				},
+			},
+		},
+		"currency match, wrong sign": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceLessOrEqual,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "blah",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "100",
+		},
+		"currency match, right sign": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceGreaterOrEqual,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "blah",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "100",
+			expected: &types.BalanceExemption{
+				ExemptionType: types.BalanceGreaterOrEqual,
+				Currency: &types.Currency{
+					Symbol:   "BTC",
+					Decimals: 8,
+				},
+			},
+		},
+		"currency match, zero": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceGreaterOrEqual,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "blah",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "0",
+			expected: &types.BalanceExemption{
+				ExemptionType: types.BalanceGreaterOrEqual,
+				Currency: &types.Currency{
+					Symbol:   "BTC",
+					Decimals: 8,
+				},
+			},
+		},
+		"subaccount match": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 7,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "hello",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "100",
+			expected: &types.BalanceExemption{
+				ExemptionType:     types.BalanceDynamic,
+				SubAccountAddress: stringPointer("hello"),
+			},
+		},
+		"multiple match": {
+			balanceExemptions: []*types.BalanceExemption{
+				{
+					ExemptionType: types.BalanceDynamic,
+					Currency: &types.Currency{
+						Symbol:   "BTC",
+						Decimals: 8,
+					},
+				},
+				{
+					ExemptionType:     types.BalanceDynamic,
+					SubAccountAddress: stringPointer("hello"),
+				},
+			},
+			account: &types.AccountIdentifier{
+				Address: "test",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "hello",
+				},
+			},
+			currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+			difference: "100",
+			expected: &types.BalanceExemption{
+				ExemptionType: types.BalanceDynamic,
+				Currency: &types.Currency{
+					Symbol:   "BTC",
+					Decimals: 8,
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			parser := New(nil, nil, test.balanceExemptions)
+			assert.Equal(t, test.expected, parser.MatchBalanceExemption(test.account, test.currency, test.difference))
 		})
 	}
 }

--- a/parser/intent_test.go
+++ b/parser/intent_test.go
@@ -543,7 +543,7 @@ func TestExpectedOperations(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, asserter)
 
-		parser := New(asserter, nil)
+		parser := New(asserter, nil, nil)
 
 		t.Run(name, func(t *testing.T) {
 			err := parser.ExpectedOperations(

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -16,18 +16,25 @@ package parser
 
 import (
 	"github.com/coinbase/rosetta-sdk-go/asserter"
+	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
 // Parser provides support for parsing Rosetta blocks.
 type Parser struct {
-	Asserter   *asserter.Asserter
-	ExemptFunc ExemptOperation
+	Asserter          *asserter.Asserter
+	ExemptFunc        ExemptOperation
+	BalanceExemptions []*types.BalanceExemption
 }
 
 // New creates a new Parser.
-func New(asserter *asserter.Asserter, exemptFunc ExemptOperation) *Parser {
+func New(
+	asserter *asserter.Asserter,
+	exemptFunc ExemptOperation,
+	balanceExemptions []*types.BalanceExemption,
+) *Parser {
 	return &Parser{
-		Asserter:   asserter,
-		ExemptFunc: exemptFunc,
+		Asserter:          asserter,
+		ExemptFunc:        exemptFunc,
+		BalanceExemptions: balanceExemptions,
 	}
 }

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -93,11 +93,3 @@ func WithDebugLogging(debug bool) Option {
 		r.debugLogging = debug
 	}
 }
-
-// WithBalanceExemptions is which reconciliation errors to
-// skip.
-func WithBalanceExemptions(exemptions []*types.BalanceExemption) Option {
-	return func(r *Reconciler) {
-		r.exemptions = exemptions
-	}
-}

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -488,9 +488,8 @@ func (r *Reconciler) handleBalanceMismatch(
 	block *types.BlockIdentifier,
 ) error {
 	// Check if the reconciliation was exempt (supports compound exemptions)
-	exemption := r.parser.MatchBalanceExemption(
-		account,
-		currency,
+	exemption := parser.MatchBalanceExemption(
+		r.parser.FindExemptions(account, currency),
 		difference,
 	)
 	if exemption != nil {

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -322,7 +322,10 @@ func (b *BalanceStorage) existingValue(
 	// with any balance exemption.
 	difference, err := types.SubtractValues(amount.Value, existingValue)
 	if err != nil {
-		return "", fmt.Errorf("%w: unable to calculate difference between live and computed balances", err)
+		return "", fmt.Errorf(
+			"%w: unable to calculate difference between live and computed balances",
+			err,
+		)
 	}
 
 	exemption := parser.MatchBalanceExemption(

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -64,6 +64,7 @@ type BalanceStorageHelper interface {
 	) (*types.Amount, error)
 
 	ExemptFunc() parser.ExemptOperation
+	BalanceExemptions() []*types.BalanceExemption
 	Asserter() *asserter.Asserter
 }
 
@@ -88,10 +89,17 @@ func NewBalanceStorage(
 
 // Initialize adds a BalanceStorageHelper and BalanceStorageHandler to BalanceStorage.
 // This must be called prior to syncing!
-func (b *BalanceStorage) Initialize(helper BalanceStorageHelper, handler BalanceStorageHandler) {
+func (b *BalanceStorage) Initialize(
+	helper BalanceStorageHelper,
+	handler BalanceStorageHandler,
+) {
 	b.helper = helper
 	b.handler = handler
-	b.parser = parser.New(helper.Asserter(), helper.ExemptFunc())
+	b.parser = parser.New(
+		helper.Asserter(),
+		helper.ExemptFunc(),
+		helper.BalanceExemptions(),
+	)
 }
 
 // AddingBlock is called by BlockStorage when adding a block to storage.
@@ -262,6 +270,78 @@ func (b *BalanceStorage) ReconciliationCoverage(
 	return float64(validCoverage) / float64(seen), nil
 }
 
+// existingValue finds the existing value for
+// a given *types.AccountIdentifier and *types.Currency.
+func (b *BalanceStorage) existingValue(
+	ctx context.Context,
+	change *parser.BalanceChange,
+	parentBlock *types.BlockIdentifier,
+	namespace string,
+	balance []byte,
+	exists bool,
+	exemptions []*types.BalanceExemption,
+) (string, error) {
+	if parentBlock != nil && change.Block.Hash == parentBlock.Hash {
+		// Don't attempt to use the helper if we are going to query the same
+		// block we are processing (causes the duplicate issue).
+		return "0", nil
+	}
+
+	var existingValue string
+	if exists {
+		var bal balanceEntry
+		err := b.db.Encoder().Decode(namespace, balance, &bal, true)
+		if err != nil {
+			return "", err
+		}
+
+		existingValue = bal.Amount.Value
+		if len(exemptions) == 0 {
+			return existingValue, nil
+		}
+	}
+
+	// Use helper to fetch existing balance.
+	amount, err := b.helper.AccountBalance(ctx, change.Account, change.Currency, parentBlock)
+	if err != nil {
+		return "", fmt.Errorf(
+			"%w: unable to get previous account balance for %s %s at %s",
+			err,
+			types.PrintStruct(change.Account),
+			types.PrintStruct(change.Currency),
+			types.PrintStruct(parentBlock),
+		)
+	}
+
+	// Nothing to compare, so should return.
+	if len(existingValue) == 0 {
+		return amount.Value, nil
+	}
+
+	// Determine if new live balance complies
+	// with any balance exemption.
+	difference, err := types.SubtractValues(amount.Value, existingValue)
+	if err != nil {
+		return "", fmt.Errorf("%w: unable to calculate difference between live and computed balances", err)
+	}
+
+	exemption := parser.MatchBalanceExemption(
+		exemptions,
+		difference,
+	)
+	if exemption == nil {
+		return "", fmt.Errorf(
+			"%w: account %s balance difference (live - computed) %s at %s is not allowed by any balance exemption",
+			ErrInvalidLiveBalance,
+			types.PrintStruct(change.Account),
+			difference,
+			types.PrintStruct(parentBlock),
+		)
+	}
+
+	return amount.Value, nil
+}
+
 // UpdateBalance updates a types.AccountIdentifer
 // by a types.Amount and sets the account's most
 // recent accessed block.
@@ -275,43 +355,30 @@ func (b *BalanceStorage) UpdateBalance(
 		return errors.New("invalid currency")
 	}
 
-	namespace, key := GetBalanceKey(change.Account, change.Currency)
 	// Get existing balance on key
+	namespace, key := GetBalanceKey(change.Account, change.Currency)
 	exists, balance, err := dbTransaction.Get(ctx, key)
 	if err != nil {
 		return err
 	}
 
-	var existingValue string
-	switch {
-	case exists:
-		// This could happen if balances are bootstrapped and should not be
-		// overridden.
-		var bal balanceEntry
-		err := b.db.Encoder().Decode(namespace, balance, &bal, true)
-		if err != nil {
-			return err
-		}
+	// Find exemptions that are applicable to the *parser.BalanceChange
+	exemptions := b.parser.FindExemptions(change.Account, change.Currency)
 
-		existingValue = bal.Amount.Value
-	case parentBlock != nil && change.Block.Hash == parentBlock.Hash:
-		// Don't attempt to use the helper if we are going to query the same
-		// block we are processing (causes the duplicate issue).
-		existingValue = "0"
-	default:
-		// Use helper to fetch existing balance.
-		amount, err := b.helper.AccountBalance(ctx, change.Account, change.Currency, parentBlock)
-		if err != nil {
-			return fmt.Errorf(
-				"%w: unable to get previous account balance for %s %s at %s",
-				err,
-				types.PrintStruct(change.Account),
-				types.PrintStruct(change.Currency),
-				types.PrintStruct(parentBlock),
-			)
-		}
-
-		existingValue = amount.Value
+	// Find account existing value whether the account is new, has an
+	// existing balance, or is subject to additional accounting from
+	// a balance exemption.
+	existingValue, err := b.existingValue(
+		ctx,
+		change,
+		parentBlock,
+		namespace,
+		balance,
+		exists,
+		exemptions,
+	)
+	if err != nil {
+		return err
 	}
 
 	newVal, err := types.AddValues(change.Difference, existingValue)

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -887,6 +887,7 @@ type MockBalanceStorageHelper struct {
 	AccountBalanceAmount string
 	AccountBalances      map[string]string
 	ExemptAccounts       []*reconciler.AccountCurrency
+	BalExemptions        []*types.BalanceExemption
 }
 
 func (h *MockBalanceStorageHelper) AccountBalance(
@@ -951,4 +952,8 @@ func (h *MockBalanceStorageHelper) ExemptFunc() parser.ExemptOperation {
 
 		return false
 	}
+}
+
+func (h *MockBalanceStorageHelper) BalanceExemptions() []*types.BalanceExemption {
+	return h.BalExemptions
 }

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -93,6 +93,19 @@ func TestBalance(t *testing.T) {
 				},
 			},
 		}
+		exemptionAccount = &types.AccountIdentifier{
+			Address: "exemption",
+		}
+		exemptionCurrency = &types.Currency{
+			Symbol:   "exempt",
+			Decimals: 3,
+		}
+		exemptions = []*types.BalanceExemption{
+			{
+				ExemptionType: types.BalanceGreaterOrEqual,
+				Currency:      exemptionCurrency,
+			},
+		}
 		currency = &types.Currency{
 			Symbol:   "BLAH",
 			Decimals: 2,
@@ -128,6 +141,10 @@ func TestBalance(t *testing.T) {
 			Hash:  "pkdgdj",
 			Index: 123891,
 		}
+		newBlock4 = &types.BlockIdentifier{
+			Hash:  "asdjkajsdk",
+			Index: 123892,
+		}
 		largeDeduction = &types.Amount{
 			Value:    "-1000",
 			Currency: currency,
@@ -136,6 +153,7 @@ func TestBalance(t *testing.T) {
 			AccountBalances: map[string]string{
 				"genesis": "100",
 			},
+			BalExemptions: exemptions,
 		}
 	)
 
@@ -426,6 +444,116 @@ func TestBalance(t *testing.T) {
 		assert.Equal(t, newBlock, block)
 	})
 
+	t.Run("balance exemption update", func(t *testing.T) {
+		mockHelper.AccountBalanceAmount = "0"
+		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		err := storage.UpdateBalance(
+			ctx,
+			txn,
+			&parser.BalanceChange{
+				Account:    exemptionAccount,
+				Currency:   exemptionCurrency,
+				Block:      newBlock,
+				Difference: amount.Value,
+			},
+			nil,
+		)
+		assert.NoError(t, err)
+		assert.NoError(t, txn.Commit(ctx))
+
+		retrievedAmount, block, err := storage.GetBalance(
+			ctx,
+			exemptionAccount,
+			exemptionCurrency,
+			newBlock,
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, amount.Value, retrievedAmount.Value)
+		assert.Equal(t, newBlock, block)
+
+		// Successful (balance == computed)
+		mockHelper.AccountBalanceAmount = amount.Value
+		txn = storage.db.NewDatabaseTransaction(ctx, true)
+		err = storage.UpdateBalance(
+			ctx,
+			txn,
+			&parser.BalanceChange{
+				Account:    exemptionAccount,
+				Currency:   exemptionCurrency,
+				Block:      newBlock3,
+				Difference: "50",
+			},
+			nil,
+		)
+		assert.NoError(t, err)
+		assert.NoError(t, txn.Commit(ctx))
+
+		retrievedAmount, block, err = storage.GetBalance(
+			ctx,
+			exemptionAccount,
+			exemptionCurrency,
+			newBlock3,
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, "150", retrievedAmount.Value)
+		assert.Equal(t, newBlock3, block)
+
+		// Successful (balance > computed)
+		mockHelper.AccountBalanceAmount = "200"
+		txn = storage.db.NewDatabaseTransaction(ctx, true)
+		err = storage.UpdateBalance(
+			ctx,
+			txn,
+			&parser.BalanceChange{
+				Account:    exemptionAccount,
+				Currency:   exemptionCurrency,
+				Block:      newBlock4,
+				Difference: "50",
+			},
+			nil,
+		)
+		assert.NoError(t, err)
+		assert.NoError(t, txn.Commit(ctx))
+
+		retrievedAmount, block, err = storage.GetBalance(
+			ctx,
+			exemptionAccount,
+			exemptionCurrency,
+			newBlock4,
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, "250", retrievedAmount.Value)
+		assert.Equal(t, newBlock4, block)
+
+		// Unsuccessful (balance < computed)
+		mockHelper.AccountBalanceAmount = "10"
+		txn = storage.db.NewDatabaseTransaction(ctx, true)
+		err = storage.UpdateBalance(
+			ctx,
+			txn,
+			&parser.BalanceChange{
+				Account:    exemptionAccount,
+				Currency:   exemptionCurrency,
+				Block:      newBlock4,
+				Difference: "50",
+			},
+			nil,
+		)
+		assert.Error(t, err)
+		txn.Discard(ctx)
+
+		retrievedAmount, block, err = storage.GetBalance(
+			ctx,
+			exemptionAccount,
+			exemptionCurrency,
+			newBlock4,
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, "250", retrievedAmount.Value)
+		assert.Equal(t, newBlock4, block)
+		mockHelper.AccountBalanceAmount = ""
+	})
+
 	t.Run("get all set AccountCurrency", func(t *testing.T) {
 		accounts, err := storage.GetAllAccountCurrency(ctx)
 		assert.NoError(t, err)
@@ -453,6 +581,10 @@ func TestBalance(t *testing.T) {
 			{
 				Account:  subAccountMetadata2,
 				Currency: currency,
+			},
+			{
+				Account:  exemptionAccount,
+				Currency: exemptionCurrency,
 			},
 		}, accounts)
 	})

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -315,8 +315,14 @@ var (
 	// balance goes negative as the result of an operation.
 	ErrNegativeBalance = errors.New("negative balance")
 
+	// ErrInvalidLiveBalance is returned when an account's
+	// live balance varies in a way that is inconsistent
+	// with any balance exemption.
+	ErrInvalidLiveBalance = errors.New("invalid live balance")
+
 	BalanceStorageErrs = []error{
 		ErrNegativeBalance,
+		ErrInvalidLiveBalance,
 	}
 
 	///////////////////


### PR DESCRIPTION
This PR extends `BalanceStorage` to update computed balances with an updated live balance if an account is subject to a `*types.BalanceExemption`.

### Changes
- [x] Add functionality to `parser` to match `*types.AccountIdentifier` and `*types.Currency` with `[]*types.BalanceExemption`
- [x] Modify `reconciler` to use this parser implementation
- [x] Automatically update computed balance of any account based on applicable balance exemptions (this could slow down syncing considerably)
  - [x] Check that modification to computed balance is permitted by the matching `*types.BalanceExemption`