### PR TITLE
[storage] Balance Exemption Overhaul

### DIFF
--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -435,9 +435,24 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("balance exemption update", func(t *testing.T) {
-		mockHelper.AccountBalanceAmount = "0"
 		txn := storage.db.NewDatabaseTransaction(ctx, true)
-		err := storage.UpdateBalance(
+		err := storage.SetBalance(
+			ctx,
+			txn,
+			exemptionAccount,
+			&types.Amount{
+				Value:    "0",
+				Currency: exemptionCurrency,
+			},
+			genesisBlock,
+		)
+		assert.NoError(t, err)
+		assert.NoError(t, txn.Commit(ctx))
+
+		// Successful (balance > computed)
+		mockHelper.AccountBalanceAmount = "150"
+		txn = storage.db.NewDatabaseTransaction(ctx, true)
+		err = storage.UpdateBalance(
 			ctx,
 			txn,
 			&parser.BalanceChange{
@@ -458,10 +473,10 @@ func TestBalance(t *testing.T) {
 			newBlock,
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, amount.Value, retrievedAmount.Value)
+		assert.Equal(t, "150", retrievedAmount.Value)
 
 		// Successful (balance == computed)
-		mockHelper.AccountBalanceAmount = amount.Value
+		mockHelper.AccountBalanceAmount = "200"
 		txn = storage.db.NewDatabaseTransaction(ctx, true)
 		err = storage.UpdateBalance(
 			ctx,
@@ -484,33 +499,7 @@ func TestBalance(t *testing.T) {
 			newBlock3,
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, "150", retrievedAmount.Value)
-
-		// Successful (balance > computed)
-		mockHelper.AccountBalanceAmount = "200"
-		txn = storage.db.NewDatabaseTransaction(ctx, true)
-		err = storage.UpdateBalance(
-			ctx,
-			txn,
-			&parser.BalanceChange{
-				Account:    exemptionAccount,
-				Currency:   exemptionCurrency,
-				Block:      newBlock4,
-				Difference: "50",
-			},
-			nil,
-		)
-		assert.NoError(t, err)
-		assert.NoError(t, txn.Commit(ctx))
-
-		retrievedAmount, err = storage.GetBalance(
-			ctx,
-			exemptionAccount,
-			exemptionCurrency,
-			newBlock4,
-		)
-		assert.NoError(t, err)
-		assert.Equal(t, "250", retrievedAmount.Value)
+		assert.Equal(t, "200", retrievedAmount.Value)
 
 		// Unsuccessful (balance < computed)
 		mockHelper.AccountBalanceAmount = "10"
@@ -536,7 +525,7 @@ func TestBalance(t *testing.T) {
 			newBlock4,
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, "250", retrievedAmount.Value)
+		assert.Equal(t, "200", retrievedAmount.Value)
 		mockHelper.AccountBalanceAmount = ""
 	})
 

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -449,7 +449,7 @@ func TestBalance(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
-		// Successful (balance > computed)
+		// Successful (balance > computed and negative intermediate value)
 		mockHelper.AccountBalanceAmount = "150"
 		txn = storage.db.NewDatabaseTransaction(ctx, true)
 		err = storage.UpdateBalance(
@@ -459,7 +459,7 @@ func TestBalance(t *testing.T) {
 				Account:    exemptionAccount,
 				Currency:   exemptionCurrency,
 				Block:      newBlock,
-				Difference: amount.Value,
+				Difference: "-10",
 			},
 			nil,
 		)


### PR DESCRIPTION
Because many blockchains apply rewards after the parent block is processed (usually before transactions in the next block are applied), adjusting the computed balance to equal the live balance of the parent block before applying balance changes doesn't guarantee that a computed account balance won't go negative (if a transaction in the new block spends the new rewards). This PR modifies the balance exemption logic to compare the computed balance after applying operations but before being checked for a negative value.

### Changes
- [x] Compare computed balance with exemptions after new operations are applied
- [x] Add a negative intermediate value test