### PR TITLE
[storage] Historical Balance Tracking

### DIFF
--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -431,10 +431,12 @@ func (b *BadgerTransaction) Scan(
 	prefix []byte,
 	worker func([]byte, []byte) error,
 	logEntries bool,
+	reverse bool, // reverse == true means greatest to least
 ) (int, error) {
 	entries := 0
 	opts := badger.DefaultIteratorOptions
 	opts.PrefetchValues = false
+	opts.Reverse = reverse
 	it := b.txn.NewIterator(opts)
 	defer it.Close()
 	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
@@ -554,6 +556,7 @@ func recompress(
 			return nil
 		},
 		true,
+		false,
 	)
 	if err != nil {
 		return -1, -1, fmt.Errorf("%w: %v", ErrRecompressFailed, err)
@@ -633,6 +636,7 @@ func BadgerTrain(
 			return nil
 		},
 		true,
+		false,
 	)
 	if err != nil && !errors.Is(err, ErrMaxEntries) {
 		return -1, -1, fmt.Errorf("%w for %s: %v", ErrScanFailed, namespace, err)

--- a/storage/badger_storage_test.go
+++ b/storage/badger_storage_test.go
@@ -151,6 +151,7 @@ func TestDatabase(t *testing.T) {
 						return nil
 					},
 					false,
+					false,
 				)
 				assert.NoError(t, err)
 				assert.Equal(t, 100, numValues)

