### PR TITLE
[storage] Concurrent Compression on Write

### DIFF
--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -449,7 +449,6 @@ func (b *BadgerTransaction) Scan(
 
 	entries := 0
 	opts := badger.DefaultIteratorOptions
-	opts.PrefetchValues = false
 	opts.Reverse = reverse
 	it := b.txn.NewIterator(opts)
 	defer it.Close()

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -155,7 +155,8 @@ func (b *BalanceStorage) AddingBlock(
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	for _, change := range changes {
+	for _, thisChange := range changes {
+		change := thisChange
 		g.Go(func() error {
 			return b.UpdateBalance(gctx, transaction, change, block.ParentBlockIdentifier)
 		})
@@ -182,7 +183,8 @@ func (b *BalanceStorage) RemovingBlock(
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	for _, change := range changes {
+	for _, thisChange := range changes {
+		change := thisChange
 		g.Go(func() error {
 			return b.OrphanBalance(gctx, transaction, change.Account, change.Currency, block.BlockIdentifier)
 		})

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -26,6 +26,8 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/reconciler"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"
+
+	"golang.org/x/sync/errgroup"
 )
 
 var _ BlockWorker = (*BalanceStorage)(nil)
@@ -152,10 +154,15 @@ func (b *BalanceStorage) AddingBlock(
 		return nil, fmt.Errorf("%w: unable to calculate balance changes", err)
 	}
 
+	g, gctx := errgroup.WithContext(ctx)
 	for _, change := range changes {
-		if err := b.UpdateBalance(ctx, transaction, change, block.ParentBlockIdentifier); err != nil {
-			return nil, err
-		}
+		g.Go(func() error {
+			return b.UpdateBalance(gctx, transaction, change, block.ParentBlockIdentifier)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	return func(ctx context.Context) error {
@@ -174,10 +181,15 @@ func (b *BalanceStorage) RemovingBlock(
 		return nil, fmt.Errorf("%w: unable to calculate balance changes", err)
 	}
 
+	g, gctx := errgroup.WithContext(ctx)
 	for _, change := range changes {
-		if err := b.OrphanBalance(ctx, transaction, change.Account, change.Currency, block.BlockIdentifier); err != nil {
-			return nil, err
-		}
+		g.Go(func() error {
+			return b.OrphanBalance(gctx, transaction, change.Account, change.Currency, block.BlockIdentifier)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	return func(ctx context.Context) error {

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -186,7 +186,13 @@ func (b *BalanceStorage) RemovingBlock(
 	for _, thisChange := range changes {
 		change := thisChange
 		g.Go(func() error {
-			return b.OrphanBalance(gctx, transaction, change.Account, change.Currency, block.BlockIdentifier)
+			return b.OrphanBalance(
+				gctx,
+				transaction,
+				change.Account,
+				change.Currency,
+				block.BlockIdentifier,
+			)
 		})
 	}
 

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -155,8 +155,11 @@ func (b *BalanceStorage) AddingBlock(
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	for _, thisChange := range changes {
-		change := thisChange
+	for i := range changes {
+		// We need to set variable before calling goroutine
+		// to avoid getting an updated pointer as loop iteration
+		// continues.
+		change := changes[i]
 		g.Go(func() error {
 			return b.UpdateBalance(gctx, transaction, change, block.ParentBlockIdentifier)
 		})
@@ -183,8 +186,11 @@ func (b *BalanceStorage) RemovingBlock(
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	for _, thisChange := range changes {
-		change := thisChange
+	for i := range changes {
+		// We need to set variable before calling goroutine
+		// to avoid getting an updated pointer as loop iteration
+		// continues.
+		change := changes[i]
 		g.Go(func() error {
 			return b.OrphanBalance(
 				gctx,

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -663,7 +663,12 @@ func (b *BlockStorage) RemoveBlock(
 	for _, thisTransaction := range block.Transactions {
 		txn := thisTransaction
 		g.Go(func() error {
-			return b.removeTransaction(gctx, transaction, blockIdentifier, txn.TransactionIdentifier)
+			return b.removeTransaction(
+				gctx,
+				transaction,
+				blockIdentifier,
+				txn.TransactionIdentifier,
+			)
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -840,10 +840,10 @@ func (b *BlockStorage) storeTransaction(
 	if !exists {
 		blocks = make(map[string]*blockTransaction)
 	} else {
-		if err := b.db.Encoder().Decode(namespace, val, &blocks, true); err != nil {
+		err := b.db.Encoder().Decode(namespace, val, &blocks, true)
+		if err != nil {
 			return fmt.Errorf("%w: could not decode transaction hash contents", err)
 		}
-
 	}
 	// We check for duplicates before storing transaction,
 	// so this must be a new key.

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -580,7 +580,8 @@ func (b *BlockStorage) AddBlock(
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	for _, txn := range block.Transactions {
+	for _, thisTransaction := range block.Transactions {
+		txn := thisTransaction
 		g.Go(func() error {
 			err := b.storeTransaction(
 				gctx,
@@ -659,7 +660,8 @@ func (b *BlockStorage) RemoveBlock(
 
 	// Remove all transaction hashes
 	g, gctx := errgroup.WithContext(ctx)
-	for _, txn := range block.Transactions {
+	for _, thisTransaction := range block.Transactions {
+		txn := thisTransaction
 		g.Go(func() error {
 			return b.removeTransaction(gctx, transaction, blockIdentifier, txn.TransactionIdentifier)
 		})

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -580,8 +580,11 @@ func (b *BlockStorage) AddBlock(
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	for _, thisTransaction := range block.Transactions {
-		txn := thisTransaction
+	for i := range block.Transactions {
+		// We need to set variable before calling goroutine
+		// to avoid getting an updated pointer as loop iteration
+		// continues.
+		txn := block.Transactions[i]
 		g.Go(func() error {
 			err := b.storeTransaction(
 				gctx,
@@ -660,8 +663,11 @@ func (b *BlockStorage) RemoveBlock(
 
 	// Remove all transaction hashes
 	g, gctx := errgroup.WithContext(ctx)
-	for _, thisTransaction := range block.Transactions {
-		txn := thisTransaction
+	for i := range block.Transactions {
+		// We need to set variable before calling goroutine
+		// to avoid getting an updated pointer as loop iteration
+		// continues.
+		txn := block.Transactions[i]
 		g.Go(func() error {
 			return b.removeTransaction(
 				gctx,

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -529,7 +529,6 @@ func TestBlock(t *testing.T) {
 
 	t.Run("Set duplicate transaction hash (same block)", func(t *testing.T) {
 		err = storage.AddBlock(ctx, duplicateTxBlock)
-		fmt.Println(err)
 		assert.Contains(t, err.Error(), ErrDuplicateTransactionHash.Error())
 
 		head, err := storage.GetHeadBlockIdentifier(ctx)

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -529,6 +529,7 @@ func TestBlock(t *testing.T) {
 
 	t.Run("Set duplicate transaction hash (same block)", func(t *testing.T) {
 		err = storage.AddBlock(ctx, duplicateTxBlock)
+		fmt.Println(err)
 		assert.Contains(t, err.Error(), ErrDuplicateTransactionHash.Error())
 
 		head, err := storage.GetHeadBlockIdentifier(ctx)

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -271,7 +271,7 @@ func (c *CoinStorage) skipOperation(
 // Alternatively, we could add all coins to the database
 // (regardless of whether they are spent in the same block),
 // however, this would put a larger strain on the db.
-func (c *CoinStorage) updateCoins(
+func (c *CoinStorage) updateCoins( // nolint:gocognit
 	ctx context.Context,
 	block *types.Block,
 	addCoinCreated bool,

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -307,14 +307,15 @@ func (c *CoinStorage) updateCoins( // nolint:gocognit
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	for identifier, thisOp := range addCoins {
+	for identifier, val := range addCoins {
 		if _, ok := removeCoins[identifier]; ok {
 			continue
 		}
 
-		// Need to copy pointer, otherwise will use whatever
-		// item op is currently assigned to.
-		op := thisOp
+		// We need to set variable before calling goroutine
+		// to avoid getting an updated pointer as loop iteration
+		// continues.
+		op := val
 		g.Go(func() error {
 			if err := c.addCoin(
 				gctx,
@@ -332,14 +333,15 @@ func (c *CoinStorage) updateCoins( // nolint:gocognit
 		})
 	}
 
-	for identifier, thisOp := range removeCoins {
+	for identifier, val := range removeCoins {
 		if _, ok := addCoins[identifier]; ok {
 			continue
 		}
 
-		// Need to copy pointer, otherwise will use whatever
-		// item op is currently assigned to.
-		op := thisOp
+		// We need to set variable before calling goroutine
+		// to avoid getting an updated pointer as loop iteration
+		// continues.
+		op := val
 		g.Go(func() error {
 			if err := c.removeCoin(
 				gctx,

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -307,11 +307,14 @@ func (c *CoinStorage) updateCoins( // nolint:gocognit
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	for identifier, op := range addCoins {
+	for identifier, thisOp := range addCoins {
 		if _, ok := removeCoins[identifier]; ok {
 			continue
 		}
 
+		// Need to copy pointer, otherwise will use whatever
+		// item op is currently assigned to.
+		op := thisOp
 		g.Go(func() error {
 			if err := c.addCoin(
 				gctx,
@@ -329,14 +332,17 @@ func (c *CoinStorage) updateCoins( // nolint:gocognit
 		})
 	}
 
-	for identifier, op := range removeCoins {
+	for identifier, thisOp := range removeCoins {
 		if _, ok := addCoins[identifier]; ok {
 			continue
 		}
 
+		// Need to copy pointer, otherwise will use whatever
+		// item op is currently assigned to.
+		op := thisOp
 		g.Go(func() error {
 			if err := c.removeCoin(
-				ctx,
+				gctx,
 				op.Account,
 				op.CoinChange.CoinIdentifier,
 				dbTx,


### PR DESCRIPTION
This PR updates the `storage` package to perform concurrent compression of items on write instead of performing compression serially. In practice, this can increase the **sync speed by 5-10x** (usually increasing even more if using a more powerful CPU).

### Changelog
- [x] Protect `DatabaseTransaction` from concurrent writes using `RWMutex`
- [x] Use default scan options instead of disabling value prefetch
- [x] Concurrent compression for `BalanceStorage`
- [x] Concurrent compression for `CoinStorage`
- [x] Concurrent compression for `BlockStorage`