### PR TITLE
[reconciler] Skip Handler

### DIFF
--- a/mocks/reconciler/handler.go
+++ b/mocks/reconciler/handler.go
@@ -43,6 +43,20 @@ func (_m *Handler) ReconciliationFailed(ctx context.Context, reconciliationType 
 	return r0
 }
 
+// ReconciliationSkipped provides a mock function with given fields: ctx, reconciliationType, account, currency, cause
+func (_m *Handler) ReconciliationSkipped(ctx context.Context, reconciliationType string, account *types.AccountIdentifier, currency *types.Currency, cause string) error {
+	ret := _m.Called(ctx, reconciliationType, account, currency, cause)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *types.AccountIdentifier, *types.Currency, string) error); ok {
+		r0 = rf(ctx, reconciliationType, account, currency, cause)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ReconciliationSucceeded provides a mock function with given fields: ctx, reconciliationType, account, currency, balance, block
 func (_m *Handler) ReconciliationSucceeded(ctx context.Context, reconciliationType string, account *types.AccountIdentifier, currency *types.Currency, balance string, block *types.BlockIdentifier) error {
 	ret := _m.Called(ctx, reconciliationType, account, currency, balance, block)

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -29,7 +29,7 @@ type Option func(r *Reconciler)
 // concurrency.
 func WithInactiveConcurrency(concurrency int) Option {
 	return func(r *Reconciler) {
-		r.inactiveConcurrency = concurrency
+		r.InactiveConcurrency = concurrency
 	}
 }
 
@@ -37,7 +37,7 @@ func WithInactiveConcurrency(concurrency int) Option {
 // concurrency.
 func WithActiveConcurrency(concurrency int) Option {
 	return func(r *Reconciler) {
-		r.activeConcurrency = concurrency
+		r.ActiveConcurrency = concurrency
 	}
 }
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -586,12 +586,24 @@ func (r *Reconciler) accountReconciliation(
 			if errors.Is(err, ErrBlockGone) {
 				// Either the block has not been processed in a re-org yet
 				// or the block was orphaned
+				if r.debugLogging {
+					log.Println(
+						"skipping reconciliation because block gone",
+						types.PrintStruct(liveBlock),
+					)
+				}
 				break
 			}
 
 			if errors.Is(err, ErrAccountUpdated) {
 				// If account was updated, it must be
 				// enqueued again
+				if r.debugLogging {
+					log.Println(
+						"skipping reconciliation because account updated",
+						types.PrintStruct(accountCurrency.Account),
+					)
+				}
 				break
 			}
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -683,6 +683,11 @@ func (r *Reconciler) reconcileActiveAccounts(
 			return ctx.Err()
 		case balanceChange := <-r.changeQueue:
 			if balanceChange.Block.Index < r.highWaterMark {
+				if r.debugLogging {
+					log.Println(
+						"waiting to continue active reconciliation until reaching high water mark...",
+					)
+				}
 				continue
 			}
 
@@ -693,6 +698,12 @@ func (r *Reconciler) reconcileActiveAccounts(
 				balanceChange.Block,
 			)
 			if errors.Is(err, ErrBlockGone) {
+				if r.debugLogging {
+					log.Println(
+						"err block gone...",
+						types.PrintStruct(balanceChange.Block),
+					)
+				}
 				continue
 			}
 			if err != nil {

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -27,44 +27,36 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// ReconciliationType is the type of reconciliation
-// performed.
-type ReconciliationType string
-
 const (
 	// ActiveReconciliation is included in the reconciliation
 	// error message if reconciliation failed during active
 	// reconciliation.
-	ActiveReconciliation ReconciliationType = "ACTIVE"
+	ActiveReconciliation = "ACTIVE"
 
 	// InactiveReconciliation is included in the reconciliation
 	// error message if reconciliation failed during inactive
 	// reconciliation.
-	InactiveReconciliation ReconciliationType = "INACTIVE"
+	InactiveReconciliation = "INACTIVE"
 )
-
-// SkipCause is the reason reconciliation of a particular account
-// is skipped.
-type SkipCause string
 
 const (
 	// BlockGone is when the block where a reconciliation
 	// is supposed to happen is orphaned.
-	BlockGone SkipCause = "BLOCK_GONE"
+	BlockGone = "BLOCK_GONE"
 
 	// AccountUpdated is when an account that is to be
 	// reconciled is updated after the block where the
 	// balance change occurs (this usually occurs
 	// in large backlogs).
-	AccountUpdated SkipCause = "ACCOUNT_UPDATED"
+	AccountUpdated = "ACCOUNT_UPDATED"
 
 	// HeadBehind is when the synced tip (where balances
 	// were last computed) is behind the *types.BlockIdentifier
 	// returned by the call to /account/balance.
-	HeadBehind SkipCause = "HEAD_BEHIND"
+	HeadBehind = "HEAD_BEHIND"
 
 	// BacklogFull is when the reconciliation backlog is full.
-	BacklogFull SkipCause = "BACKLOG_FULL"
+	BacklogFull = "BACKLOG_FULL"
 )
 
 const (
@@ -148,7 +140,7 @@ type Helper interface {
 type Handler interface {
 	ReconciliationFailed(
 		ctx context.Context,
-		reconciliationType ReconciliationType,
+		reconciliationType string,
 		account *types.AccountIdentifier,
 		currency *types.Currency,
 		computedBalance string,
@@ -158,7 +150,7 @@ type Handler interface {
 
 	ReconciliationSucceeded(
 		ctx context.Context,
-		reconciliationType ReconciliationType,
+		reconciliationType string,
 		account *types.AccountIdentifier,
 		currency *types.Currency,
 		balance string,
@@ -167,7 +159,7 @@ type Handler interface {
 
 	ReconciliationExempt(
 		ctx context.Context,
-		reconciliationType ReconciliationType,
+		reconciliationType string,
 		account *types.AccountIdentifier,
 		currency *types.Currency,
 		computedBalance string,
@@ -178,10 +170,10 @@ type Handler interface {
 
 	ReconciliationSkipped(
 		ctx context.Context,
-		reconciliationType ReconciliationType,
+		reconciliationType string,
 		account *types.AccountIdentifier,
 		currency *types.Currency,
-		cause SkipCause,
+		cause string,
 	) error
 }
 
@@ -539,7 +531,7 @@ func (r *Reconciler) bestLiveBalance(
 func (r *Reconciler) handleBalanceMismatch(
 	ctx context.Context,
 	difference string,
-	reconciliationType ReconciliationType,
+	reconciliationType string,
 	account *types.AccountIdentifier,
 	currency *types.Currency,
 	computedBalance string,

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -639,6 +639,8 @@ func (r *Reconciler) accountReconciliation(
 	}
 
 	// We return here if we gave up trying to reconcile an account.
+
+	// TODO: track reconciliations skipped
 	return nil
 }
 
@@ -702,6 +704,8 @@ func (r *Reconciler) reconcileActiveAccounts(
 				}
 				continue
 			}
+
+			// TODO: check if account computed balance height > best live balance
 
 			amount, block, err := r.bestLiveBalance(
 				ctx,

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -596,7 +596,7 @@ func (r *Reconciler) accountReconciliation(
 	if inactive {
 		reconciliationType = InactiveReconciliation
 	}
-	for ctx.Err() != nil {
+	for ctx.Err() == nil {
 		// If don't have previous balance because stateless, check diff on block
 		// instead of comparing entire computed balance
 		difference, computedBalance, headIndex, err := r.CompareBalance(

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -214,8 +214,8 @@ type Reconciler struct {
 	// it is useful to allocate more resources to
 	// active reconciliation as it is synchronous
 	// (when lookupBalanceByBlock is enabled).
-	activeConcurrency   int
-	inactiveConcurrency int
+	ActiveConcurrency   int
+	InactiveConcurrency int
 
 	// highWaterMark is used to skip requests when
 	// we are very far behind the live head.
@@ -252,8 +252,8 @@ func New(
 		handler:              handler,
 		parser:               p,
 		inactiveFrequency:    defaultInactiveFrequency,
-		activeConcurrency:    defaultReconcilerConcurrency,
-		inactiveConcurrency:  defaultReconcilerConcurrency,
+		ActiveConcurrency:    defaultReconcilerConcurrency,
+		InactiveConcurrency:  defaultReconcilerConcurrency,
 		highWaterMark:        -1,
 		seenAccounts:         map[string]struct{}{},
 		inactiveQueue:        []*InactiveEntry{},
@@ -973,13 +973,13 @@ func (r *Reconciler) reconcileInactiveAccounts(
 // If any goroutine errors, the function will return an error.
 func (r *Reconciler) Reconcile(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
-	for j := 0; j < r.activeConcurrency; j++ {
+	for j := 0; j < r.ActiveConcurrency; j++ {
 		g.Go(func() error {
 			return r.reconcileActiveAccounts(ctx)
 		})
 	}
 
-	for j := 0; j < r.inactiveConcurrency; j++ {
+	for j := 0; j < r.InactiveConcurrency; j++ {
 		g.Go(func() error {
 			return r.reconcileInactiveAccounts(ctx)
 		})

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -1035,6 +1035,14 @@ func TestReconcile_Orphan(t *testing.T) {
 		errors.New("cannot find block"),
 	).Once()
 	mockHelper.On("CanonicalBlock", mock.Anything, block).Return(false, nil).Once()
+	mockHandler.On(
+		"ReconciliationSkipped",
+		mock.Anything,
+		ActiveReconciliation,
+		accountCurrency.Account,
+		accountCurrency.Currency,
+		BlockGone,
+	).Return(nil).Once()
 
 	go func() {
 		err := r.Reconcile(ctx)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -945,6 +945,24 @@ func TestReconcile_HighWaterMark(t *testing.T) {
 		false,
 	)
 
+	// Skip handler called
+	mockHandler.On(
+		"ReconciliationSkipped",
+		mock.Anything,
+		ActiveReconciliation,
+		accountCurrency.Account,
+		accountCurrency.Currency,
+		HeadBehind,
+	).Return(nil).Once()
+	mockHandler.On(
+		"ReconciliationSkipped",
+		mock.Anything,
+		ActiveReconciliation,
+		accountCurrency2.Account,
+		accountCurrency2.Currency,
+		HeadBehind,
+	).Return(nil).Once()
+
 	err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
 		{
 			Account:  accountCurrency.Account,
@@ -966,7 +984,7 @@ func TestReconcile_HighWaterMark(t *testing.T) {
 
 	go func() {
 		err := r.Reconcile(ctx)
-		assert.Contains(t, context.Canceled.Error(), err.Error())
+		assert.True(t, errors.Is(err, context.Canceled))
 	}()
 
 	time.Sleep(1 * time.Second)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -56,8 +56,8 @@ func TestNewReconciler(t *testing.T) {
 			},
 			expected: func() *Reconciler {
 				r := New(nil, nil, nil)
-				r.inactiveConcurrency = 100
-				r.activeConcurrency = 200
+				r.InactiveConcurrency = 100
+				r.ActiveConcurrency = 200
 
 				return r
 			}(),
@@ -117,8 +117,8 @@ func TestNewReconciler(t *testing.T) {
 			assert.ElementsMatch(t, test.expected.inactiveQueue, result.inactiveQueue)
 			assert.Equal(t, test.expected.seenAccounts, result.seenAccounts)
 			assert.ElementsMatch(t, test.expected.interestingAccounts, result.interestingAccounts)
-			assert.Equal(t, test.expected.inactiveConcurrency, result.inactiveConcurrency)
-			assert.Equal(t, test.expected.activeConcurrency, result.activeConcurrency)
+			assert.Equal(t, test.expected.InactiveConcurrency, result.InactiveConcurrency)
+			assert.Equal(t, test.expected.ActiveConcurrency, result.ActiveConcurrency)
 			assert.Equal(t, test.expected.lookupBalanceByBlock, result.lookupBalanceByBlock)
 			assert.Equal(t, cap(test.expected.changeQueue), cap(result.changeQueue))
 		})

--- a/storage/counter_storage.go
+++ b/storage/counter_storage.go
@@ -66,6 +66,12 @@ const (
 	// failures that were not exempt.
 	FailedReconciliationCounter = "failed_reconciliations"
 
+	// SkippedReconciliationsCounter is the number of reconciliation
+	// attempts that were skipped. This typically occurs because an
+	// account balance has been updated since being marked for reconciliation
+	// or the block where an account was updated has been orphaned.
+	SkippedReconciliationsCounter = "skipped_reconciliations"
+
 	// counterNamespace is preprended to any counter.
 	counterNamespace = "counter"
 )


### PR DESCRIPTION
This PR ensures no reconciliations "enter the abyss". We now invoke the new `ReconciliationSkipped` handler if we opt to skip reconciliation for any account.

### Changes
- [x] Add `ReconciliationSkipped` hander
- [x] Add `SkippedReconciliationsCounter`
- [x] Cleanup `debugLog`
- [x] Make concurrency variables public