### PR TITLE
[reconciler] Remove ErrAccountUpdated

### DIFF
--- a/mocks/reconciler/helper.go
+++ b/mocks/reconciler/helper.go
@@ -113,3 +113,17 @@ func (_m *Helper) LiveBalance(ctx context.Context, account *types.AccountIdentif
 
 	return r0, r1, r2
 }
+
+// PruneHistoricalBalances provides a mock function with given fields: ctx, account, currency, index
+func (_m *Helper) PruneHistoricalBalances(ctx context.Context, account *types.AccountIdentifier, currency *types.Currency, index int64) error {
+	ret := _m.Called(ctx, account, currency, index)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.AccountIdentifier, *types.Currency, int64) error); ok {
+		r0 = rf(ctx, account, currency, index)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/mocks/reconciler/helper.go
+++ b/mocks/reconciler/helper.go
@@ -114,8 +114,8 @@ func (_m *Helper) LiveBalance(ctx context.Context, account *types.AccountIdentif
 	return r0, r1, r2
 }
 
-// PruneHistoricalBalances provides a mock function with given fields: ctx, account, currency, index
-func (_m *Helper) PruneHistoricalBalances(ctx context.Context, account *types.AccountIdentifier, currency *types.Currency, index int64) error {
+// PruneBalances provides a mock function with given fields: ctx, account, currency, index
+func (_m *Helper) PruneBalances(ctx context.Context, account *types.AccountIdentifier, currency *types.Currency, index int64) error {
 	ret := _m.Called(ctx, account, currency, index)
 
 	var r0 error

--- a/mocks/reconciler/helper.go
+++ b/mocks/reconciler/helper.go
@@ -36,36 +36,27 @@ func (_m *Helper) CanonicalBlock(ctx context.Context, block *types.BlockIdentifi
 	return r0, r1
 }
 
-// ComputedBalance provides a mock function with given fields: ctx, account, currency, headBlock
-func (_m *Helper) ComputedBalance(ctx context.Context, account *types.AccountIdentifier, currency *types.Currency, headBlock *types.BlockIdentifier) (*types.Amount, *types.BlockIdentifier, error) {
-	ret := _m.Called(ctx, account, currency, headBlock)
+// ComputedBalance provides a mock function with given fields: ctx, account, currency, block
+func (_m *Helper) ComputedBalance(ctx context.Context, account *types.AccountIdentifier, currency *types.Currency, block *types.BlockIdentifier) (*types.Amount, error) {
+	ret := _m.Called(ctx, account, currency, block)
 
 	var r0 *types.Amount
 	if rf, ok := ret.Get(0).(func(context.Context, *types.AccountIdentifier, *types.Currency, *types.BlockIdentifier) *types.Amount); ok {
-		r0 = rf(ctx, account, currency, headBlock)
+		r0 = rf(ctx, account, currency, block)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.Amount)
 		}
 	}
 
-	var r1 *types.BlockIdentifier
-	if rf, ok := ret.Get(1).(func(context.Context, *types.AccountIdentifier, *types.Currency, *types.BlockIdentifier) *types.BlockIdentifier); ok {
-		r1 = rf(ctx, account, currency, headBlock)
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *types.AccountIdentifier, *types.Currency, *types.BlockIdentifier) error); ok {
+		r1 = rf(ctx, account, currency, block)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*types.BlockIdentifier)
-		}
+		r1 = ret.Error(1)
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, *types.AccountIdentifier, *types.Currency, *types.BlockIdentifier) error); ok {
-		r2 = rf(ctx, account, currency, headBlock)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // CurrentBlock provides a mock function with given fields: ctx

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -92,12 +92,12 @@ func WithDebugLogging() Option {
 	}
 }
 
-// WithHistoricalBalancePruning determines if historical
+// WithBalancePruning determines if historical
 // balance states should be pruned after they are used.
 // This can prevent storage blowup if historical states
 // are only ever used once.
