### PR TITLE
[reconciler] Skip on Live Balance Fetch Errors at Tip

### DIFF
--- a/mocks/reconciler/helper.go
+++ b/mocks/reconciler/helper.go
@@ -17,6 +17,27 @@ type Helper struct {
 	mock.Mock
 }
 
+// AtTip provides a mock function with given fields: ctx
+func (_m *Helper) AtTip(ctx context.Context) (bool, error) {
+	ret := _m.Called(ctx)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CanonicalBlock provides a mock function with given fields: ctx, dbTx, block
 func (_m *Helper) CanonicalBlock(ctx context.Context, dbTx storage.DatabaseTransaction, block *types.BlockIdentifier) (bool, error) {
 	ret := _m.Called(ctx, dbTx, block)

--- a/mocks/reconciler/helper.go
+++ b/mocks/reconciler/helper.go
@@ -17,27 +17,6 @@ type Helper struct {
 	mock.Mock
 }
 
-// AtTip provides a mock function with given fields: ctx
-func (_m *Helper) AtTip(ctx context.Context) (bool, error) {
-	ret := _m.Called(ctx)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // CanonicalBlock provides a mock function with given fields: ctx, dbTx, block
 func (_m *Helper) CanonicalBlock(ctx context.Context, dbTx storage.DatabaseTransaction, block *types.BlockIdentifier) (bool, error) {
 	ret := _m.Called(ctx, dbTx, block)
@@ -119,6 +98,27 @@ func (_m *Helper) DatabaseTransaction(ctx context.Context) storage.DatabaseTrans
 	}
 
 	return r0
+}
+
+// IndexAtTip provides a mock function with given fields: ctx, index
+func (_m *Helper) IndexAtTip(ctx context.Context, index int64) (bool, error) {
+	ret := _m.Called(ctx, index)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, int64) bool); ok {
+		r0 = rf(ctx, index)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = rf(ctx, index)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // LiveBalance provides a mock function with given fields: ctx, account, currency, index

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -873,7 +873,7 @@ func (r *Reconciler) shouldAttemptInactiveReconciliation(
 // from all previously seen accounts and reconciles
 // the balance. This is useful for detecting balance
 // changes that were not returned in operations.
-func (r *Reconciler) reconcileInactiveAccounts(
+func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 	ctx context.Context,
 ) error {
 	for {

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -116,8 +116,9 @@ type Helper interface {
 		dbTx storage.DatabaseTransaction,
 	) (*types.BlockIdentifier, error)
 
-	AtTip(
+	IndexAtTip(
 		ctx context.Context,
+		index int64,
 	) (bool, error)
 
 	CanonicalBlock(
@@ -791,7 +792,7 @@ func (r *Reconciler) reconcileActiveAccounts(ctx context.Context) error { // nol
 					return err
 				}
 
-				tip, tErr := r.helper.AtTip(ctx)
+				tip, tErr := r.helper.IndexAtTip(ctx, balanceChange.Block.Index)
 				switch {
 				case tErr == nil && tip:
 					if err := r.handler.ReconciliationSkipped(
@@ -922,7 +923,7 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 					return err
 				}
 
-				tip, tErr := r.helper.AtTip(ctx)
+				tip, tErr := r.helper.IndexAtTip(ctx, head.Index)
 				switch {
 				case tErr == nil && tip:
 					if err := r.handler.ReconciliationSkipped(

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -53,12 +53,12 @@ const (
 	// BacklogFull is when the reconciliation backlog is full.
 	BacklogFull = "BACKLOG_FULL"
 
-	// TransientFailure is returned when looking up the live
+	// TipFailure is returned when looking up the live
 	// balance fails but we are at tip. This usually occurs
 	// when the node processes an re-org that we have yet
 	// to process (so the index we are querying at may be
 	// ahead of the nodes tip).
-	TransientFailure = "TRANSIENT_FAILURE"
+	TipFailure = "TIP_FAILURE"
 )
 
 const (
@@ -799,7 +799,7 @@ func (r *Reconciler) reconcileActiveAccounts(ctx context.Context) error { // nol
 						ActiveReconciliation,
 						balanceChange.Account,
 						balanceChange.Currency,
-						TransientFailure,
+						TipFailure,
 					); err != nil {
 						return err
 					}
@@ -930,7 +930,7 @@ func (r *Reconciler) reconcileInactiveAccounts(
 						InactiveReconciliation,
 						nextAcct.Entry.Account,
 						nextAcct.Entry.Currency,
-						TransientFailure,
+						TipFailure,
 					); err != nil {
 						return err
 					}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -2277,3 +2277,67 @@ func TestReconcile_ActiveAtTipError(t *testing.T) {
 	mockHelper.AssertExpectations(t)
 	mockHandler.AssertExpectations(t)
 }
+
+func TestReconcile_ActiveNotAtTipError(t *testing.T) {
+	var (
+		block = &types.BlockIdentifier{
+			Hash:  "block 1",
+			Index: 1,
+		}
+		accountCurrency = &types.AccountCurrency{
+			Account: &types.AccountIdentifier{
+				Address: "addr 1",
+			},
+			Currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+		}
+	)
+
+	mockHelper := &mocks.Helper{}
+	mockHandler := &mocks.Handler{}
+	r := New(
+		mockHelper,
+		mockHandler,
+		nil,
+		WithActiveConcurrency(1),
+		WithInactiveConcurrency(0),
+		WithLookupBalanceByBlock(),
+	)
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+
+	mockHelper.On(
+		"LiveBalance",
+		mock.Anything,
+		accountCurrency.Account,
+		accountCurrency.Currency,
+		int64(1),
+	).Return(
+		nil,
+		nil,
+		errors.New("blah"),
+	).Once()
+	mockHelper.On("AtTip", mock.Anything).Return(false, nil).Once()
+
+	go func() {
+		err := r.Reconcile(ctx)
+		assert.True(t, errors.Is(err, ErrLiveBalanceLookupFailed))
+	}()
+
+	err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
+		{
+			Account:  accountCurrency.Account,
+			Currency: accountCurrency.Currency,
+			Block:    block,
+		},
+	})
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+	cancel()
+
+	mockHelper.AssertExpectations(t)
+	mockHandler.AssertExpectations(t)
+}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -2206,7 +2206,7 @@ func TestReconcile_EnqueueCancel(t *testing.T) {
 	mockHandler.AssertExpectations(t)
 }
 
-func TestReconcile_ActiveAtTipError(t *testing.T) {
+func TestReconcile_ActiveIndexAtTipError(t *testing.T) {
 	var (
 		block = &types.BlockIdentifier{
 			Hash:  "block 1",
@@ -2247,7 +2247,7 @@ func TestReconcile_ActiveAtTipError(t *testing.T) {
 		nil,
 		errors.New("blah"),
 	).Once()
-	mockHelper.On("AtTip", mock.Anything).Return(true, nil).Once()
+	mockHelper.On("IndexAtTip", mock.Anything, int64(1)).Return(true, nil).Once()
 	mockHandler.On(
 		"ReconciliationSkipped",
 		mock.Anything,
@@ -2278,7 +2278,7 @@ func TestReconcile_ActiveAtTipError(t *testing.T) {
 	mockHandler.AssertExpectations(t)
 }
 
-func TestReconcile_ActiveNotAtTipError(t *testing.T) {
+func TestReconcile_ActiveNotIndexAtTipError(t *testing.T) {
 	var (
 		block = &types.BlockIdentifier{
 			Hash:  "block 1",
@@ -2319,7 +2319,7 @@ func TestReconcile_ActiveNotAtTipError(t *testing.T) {
 		nil,
 		errors.New("blah"),
 	).Once()
-	mockHelper.On("AtTip", mock.Anything).Return(false, nil).Once()
+	mockHelper.On("IndexAtTip", mock.Anything, int64(1)).Return(false, nil).Once()
 
 	go func() {
 		err := r.Reconcile(ctx)
@@ -2342,7 +2342,7 @@ func TestReconcile_ActiveNotAtTipError(t *testing.T) {
 	mockHandler.AssertExpectations(t)
 }
 
-func TestReconcile_ActiveErrorAtTipError(t *testing.T) {
+func TestReconcile_ActiveErrorIndexAtTipError(t *testing.T) {
 	var (
 		block = &types.BlockIdentifier{
 			Hash:  "block 1",
@@ -2383,7 +2383,7 @@ func TestReconcile_ActiveErrorAtTipError(t *testing.T) {
 		nil,
 		errors.New("blah"),
 	).Once()
-	mockHelper.On("AtTip", mock.Anything).Return(false, errors.New("blazz")).Once()
+	mockHelper.On("IndexAtTip", mock.Anything, int64(1)).Return(false, errors.New("blazz")).Once()
 
 	go func() {
 		err := r.Reconcile(ctx)
@@ -2406,7 +2406,7 @@ func TestReconcile_ActiveErrorAtTipError(t *testing.T) {
 	mockHandler.AssertExpectations(t)
 }
 
-func TestReconcile_FailureAtTipInactive(t *testing.T) {
+func TestReconcile_FailureIndexAtTipInactive(t *testing.T) {
 	var (
 		block = &types.BlockIdentifier{
 			Hash:  "block 1",
@@ -2458,7 +2458,7 @@ func TestReconcile_FailureAtTipInactive(t *testing.T) {
 		nil,
 		errors.New("blah"),
 	).Once()
-	mockHelper.On("AtTip", mock.Anything).Return(true, nil).Once()
+	mockHelper.On("IndexAtTip", mock.Anything, int64(1)).Return(true, nil).Once()
 	mockHandler.On(
 		"ReconciliationSkipped",
 		mock.Anything,
@@ -2483,7 +2483,7 @@ func TestReconcile_FailureAtTipInactive(t *testing.T) {
 	mtxn.AssertExpectations(t)
 }
 
-func TestReconcile_FailureNotAtTipInactive(t *testing.T) {
+func TestReconcile_FailureNotIndexAtTipInactive(t *testing.T) {
 	var (
 		block = &types.BlockIdentifier{
 			Hash:  "block 1",
@@ -2534,7 +2534,7 @@ func TestReconcile_FailureNotAtTipInactive(t *testing.T) {
 		nil,
 		errors.New("blah"),
 	).Once()
-	mockHelper.On("AtTip", mock.Anything).Return(false, nil).Once()
+	mockHelper.On("IndexAtTip", mock.Anything, int64(1)).Return(false, nil).Once()
 
 	go func() {
 		err := r.Reconcile(ctx)
@@ -2547,7 +2547,7 @@ func TestReconcile_FailureNotAtTipInactive(t *testing.T) {
 	mtxn.AssertExpectations(t)
 }
 
-func TestReconcile_FailureErrorAtTipInactive(t *testing.T) {
+func TestReconcile_FailureErrorIndexAtTipInactive(t *testing.T) {
 	var (
 		block = &types.BlockIdentifier{
 			Hash:  "block 1",
@@ -2598,7 +2598,7 @@ func TestReconcile_FailureErrorAtTipInactive(t *testing.T) {
 		nil,
 		errors.New("blah"),
 	).Once()
-	mockHelper.On("AtTip", mock.Anything).Return(false, errors.New("blah")).Once()
+	mockHelper.On("IndexAtTip", mock.Anything, int64(1)).Return(false, errors.New("blah")).Once()
 
 	go func() {
 		err := r.Reconcile(ctx)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -2205,3 +2205,75 @@ func TestReconcile_EnqueueCancel(t *testing.T) {
 	mockHelper.AssertExpectations(t)
 	mockHandler.AssertExpectations(t)
 }
+
+func TestReconcile_ActiveAtTipError(t *testing.T) {
+	var (
+		block = &types.BlockIdentifier{
+			Hash:  "block 1",
+			Index: 1,
+		}
+		accountCurrency = &types.AccountCurrency{
+			Account: &types.AccountIdentifier{
+				Address: "addr 1",
+			},
+			Currency: &types.Currency{
+				Symbol:   "BTC",
+				Decimals: 8,
+			},
+		}
+	)
+
+	mockHelper := &mocks.Helper{}
+	mockHandler := &mocks.Handler{}
+	r := New(
+		mockHelper,
+		mockHandler,
+		nil,
+		WithActiveConcurrency(1),
+		WithInactiveConcurrency(0),
+		WithLookupBalanceByBlock(),
+	)
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+
+	mockHelper.On(
+		"LiveBalance",
+		mock.Anything,
+		accountCurrency.Account,
+		accountCurrency.Currency,
+		int64(1),
+	).Return(
+		nil,
+		nil,
+		errors.New("blah"),
+	).Once()
+	mockHelper.On("AtTip", mock.Anything).Return(true, nil).Once()
+	mockHandler.On(
+		"ReconciliationSkipped",
+		mock.Anything,
+		ActiveReconciliation,
+		accountCurrency.Account,
+		accountCurrency.Currency,
+		TipFailure,
+	).Return(nil).Once()
+
+	go func() {
+		err := r.Reconcile(ctx)
+		assert.True(t, errors.Is(err, context.Canceled))
+	}()
+
+	err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
+		{
+			Account:  accountCurrency.Account,
+			Currency: accountCurrency.Currency,
+			Block:    block,
+		},
+	})
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+	cancel()
+
+	mockHelper.AssertExpectations(t)
+	mockHandler.AssertExpectations(t)
+}

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -1103,11 +1103,7 @@ func (b *BlockStorage) IndexAtTip(
 	// tip.
 	headBlock := headBlockResponse.Block
 	if headBlock.BlockIdentifier.Index < index {
-		if utils.AtTip(tipDelay, headBlock.Timestamp) {
-			return true, nil
-		}
-
-		return false, nil
+		return utils.AtTip(tipDelay, headBlock.Timestamp), nil
 	}
 
 	// Query block at index
@@ -1121,10 +1117,5 @@ func (b *BlockStorage) IndexAtTip(
 	}
 	block := blockResponse.Block
 
-	atTip := utils.AtTip(tipDelay, block.Timestamp)
-	if !atTip {
-		return false, nil
-	}
-
-	return true, nil
+	return utils.AtTip(tipDelay, block.Timestamp), nil
 }

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -792,6 +792,10 @@ func TestAtTip(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, atTip)
 		assert.Nil(t, blockIdentifier)
+
+		atTip, err = storage.IndexAtTip(ctx, tipDelay, 1)
+		assert.NoError(t, err)
+		assert.False(t, atTip)
 	})
 
 	t.Run("Add old block", func(t *testing.T) {
@@ -812,6 +816,10 @@ func TestAtTip(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, atTip)
 		assert.Nil(t, blockIdentifier)
+
+		atTip, err = storage.IndexAtTip(ctx, tipDelay, 1)
+		assert.NoError(t, err)
+		assert.False(t, atTip)
 	})
 
 	t.Run("Add new block", func(t *testing.T) {
@@ -835,5 +843,13 @@ func TestAtTip(t *testing.T) {
 			Hash:  "block 1",
 			Index: 1,
 		}, blockIdentifier)
+
+		atTip, err = storage.IndexAtTip(ctx, tipDelay, 1)
+		assert.NoError(t, err)
+		assert.True(t, atTip)
+
+		atTip, err = storage.IndexAtTip(ctx, tipDelay, 2)
+		assert.NoError(t, err)
+		assert.True(t, atTip)
 	})
 }


### PR DESCRIPTION
It is possible that the `reconciler` could query an account balance at an index not known to a Rosetta implementation if any balance queries are made before the `syncer` processes a node re-org. This PR ensures we treat these as "skipped" reconciliations instead of failures.

If a failure occurs because of some re-org (and we are querying balance at an index ahead of tip), we will retry the skipped reconciliation when the balance changes from the replacement blocks are added.

### Changes
- [x] Add `IndexAtTip` to `ReconcilerHelper`
- [x] Skip reconciliation if balance fetch fails at tip
- [x] Add `IndexAtTip` to `BlockStorage`