### PR TITLE
[parser/storage] Orphan Block Pointer Overwrite

### DIFF
--- a/parser/balance_changes.go
+++ b/parser/balance_changes.go
@@ -88,14 +88,17 @@ func (p *Parser) BalanceChanges(
 				continue
 			}
 
-			amount := op.Amount
+			// We create a copy of Amount.Value
+			// here to ensure we don't accidentally overwrite
+			// the value of op.Amount.
+			amountValue := op.Amount.Value
 			blockIdentifier := block.BlockIdentifier
 			if blockRemoved {
-				negatedValue, err := types.NegateValue(amount.Value)
+				negatedValue, err := types.NegateValue(amountValue)
 				if err != nil {
 					return nil, err
 				}
-				amount.Value = negatedValue
+				amountValue = negatedValue
 				blockIdentifier = block.ParentBlockIdentifier
 			}
 
@@ -111,13 +114,13 @@ func (p *Parser) BalanceChanges(
 				balanceChanges[key] = &BalanceChange{
 					Account:    op.Account,
 					Currency:   op.Amount.Currency,
-					Difference: amount.Value,
+					Difference: amountValue,
 					Block:      blockIdentifier,
 				}
 				continue
 			}
 
-			newDifference, err := types.AddValues(val.Difference, amount.Value)
+			newDifference, err := types.AddValues(val.Difference, amountValue)
 			if err != nil {
 				return nil, err
 			}

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -454,6 +454,8 @@ func (b *BalanceStorage) OrphanBalance(
 	currency *types.Currency,
 	block *types.BlockIdentifier,
 ) error {
+	// TODO: remove account record in the case that orphaned
+	// so that we don't accidentally delete fetched record
 	return b.removeHistoricalBalances(
 		ctx,
 		dbTransaction,

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -1213,7 +1213,11 @@ func TestBlockSyncing(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	mockHelper := &MockBalanceStorageHelper{}
+	mockHelper := &MockBalanceStorageHelper{
+		AccountBalances: map[string]string{
+			"addr1": "1",
+		},
+	}
 	storage := NewBalanceStorage(database)
 	storage.Initialize(mockHelper, nil)
 
@@ -1404,7 +1408,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "100",
+			Value:    "101",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
@@ -1427,7 +1431,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "100",
+			Value:    "101",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
@@ -1439,7 +1443,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "49",
+			Value:    "50",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
@@ -1465,7 +1469,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "100",
+			Value:    "101",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
@@ -1477,7 +1481,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "100",
+			Value:    "101",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
@@ -1541,7 +1545,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "100",
+			Value:    "101",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
@@ -1553,7 +1557,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "100",
+			Value:    "101",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
@@ -1579,7 +1583,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "100",
+			Value:    "101",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
@@ -1591,7 +1595,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "0",
+			Value:    "1",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -1473,11 +1473,8 @@ func TestBlockSyncing(t *testing.T) {
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
@@ -1485,11 +1482,8 @@ func TestBlockSyncing(t *testing.T) {
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 	})
 
 	t.Run("orphan block 1", func(t *testing.T) {
@@ -1499,35 +1493,23 @@ func TestBlockSyncing(t *testing.T) {
 		assert.NoError(t, dbTx.Commit(ctx))
 
 		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b0.BlockIdentifier.Index)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 	})
 
 	t.Run("add block 1", func(t *testing.T) {
@@ -1549,11 +1531,8 @@ func TestBlockSyncing(t *testing.T) {
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
@@ -1561,11 +1540,8 @@ func TestBlockSyncing(t *testing.T) {
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
-		assert.NoError(t, err)
-		assert.Equal(t, &types.Amount{
-			Value:    "0",
-			Currency: curr,
-		}, amount)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
 	})
 
 	t.Run("add block 2a", func(t *testing.T) {

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -1553,7 +1553,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "0",
+			Value:    "100",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -1313,6 +1313,18 @@ func TestBlockSyncing(t *testing.T) {
 							Currency: curr,
 						},
 					},
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 2,
+						},
+						Account: addr1,
+						Status:  "Success",
+						Type:    "Transfer",
+						Amount: &types.Amount{
+							Value:    "-1",
+							Currency: curr,
+						},
+					},
 				},
 			},
 		},
@@ -1427,7 +1439,7 @@ func TestBlockSyncing(t *testing.T) {
 		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
-			Value:    "50",
+			Value:    "49",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
@@ -1466,6 +1478,82 @@ func TestBlockSyncing(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, &types.Amount{
 			Value:    "100",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+	})
+
+	t.Run("orphan block 1", func(t *testing.T) {
+		dbTx := database.NewDatabaseTransaction(ctx, true)
+		_, err = storage.RemovingBlock(ctx, b1, dbTx)
+		assert.NoError(t, err)
+		assert.NoError(t, dbTx.Commit(ctx))
+
+		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+	})
+
+	t.Run("add block 1", func(t *testing.T) {
+		dbTx := database.NewDatabaseTransaction(ctx, true)
+		_, err = storage.AddingBlock(ctx, b1, dbTx)
+		assert.NoError(t, err)
+		assert.NoError(t, dbTx.Commit(ctx))
+
+		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "100",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
 			Currency: curr,
 		}, amount)
 		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -1202,6 +1202,319 @@ func TestBalanceReconciliation(t *testing.T) {
 	})
 }
 