--- a/storage/badger_storage_test.go
+++ b/storage/badger_storage_test.go
@@ -136,6 +136,7 @@ func TestDatabase(t *testing.T) {
 				numValues, err := txn.Scan(
 					ctx,
 					[]byte("test/"),
+					[]byte("test/"),
 					func(k []byte, v []byte) error {
 						thisK := make([]byte, len(k))
 						thisV := make([]byte, len(v))

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -449,12 +449,10 @@ func (b *BalanceStorage) UpdateBalance(
 		)
 		switch {
 		case errors.Is(err, errAccountMissing):
-			fmt.Println("account missing", balance, lastUpdate)
 			storedValue = "0"
 		case err != nil:
 			return err
 		default:
-			fmt.Println("account exists", balance.Value)
 			storedValue = balance.Value
 		}
 
@@ -482,14 +480,10 @@ func (b *BalanceStorage) UpdateBalance(
 		return err
 	}
 
-	fmt.Println("existing value", existingValue)
-
 	newVal, err := types.AddValues(change.Difference, existingValue)
 	if err != nil {
 		return err
 	}
-
-	fmt.Println("new val", newVal)
 
 	bigNewVal, ok := new(big.Int).SetString(newVal, 10)
 	if !ok {
@@ -590,7 +584,6 @@ func (b *BalanceStorage) GetBalanceTransactional(
 	// we fetch the balance from the node for the given height and persist
 	// it. This is particularly useful when monitoring interesting accounts.
 	if !exists {
-		fmt.Println("doesn't exist")
 		amount, err := b.helper.AccountBalance(ctx, account, currency, block)
 		if err != nil {
 			return nil, fmt.Errorf("%w: unable to get account balance from helper", err)
@@ -632,7 +625,6 @@ func (b *BalanceStorage) GetBalanceTransactional(
 		return nil, err
 	}
 
-	fmt.Println("historical balance", amount)
 	return amount, nil
 }
 
@@ -824,7 +816,6 @@ func (b *BalanceStorage) getHistoricalBalance(
 		GetHistoricalBalancePrefix(account, currency),
 		GetHistoricalBalanceKey(account, currency, block.Index),
 		func(k []byte, v []byte) error {
-			fmt.Println(string(k))
 			var deserialBal balanceEntry
 			// We should not reclaim memory during a scan!!
 			err := b.db.Encoder().Decode(historicalBalanceNamespace, v, &deserialBal, false)

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -33,6 +33,10 @@ var _ BlockWorker = (*BalanceStorage)(nil)
 const (
 	// balanceNamespace is prepended to any stored balance.
 	balanceNamespace = "balance"
+
+	// historicalBalanceNamespace is prepended to any stored
+	// historical balance.
+	historicalBalanceNamespace = "hbalance"
 )
 
 var (
@@ -54,7 +58,7 @@ func GetBalanceKey(account *types.AccountIdentifier, currency *types.Currency) [
 // GetBalanceKeyHistorical returns a deterministic hash of an types.Account + types.Currency + block index.
 func GetBalanceKeyHistorical(account *types.AccountIdentifier, currency *types.Currency, blockIndex int64) []byte {
 	return []byte(
-		fmt.Sprintf("%s/%s/%s/%020d", balanceNamespace, types.Hash(account), types.Hash(currency), blockIndex),
+		fmt.Sprintf("%s/%s/%s/%020d", historicalBalanceNamespace, types.Hash(account), types.Hash(currency), blockIndex),
 	)
 }
 

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -48,14 +48,14 @@ var (
   Key Construction
 */
 
-// GetAccountKey returns a deterministic hash of an types.Account + types.Currency.
+// GetAccountKey returns a deterministic hash of a types.Account + types.Currency.
 func GetAccountKey(account *types.AccountIdentifier, currency *types.Currency) []byte {
 	return []byte(
 		fmt.Sprintf("%s/%s/%s", accountNamespace, types.Hash(account), types.Hash(currency)),
 	)
 }
 
-// GetHistoricalBalanceKey returns a deterministic hash of an types.Account + types.Currency + block
+// GetHistoricalBalanceKey returns a deterministic hash of a types.Account + types.Currency + block
 // index.
 func GetHistoricalBalanceKey(
 	account *types.AccountIdentifier,
@@ -73,7 +73,7 @@ func GetHistoricalBalanceKey(
 	)
 }
 
-// GetHistoricalBalancePrefix returns a deterministic hash of an types.Account + types.Currency to
+// GetHistoricalBalancePrefix returns a deterministic hash of a types.Account + types.Currency to
 // limit scan results.
 func GetHistoricalBalancePrefix(account *types.AccountIdentifier, currency *types.Currency) []byte {
 	return []byte(

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -55,17 +55,34 @@ func GetAccountKey(account *types.AccountIdentifier, currency *types.Currency) [
 	)
 }
 
-// GetHistoricalBalanceKey returns a deterministic hash of an types.Account + types.Currency + block index.
-func GetHistoricalBalanceKey(account *types.AccountIdentifier, currency *types.Currency, blockIndex int64) []byte {
+// GetHistoricalBalanceKey returns a deterministic hash of an types.Account + types.Currency + block
+// index.
+func GetHistoricalBalanceKey(
+	account *types.AccountIdentifier,
+	currency *types.Currency,
+	blockIndex int64,
+) []byte {
 	return []byte(
-		fmt.Sprintf("%s/%s/%s/%020d", historicalBalanceNamespace, types.Hash(account), types.Hash(currency), blockIndex),
+		fmt.Sprintf(
+			"%s/%s/%s/%020d",
+			historicalBalanceNamespace,
+			types.Hash(account),
+			types.Hash(currency),
+			blockIndex,
+		),
 	)
 }
 
-// GetHistoricalBalancePrefix returns a deterministic hash of an types.Account + types.Currency to limit scan results.
+// GetHistoricalBalancePrefix returns a deterministic hash of an types.Account + types.Currency to
+// limit scan results.
 func GetHistoricalBalancePrefix(account *types.AccountIdentifier, currency *types.Currency) []byte {
 	return []byte(
-		fmt.Sprintf("%s/%s/%s/", historicalBalanceNamespace, types.Hash(account), types.Hash(currency)),
+		fmt.Sprintf(
+			"%s/%s/%s/",
+			historicalBalanceNamespace,
+			types.Hash(account),
+			types.Hash(currency),
+		),
 	)
 }
 

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -571,7 +571,7 @@ func TestBalance(t *testing.T) {
 		}, accounts)
 	})
 
-	t.Run("orphan balance", func(t *testing.T) {
+	t.Run("orphan balance with update balance", func(t *testing.T) {
 		txn := storage.db.NewDatabaseTransaction(ctx, true)
 		orphanValue, _ := new(big.Int).SetString(largeDeduction.Value, 10)
 		err := storage.UpdateBalance(
@@ -584,6 +584,26 @@ func TestBalance(t *testing.T) {
 				Difference: new(big.Int).Neg(orphanValue).String(),
 			},
 			nil,
+		)
+		assert.NoError(t, err)
+		assert.NoError(t, txn.Commit(ctx))
+
+		retrievedAmount, err := storage.GetBalance(ctx, account, largeDeduction.Currency, newBlock3)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "1200",
+			Currency: largeDeduction.Currency,
+		}, retrievedAmount)
+	})
+
+	t.Run("orphan balance correctly", func(t *testing.T) {
+		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		err := storage.OrphanBalance(
+			ctx,
+			txn,
+			account,
+			largeDeduction.Currency,
+			newBlock3,
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -588,9 +588,12 @@ func TestBalance(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
-		retrievedAmount, err := storage.GetBalance(ctx, account, currency, newBlock3)
+		retrievedAmount, err := storage.GetBalance(ctx, account, largeDeduction.Currency, newBlock3)
 		assert.NoError(t, err)
-		assert.Equal(t, result, retrievedAmount)
+		assert.Equal(t, &types.Amount{
+			Value:    "1200",
+			Currency: largeDeduction.Currency,
+		}, retrievedAmount)
 	})
 }
 
@@ -708,6 +711,11 @@ func TestBootstrapBalances(t *testing.T) {
 			Hash:  "0",
 		}
 
+		newBlock = &types.BlockIdentifier{
+			Index: 1,
+			Hash:  "1",
+		}
+
 		account = &types.AccountIdentifier{
 			Address: "hello",
 		}
@@ -785,10 +793,10 @@ func TestBootstrapBalances(t *testing.T) {
 			&parser.BalanceChange{
 				Account:    account,
 				Currency:   amount.Currency,
-				Block:      genesisBlockIdentifier,
+				Block:      newBlock,
 				Difference: "100",
 			},
-			genesisBlockIdentifier,
+			newBlock,
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
@@ -797,7 +805,7 @@ func TestBootstrapBalances(t *testing.T) {
 			ctx,
 			account,
 			amount.Currency,
-			genesisBlockIdentifier,
+			newBlock,
 		)
 
 		assert.Equal(t, "110", retrievedAmount.Value)

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -132,7 +132,7 @@ func TestBalance(t *testing.T) {
 		}
 		newBlock2 = &types.BlockIdentifier{
 			Hash:  "pkdasdj",
-			Index: 123890,
+			Index: 123891,
 		}
 		result = &types.Amount{
 			Value:    "200",
@@ -140,11 +140,11 @@ func TestBalance(t *testing.T) {
 		}
 		newBlock3 = &types.BlockIdentifier{
 			Hash:  "pkdgdj",
-			Index: 123891,
+			Index: 123892,
 		}
 		newBlock4 = &types.BlockIdentifier{
 			Hash:  "asdjkajsdk",
-			Index: 123892,
+			Index: 123893,
 		}
 		largeDeduction = &types.Amount{
 			Value:    "-1000",
@@ -205,16 +205,12 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Set and get balance", func(t *testing.T) {
 		txn := storage.db.NewDatabaseTransaction(ctx, true)
-		err := storage.UpdateBalance(
+		err := storage.SetBalance(
 			ctx,
 			txn,
-			&parser.BalanceChange{
-				Account:    account,
-				Currency:   currency,
-				Block:      newBlock,
-				Difference: amount.Value,
-			},
-			nil,
+			account,
+			amount,
+			newBlock,
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -359,6 +359,7 @@ func (b *BroadcastStorage) getAllBroadcasts(
 	_, err := dbTx.Scan(
 		ctx,
 		[]byte(namespace),
+		[]byte(namespace),
 		func(k []byte, v []byte) error {
 			var broadcast Broadcast
 			// We should not reclaim memory during a scan!!

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -370,6 +370,7 @@ func (b *BroadcastStorage) getAllBroadcasts(
 			return nil
 		},
 		false,
+		false,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrBroadcastScanFailed, err)

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -192,6 +192,7 @@ func getAndDecodeCoins(
 	_, err := transaction.Scan(
 		ctx,
 		getCoinAccountPrefix(accountIdentifier),
+		getCoinAccountPrefix(accountIdentifier),
 		func(k []byte, v []byte) error {
 			vals := strings.Split(string(k), "/")
 			coinIdentifier := vals[len(vals)-1]

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -199,6 +199,7 @@ func getAndDecodeCoins(
 			return nil
 		},
 		false,
+		false,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrAccountCoinQueryFailed, err)

--- a/storage/key_storage.go
+++ b/storage/key_storage.go
@@ -170,6 +170,7 @@ func (k *KeyStorage) GetAllAccountsTransactional(
 	_, err := dbTx.Scan(
 		ctx,
 		[]byte(keyNamespace),
+		[]byte(keyNamespace),
 		func(key []byte, v []byte) error {
 			var kp Key
 			// We should not reclaim memory during a scan!!

--- a/storage/key_storage.go
+++ b/storage/key_storage.go
@@ -181,6 +181,7 @@ func (k *KeyStorage) GetAllAccountsTransactional(
 			return nil
 		},
 		false,
+		false,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrKeyScanFailed, err)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -40,7 +40,8 @@ type DatabaseTransaction interface {
 
 	Scan(
 		context.Context,
-		[]byte,
+		[]byte, // prefix restriction
+		[]byte, // seek start
 		func([]byte, []byte) error,
 		bool, // log entries
 		bool, // reverse == true means greatest to least

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -43,6 +43,7 @@ type DatabaseTransaction interface {
 		[]byte,
 		func([]byte, []byte) error,
 		bool, // log entries
+		bool, // reverse == true means greatest to least
 	) (int, error)
 
 	Commit(context.Context) error


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13023275/97055511-d2462c00-153b-11eb-97fe-8ff980464b46.png)

After exposing the number of "skipped" reconciliations in the last release, it became abundantly clear that the `rosetta-cli` wastes up to 50% of all the calls it makes because accounts have been updated before they are able to make an /account/balance request. This PR modifies balance storage to track historical balances for all accounts.

As a side note, this PR unblocks the ability for `rosetta-bitcoin` to serve historical balance queries out of the box!

### Future PR
- [ ] Update `reconciler` package to not do skips
- [ ]  Cleanup BalanceExemption handling in `existingValue` (sometimes rewards are applied before processing, so accounts can go negative)