-func WithHistoricalBalancePruning() Option {
+func WithBalancePruning() Option {
 	return func(r *Reconciler) {
-		r.historicalBalancePruning = true
+		r.balancePruning = true
 	}
 }

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -101,3 +101,12 @@ func WithBalancePruning() Option {
 		r.balancePruning = true
 	}
 }
+
+// WithBacklogSize overrides the defaultBacklogSize
+// to some new size. This is often useful for blockchains
+// that have high network activity.
+func WithBacklogSize(size int) Option {
+	return func(r *Reconciler) {
+		r.backlogSize = size
+	}
+}

--- a/reconciler/configuration.go
+++ b/reconciler/configuration.go
@@ -69,12 +69,10 @@ func WithSeenAccounts(seen []*AccountCurrency) Option {
 	}
 }
 
-// WithLookupBalanceByBlock sets lookupBlockByBalance.
-func WithLookupBalanceByBlock(lookup bool) Option {
+// WithLookupBalanceByBlock sets lookupBlockByBalance to false.
+func WithLookupBalanceByBlock() Option {
 	return func(r *Reconciler) {
-		// We don't do anything if lookup == true because the default
-		// is already to create a non-buffered channel.
-		r.lookupBalanceByBlock = lookup
+		r.lookupBalanceByBlock = true
 	}
 }
 
@@ -88,8 +86,18 @@ func WithInactiveFrequency(blocks int64) Option {
 
 // WithDebugLogging determines if verbose logs should
 // be printed.
-func WithDebugLogging(debug bool) Option {
+func WithDebugLogging() Option {
 	return func(r *Reconciler) {
-		r.debugLogging = debug
+		r.debugLogging = true
+	}
+}
+
+// WithHistoricalBalancePruning determines if historical
+// balance states should be pruned after they are used.
+// This can prevent storage blowup if historical states
+// are only ever used once.
+func WithHistoricalBalancePruning() Option {
+	return func(r *Reconciler) {
+		r.historicalBalancePruning = true
 	}
 }

--- a/reconciler/errors.go
+++ b/reconciler/errors.go
@@ -28,11 +28,6 @@ var (
 	// we are close to the live head (waitToCheckDiff).
 	ErrHeadBlockBehindLive = errors.New("head block behind")
 
-	// ErrAccountUpdated is returned when the
-	// account was updated at a height later than
-	// the live height (when the account balance was fetched).
-	ErrAccountUpdated = errors.New("account updated")
-
 	// ErrBlockGone is returned when the processed block
 	// head is greater than the live head but the block
 	// does not exist in the store. This likely means
@@ -50,7 +45,6 @@ var (
 func Err(err error) bool {
 	reconcilerErrors := []error{
 		ErrHeadBlockBehindLive,
-		ErrAccountUpdated,
 		ErrBlockGone,
 		ErrGetCurrentBlockFailed,
 		ErrBlockExistsFailed,

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -356,10 +356,9 @@ func TestCompareBalance(t *testing.T) {
 		ctx,
 		account1,
 		amount1.Currency,
-		block2,
+		block0,
 	).Return(
 		amount1,
-		block2,
 		nil,
 	).Once()
 	t.Run("Account updated after live block", func(t *testing.T) {
@@ -371,9 +370,9 @@ func TestCompareBalance(t *testing.T) {
 			block0,
 		)
 		assert.Equal(t, "0", difference)
-		assert.Equal(t, "", cachedBalance)
+		assert.Equal(t, amount1.Value, cachedBalance)
 		assert.Equal(t, int64(2), headIndex)
-		assert.Contains(t, err.Error(), ErrAccountUpdated.Error())
+		assert.NoError(t, err)
 	})
 
 	mh.On("CurrentBlock", ctx).Return(block2, nil).Once()
@@ -383,10 +382,9 @@ func TestCompareBalance(t *testing.T) {
 		ctx,
 		account1,
 		amount1.Currency,
-		block2,
+		block1,
 	).Return(
 		amount1,
-		block1,
 		nil,
 	).Once()
 	t.Run("Account balance matches", func(t *testing.T) {
@@ -413,7 +411,6 @@ func TestCompareBalance(t *testing.T) {
 		block2,
 	).Return(
 		amount1,
-		block1,
 		nil,
 	).Once()
 	t.Run("Account balance matches later live block", func(t *testing.T) {
@@ -440,7 +437,6 @@ func TestCompareBalance(t *testing.T) {
 		block2,
 	).Return(
 		amount1,
-		block1,
 		nil,
 	).Once()
 	t.Run("Balances are not equal", func(t *testing.T) {
@@ -466,7 +462,6 @@ func TestCompareBalance(t *testing.T) {
 		currency1,
 		block2,
 	).Return(
-		nil,
 		nil,
 		errors.New("account missing"),
 	).Once()
@@ -670,7 +665,6 @@ func mockReconcilerCalls(
 		headBlock,
 	).Return(
 		&types.Amount{Value: computedValue, Currency: accountCurrency.Currency},
-		liveBlock,
 		nil,
 	).Once()
 	if success {

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -102,7 +102,7 @@ func TestNewReconciler(t *testing.T) {
 			expected: func() *Reconciler {
 				r := New(nil, nil, nil)
 				r.lookupBalanceByBlock = false
-				r.changeQueue = make(chan *parser.BalanceChange, backlogThreshold)
+				r.changeQueue = make(chan *parser.BalanceChange, defaultBacklogSize)
 
 				return r
 			}(),

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -97,10 +97,8 @@ func TestNewReconciler(t *testing.T) {
 				return r
 			}(),
 		},
-		"with lookupBalanceByBlock": {
-			options: []Option{
-				WithLookupBalanceByBlock(false),
-			},
+		"without lookupBalanceByBlock": {
+			options: []Option{},
 			expected: func() *Reconciler {
 				r := New(nil, nil, nil)
 				r.lookupBalanceByBlock = false
@@ -754,14 +752,19 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithActiveConcurrency(1),
+				WithInactiveConcurrency(0),
+				WithInterestingAccounts([]*AccountCurrency{accountCurrency2}),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				nil,
-				WithActiveConcurrency(1),
-				WithInactiveConcurrency(0),
-				WithInterestingAccounts([]*AccountCurrency{accountCurrency2}),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)
@@ -880,15 +883,17 @@ func TestReconcile_HighWaterMark(t *testing.T) {
 
 	mockHelper := &mocks.Helper{}
 	mockHandler := &mocks.Handler{}
+	opts := []Option{
+		WithActiveConcurrency(1),
+		WithInactiveConcurrency(0),
+		WithInterestingAccounts([]*AccountCurrency{accountCurrency2}),
+		WithDebugLogging(),
+	}
 	r := New(
 		mockHelper,
 		mockHandler,
 		nil,
-		WithActiveConcurrency(1),
-		WithInactiveConcurrency(0),
-		WithInterestingAccounts([]*AccountCurrency{accountCurrency2}),
-		WithLookupBalanceByBlock(false),
-		WithDebugLogging(true),
+		opts...,
 	)
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -1013,6 +1018,7 @@ func TestReconcile_Orphan(t *testing.T) {
 		nil,
 		WithActiveConcurrency(1),
 		WithInactiveConcurrency(0),
+		WithLookupBalanceByBlock(),
 	)
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -1085,13 +1091,18 @@ func TestReconcile_FailureOnlyActive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithActiveConcurrency(1),
+				WithInactiveConcurrency(0),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				parser.New(nil, nil, nil),
-				WithActiveConcurrency(1),
-				WithInactiveConcurrency(0),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 
@@ -1169,13 +1180,18 @@ func TestReconcile_ExemptOnlyActive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithActiveConcurrency(1),
+				WithInactiveConcurrency(0),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				p,
-				WithActiveConcurrency(1),
-				WithInactiveConcurrency(0),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 
@@ -1255,13 +1271,18 @@ func TestReconcile_ExemptAddressOnlyActive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithActiveConcurrency(1),
+				WithInactiveConcurrency(0),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				p,
-				WithActiveConcurrency(1),
-				WithInactiveConcurrency(0),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 
@@ -1341,12 +1362,17 @@ func TestReconcile_ExemptAddressDynamicActive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithInactiveConcurrency(0),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				p,
-				WithInactiveConcurrency(0),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 
@@ -1426,12 +1452,17 @@ func TestReconcile_ExemptAddressDynamicActiveThrow(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithInactiveConcurrency(0),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				p,
-				WithInactiveConcurrency(0),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 
@@ -1508,12 +1539,17 @@ func TestReconcile_NotExemptOnlyActive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithInactiveConcurrency(0),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				p,
-				WithInactiveConcurrency(0),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 
@@ -1591,12 +1627,17 @@ func TestReconcile_NotExemptAddressOnlyActive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithInactiveConcurrency(0),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				p,
-				WithInactiveConcurrency(0),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 
@@ -1677,13 +1718,18 @@ func TestReconcile_NotExemptWrongAddressOnlyActive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithActiveConcurrency(1),
+				WithInactiveConcurrency(0),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				p,
-				WithActiveConcurrency(1),
-				WithInactiveConcurrency(0),
-				WithLookupBalanceByBlock(lookup),
+				opts...,
 			)
 			ctx := context.Background()
 
@@ -1753,16 +1799,21 @@ func TestReconcile_SuccessOnlyInactive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithActiveConcurrency(0),
+				WithInactiveConcurrency(1),
+				WithSeenAccounts([]*AccountCurrency{accountCurrency}),
+				WithDebugLogging(),
+				WithInactiveFrequency(1),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				nil,
-				WithActiveConcurrency(0),
-				WithInactiveConcurrency(1),
-				WithSeenAccounts([]*AccountCurrency{accountCurrency}),
-				WithLookupBalanceByBlock(lookup),
-				WithInactiveFrequency(1),
-				WithDebugLogging(true),
+				opts...,
 			)
 			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)
@@ -1854,16 +1905,21 @@ func TestReconcile_FailureOnlyInactive(t *testing.T) {
 		t.Run(fmt.Sprintf("lookup balance by block %t", lookup), func(t *testing.T) {
 			mockHelper := &mocks.Helper{}
 			mockHandler := &mocks.Handler{}
+			opts := []Option{
+				WithActiveConcurrency(0),
+				WithInactiveConcurrency(1),
+				WithSeenAccounts([]*AccountCurrency{accountCurrency}),
+				WithDebugLogging(),
+				WithInactiveFrequency(1),
+			}
+			if lookup {
+				opts = append(opts, WithLookupBalanceByBlock())
+			}
 			r := New(
 				mockHelper,
 				mockHandler,
 				parser.New(nil, nil, nil),
-				WithActiveConcurrency(0),
-				WithInactiveConcurrency(1),
-				WithSeenAccounts([]*AccountCurrency{accountCurrency}),
-				WithLookupBalanceByBlock(lookup),
-				WithInactiveFrequency(1),
-				WithDebugLogging(true),
+				opts...,
 			)
 			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)
@@ -1919,13 +1975,16 @@ func TestReconcile_EnqueueCancel(t *testing.T) {
 
 	mockHelper := &mocks.Helper{}
 	mockHandler := &mocks.Handler{}
+	opts := []Option{
+		WithActiveConcurrency(1),
+		WithInactiveConcurrency(0),
+		WithLookupBalanceByBlock(),
+	}
 	r := New(
 		mockHelper,
 		mockHandler,
 		nil,
-		WithActiveConcurrency(1),
-		WithInactiveConcurrency(0),
-		WithLookupBalanceByBlock(true),
+		opts...,
 	)
 	ctx := context.Background()
 


### PR DESCRIPTION
This PR updates the reconciler to use the new historical balance lookup functionality exposed by `BalanceStorage`(#202).

### Changes
- [x] Update `ComputedBalance` interface
- [x] Remove `ErrAccountUpdated` error now that we can do historical state lookups (#202)
- [x] Optionally prune historical balance states after reconciliation
- [x] Make backlog configurable
- [x] Cleanup reconciler configs (default to false unless `Option` provided)