+func TestBlockSyncing(t *testing.T) {
+	ctx := context.Background()
+
+	newDir, err := utils.CreateTempDir()
+	assert.NoError(t, err)
+	defer utils.RemoveTempDir(newDir)
+
+	database, err := newTestBadgerStorage(ctx, newDir)
+	assert.NoError(t, err)
+	defer database.Close(ctx)
+
+	mockHelper := &MockBalanceStorageHelper{}
+	storage := NewBalanceStorage(database)
+	storage.Initialize(mockHelper, nil)
+
+	// Genesis block with no transactions
+	b0 := &types.Block{
+		BlockIdentifier: &types.BlockIdentifier{
+			Index: 0,
+			Hash:  "0",
+		},
+		ParentBlockIdentifier: &types.BlockIdentifier{
+			Index: 0,
+			Hash:  "0",
+		},
+	}
+
+	addr1 := &types.AccountIdentifier{
+		Address: "addr1",
+	}
+	addr2 := &types.AccountIdentifier{
+		Address: "addr2",
+	}
+	curr := &types.Currency{
+		Symbol:   "ETH",
+		Decimals: 18,
+	}
+
+	// Block 1 with transaction
+	b1 := &types.Block{
+		BlockIdentifier: &types.BlockIdentifier{
+			Index: 1,
+			Hash:  "1",
+		},
+		ParentBlockIdentifier: &types.BlockIdentifier{
+			Index: 0,
+			Hash:  "0",
+		},
+		Transactions: []*types.Transaction{
+			{
+				TransactionIdentifier: &types.TransactionIdentifier{
+					Hash: "1_0",
+				},
+				Operations: []*types.Operation{
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 0,
+						},
+						Account: addr1,
+						Status:  "Success",
+						Type:    "Transfer",
+						Amount: &types.Amount{
+							Value:    "100",
+							Currency: curr,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Another Transaction for some acocunt in Block 1
+	b2 := &types.Block{
+		BlockIdentifier: &types.BlockIdentifier{
+			Index: 2,
+			Hash:  "2",
+		},
+		ParentBlockIdentifier: &types.BlockIdentifier{
+			Index: 1,
+			Hash:  "1",
+		},
+		Transactions: []*types.Transaction{
+			{
+				TransactionIdentifier: &types.TransactionIdentifier{
+					Hash: "2_0",
+				},
+				Operations: []*types.Operation{
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 0,
+						},
+						Account: addr1,
+						Status:  "Success",
+						Type:    "Transfer",
+						Amount: &types.Amount{
+							Value:    "-50",
+							Currency: curr,
+						},
+					},
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 1,
+						},
+						Account: addr2,
+						Status:  "Success",
+						Type:    "Transfer",
+						Amount: &types.Amount{
+							Value:    "50",
+							Currency: curr,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Orphaned block with slightly different tx
+	b2a := &types.Block{
+		BlockIdentifier: &types.BlockIdentifier{
+			Index: 2,
+			Hash:  "2a",
+		},
+		ParentBlockIdentifier: &types.BlockIdentifier{
+			Index: 1,
+			Hash:  "1",
+		},
+		Transactions: []*types.Transaction{
+			{
+				TransactionIdentifier: &types.TransactionIdentifier{
+					Hash: "2_0",
+				},
+				Operations: []*types.Operation{
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 0,
+						},
+						Account: addr1,
+						Status:  "Success",
+						Type:    "Transfer",
+						Amount: &types.Amount{
+							Value:    "-100",
+							Currency: curr,
+						},
+					},
+					{
+						OperationIdentifier: &types.OperationIdentifier{
+							Index: 1,
+						},
+						Account: addr2,
+						Status:  "Success",
+						Type:    "Transfer",
+						Amount: &types.Amount{
+							Value:    "100",
+							Currency: curr,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("add genesis block", func(t *testing.T) {
+		dbTx := database.NewDatabaseTransaction(ctx, true)
+		_, err = storage.AddingBlock(ctx, b0, dbTx)
+		assert.NoError(t, err)
+		assert.NoError(t, dbTx.Commit(ctx))
+
+		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b0.BlockIdentifier.Index)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
+	})
+
+	t.Run("add block 1", func(t *testing.T) {
+		dbTx := database.NewDatabaseTransaction(ctx, true)
+		_, err = storage.AddingBlock(ctx, b1, dbTx)
+		assert.NoError(t, err)
+		assert.NoError(t, dbTx.Commit(ctx))
+
+		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "100",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
+		assert.True(t, errors.Is(err, ErrAccountMissing))
+		assert.Nil(t, amount)
+	})
+
+	t.Run("add block 2", func(t *testing.T) {
+		dbTx := database.NewDatabaseTransaction(ctx, true)
+		_, err = storage.AddingBlock(ctx, b2, dbTx)
+		assert.NoError(t, err)
+		assert.NoError(t, dbTx.Commit(ctx))
+
+		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "100",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "50",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "50",
+			Currency: curr,
+		}, amount)
+	})
+
+	t.Run("orphan block 2", func(t *testing.T) {
+		dbTx := database.NewDatabaseTransaction(ctx, true)
+		_, err = storage.RemovingBlock(ctx, b2, dbTx)
+		assert.NoError(t, err)
+		assert.NoError(t, dbTx.Commit(ctx))
+
+		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "100",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "100",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+	})
+
+	t.Run("add block 2a", func(t *testing.T) {
+		dbTx := database.NewDatabaseTransaction(ctx, true)
+		_, err = storage.AddingBlock(ctx, b2a, dbTx)
+		assert.NoError(t, err)
+		assert.NoError(t, dbTx.Commit(ctx))
+
+		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "100",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b1.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr1, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "0",
+			Currency: curr,
+		}, amount)
+		amount, err = storage.GetBalance(ctx, addr2, curr, b2.BlockIdentifier.Index)
+		assert.NoError(t, err)
+		assert.Equal(t, &types.Amount{
+			Value:    "100",
+			Currency: curr,
+		}, amount)
+	})
+}
+
 var _ BalanceStorageHelper = (*MockBalanceStorageHelper)(nil)
 
 type MockBalanceStorageHelper struct {


### PR DESCRIPTION
This PR fixes an issue where the `parser` can cause a negative balance error when handling a block re-org.

### Changes
- [x] Update `parser` to copy variable instead of modifying in-place
- [x] Delete account balance record when all balances are removed (to ensure balance can be re-fetched if necessary)
- [x] Add tests of `AddingBlock` and `RemovingBlock` for `BalanceStorage