### PR TITLE
[reconciler] Fix Pruning Race

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -112,13 +112,11 @@ func (r *Reconciler) addToqueueMap(
 	acctCurrency *types.AccountCurrency,
 	index int64,
 ) {
-	r.queueMapMutex.Lock()
 	key := types.Hash(acctCurrency)
+
+	r.queueMapMutex.Lock()
 	if _, ok := r.queueMap[key]; !ok {
 		r.queueMap[key] = map[int64]int{}
-	}
-	if _, ok := r.queueMap[key][index]; !ok {
-		r.queueMap[key][index] = 0
 	}
 	r.queueMap[key][index]++
 	r.queueMapMutex.Unlock()
@@ -575,12 +573,12 @@ func (r *Reconciler) updateQueueMapAndPrune(
 	ctx context.Context,
 	change *parser.BalanceChange,
 ) error {
-	r.queueMapMutex.Lock()
-
 	key := types.Hash(&types.AccountCurrency{
 		Account:  change.Account,
 		Currency: change.Currency,
 	})
+
+	r.queueMapMutex.Lock()
 	r.queueMap[key][change.Block.Index]--
 	if r.queueMap[key][change.Block.Index] > 0 {
 		r.queueMapMutex.Unlock()

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -101,7 +101,7 @@ const (
 	// safeBalancePruneDepth is the depth from the last balance
 	// change that we consider safe to prune. We are very conservative
 	// here to prevent removing balances we may need in a reorg.
-	safeBalancePruneDepth = int64(100) // nolint:gomnd
+	safeBalancePruneDepth = int64(500) // nolint:gomnd
 )
 
 // Helper functions are used by Reconciler to compare

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -790,6 +790,7 @@ func (r *Reconciler) removeAndPrune(
 		return nil
 	}
 
+	// Cleanup indexes when we don't need them anymore
 	delete(r.pruneMap[key], change.Block.Index)
 
 	// Sort indexes
@@ -806,7 +807,10 @@ func (r *Reconciler) removeAndPrune(
 		return nil
 	}
 
-	delete(r.pruneMap, key)
+	// Cleanup keys when we don't need them anymore
+	if len(r.pruneMap[key]) == 0 {
+		delete(r.pruneMap, key)
+	}
 
 	// Unlock before pruning as this could take some time
 	r.pruneMapMutex.Unlock()

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -66,7 +66,7 @@ const (
 	// defaultBacklogSize is the limit of account lookups
 	// that can be enqueued to reconcile before new
 	// requests are dropped.
-	defaultBacklogSize = 50000
+	defaultBacklogSize = 250000
 
 	// waitToCheckDiff is the syncing difference (live-head)
 	// to retry instead of exiting. In other words, if the

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -930,7 +930,7 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 			assert.Equal(t, block2.Index, r.LastIndexReconciled())
 			mockHelper.AssertExpectations(t)
 			mockHandler.AssertExpectations(t)
-			assert.Equal(t, 0, len(r.pruneMap))
+			assert.Equal(t, 0, len(r.queueMap))
 			mtxn.AssertExpectations(t)
 			mtxn2.AssertExpectations(t)
 			mtxn3.AssertExpectations(t)
@@ -2820,7 +2820,7 @@ func TestPruningRaceCondition(t *testing.T) {
 
 	<-d
 	assert.Equal(t, block2.Index, r.LastIndexReconciled())
-	assert.Equal(t, 0, len(r.pruneMap))
+	assert.Equal(t, 0, len(r.queueMap))
 	mockHelper.AssertExpectations(t)
 	mockHandler.AssertExpectations(t)
 	mtxn.AssertExpectations(t)
@@ -2942,7 +2942,7 @@ func TestPruningHappyPath(t *testing.T) {
 
 	<-d
 	assert.Equal(t, block2.Index, r.LastIndexReconciled())
-	assert.Equal(t, 0, len(r.pruneMap))
+	assert.Equal(t, 0, len(r.queueMap))
 	mockHelper.AssertExpectations(t)
 	mockHandler.AssertExpectations(t)
 	mtxn.AssertExpectations(t)
@@ -3054,7 +3054,7 @@ func TestPruningReorg(t *testing.T) {
 
 	<-d
 	assert.Equal(t, blockB.Index, r.LastIndexReconciled())
-	assert.Equal(t, 0, len(r.pruneMap))
+	assert.Equal(t, 0, len(r.queueMap))
 	mockHelper.AssertExpectations(t)
 	mockHandler.AssertExpectations(t)
 	mtxn.AssertExpectations(t)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -2840,9 +2840,11 @@ func TestPruningRaceCondition(t *testing.T) {
 
 	assert.Equal(t, int64(-1), r.LastIndexReconciled())
 
+	d := make(chan struct{})
 	go func() {
 		err := r.Reconcile(ctx)
 		assert.Contains(t, context.Canceled.Error(), err.Error())
+		close(d)
 	}()
 
 	err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
@@ -2867,8 +2869,7 @@ func TestPruningRaceCondition(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	time.Sleep(1 * time.Second)
-
+	<-d
 	assert.Equal(t, block2.Index, r.LastIndexReconciled())
 	assert.Equal(t, 0, len(r.pruneMap))
 	mockHelper.AssertExpectations(t)
@@ -2980,9 +2981,11 @@ func TestPruningHappyPath(t *testing.T) {
 
 	assert.Equal(t, int64(-1), r.LastIndexReconciled())
 
+	d := make(chan struct{})
 	go func() {
 		err := r.Reconcile(ctx)
 		assert.Contains(t, context.Canceled.Error(), err.Error())
+		close(d)
 	}()
 
 	err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
@@ -3002,8 +3005,7 @@ func TestPruningHappyPath(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	time.Sleep(1 * time.Second)
-
+	<-d
 	assert.Equal(t, block2.Index, r.LastIndexReconciled())
 	assert.Equal(t, 0, len(r.pruneMap))
 	mockHelper.AssertExpectations(t)
@@ -3122,13 +3124,14 @@ func TestPruningReorg(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	d := make(chan struct{})
 	go func() {
 		err := r.Reconcile(ctx)
 		assert.Contains(t, context.Canceled.Error(), err.Error())
+		close(d)
 	}()
 
-	time.Sleep(1 * time.Second)
-
+	<-d
 	assert.Equal(t, blockB.Index, r.LastIndexReconciled())
 	assert.Equal(t, 0, len(r.pruneMap))
 	mockHelper.AssertExpectations(t)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -930,6 +930,7 @@ func TestReconcile_SuccessOnlyActive(t *testing.T) {
 			assert.Equal(t, block2.Index, r.LastIndexReconciled())
 			mockHelper.AssertExpectations(t)
 			mockHandler.AssertExpectations(t)
+			assert.Equal(t, 0, len(r.pruneMap))
 			mtxn.AssertExpectations(t)
 			mtxn2.AssertExpectations(t)
 			mtxn3.AssertExpectations(t)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -2634,7 +2634,15 @@ func mockReconcilerCallsDelay(
 		headBlock,
 		nil,
 	).After(time.Duration(liveDelay) * time.Millisecond).Once()
-	mockHelper.On("CanonicalBlock", mock.Anything, mock.Anything, headBlock).Return(true, nil).Once()
+	mockHelper.On(
+		"CanonicalBlock",
+		mock.Anything,
+		mock.Anything,
+		headBlock,
+	).Return(
+		true,
+		nil,
+	).Once()
 	mockHelper.On(
 		"ComputedBalance",
 		mock.Anything,

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -2790,26 +2790,6 @@ func TestPruningRaceCondition(t *testing.T) {
 		200, // delay live response 200 ms
 	)
 
-	mtxn3 := &mockStorage.DatabaseTransaction{}
-	mtxn3.On("Discard", mock.Anything).Once()
-	mockHelper.On("DatabaseTransaction", mock.Anything).Return(mtxn3).Once()
-	mockReconcilerCalls(
-		mockHelper,
-		mockHandler,
-		mtxn3,
-		true,
-		accountCurrency,
-		"100",
-		"100",
-		block2,
-		block2,
-		true,
-		ActiveReconciliation,
-		nil,
-		false,
-		false,
-	)
-
 	mockHelper.On(
 		"PruneBalances",
 		mock.Anything,
@@ -2830,6 +2810,26 @@ func TestPruningRaceCondition(t *testing.T) {
 		accountCurrency2,
 		"120",
 		"120",
+		block2,
+		block2,
+		true,
+		ActiveReconciliation,
+		nil,
+		false,
+		false,
+	)
+
+	mtxn3 := &mockStorage.DatabaseTransaction{}
+	mtxn3.On("Discard", mock.Anything).Once()
+	mockHelper.On("DatabaseTransaction", mock.Anything).Return(mtxn3).Once()
+	mockReconcilerCalls(
+		mockHelper,
+		mockHandler,
+		mtxn3,
+		true,
+		accountCurrency,
+		"100",
+		"100",
 		block2,
 		block2,
 		true,
@@ -2872,6 +2872,7 @@ func TestPruningRaceCondition(t *testing.T) {
 	cancel()
 
 	assert.Equal(t, block2.Index, r.LastIndexReconciled())
+	assert.Equal(t, 0, len(r.pruneMap))
 	mockHelper.AssertExpectations(t)
 	mockHandler.AssertExpectations(t)
 	mtxn.AssertExpectations(t)

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -1,0 +1,257 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/coinbase/rosetta-sdk-go/parser"
+	"github.com/coinbase/rosetta-sdk-go/storage"
+	"github.com/coinbase/rosetta-sdk-go/types"
+)
+
+const (
+	// ActiveReconciliation is included in the reconciliation
+	// error message if reconciliation failed during active
+	// reconciliation.
+	ActiveReconciliation = "ACTIVE"
+
+	// InactiveReconciliation is included in the reconciliation
+	// error message if reconciliation failed during inactive
+	// reconciliation.
+	InactiveReconciliation = "INACTIVE"
+)
+
+const (
+	// BlockGone is when the block where a reconciliation
+	// is supposed to happen is orphaned.
+	BlockGone = "BLOCK_GONE"
+
+	// HeadBehind is when the synced tip (where balances
+	// were last computed) is behind the *types.BlockIdentifier
+	// returned by the call to /account/balance.
+	HeadBehind = "HEAD_BEHIND"
+
+	// BacklogFull is when the reconciliation backlog is full.
+	BacklogFull = "BACKLOG_FULL"
+
+	// TipFailure is returned when looking up the live
+	// balance fails but we are at tip. This usually occurs
+	// when the node processes an re-org that we have yet
+	// to process (so the index we are querying at may be
+	// ahead of the nodes tip).
+	TipFailure = "TIP_FAILURE"
+)
+
+const (
+	// defaultBacklogSize is the limit of account lookups
+	// that can be enqueued to reconcile before new
+	// requests are dropped.
+	defaultBacklogSize = 250000
+
+	// waitToCheckDiff is the syncing difference (live-head)
+	// to retry instead of exiting. In other words, if the
+	// processed head is behind the live head by <
+	// waitToCheckDiff we should try again after sleeping.
+	// TODO: Make configurable
+	waitToCheckDiff = 10
+
+	// waitToCheckDiffSleep is the amount of time to wait
+	// to check a balance difference if the syncer is within
+	// waitToCheckDiff from the block a balance was queried at.
+	waitToCheckDiffSleep = 5 * time.Second
+
+	// zeroString is a string of value 0.
+	zeroString = "0"
+
+	// inactiveReconciliationSleep is used as the time.Duration
+	// to sleep when there are no seen accounts to reconcile.
+	inactiveReconciliationSleep = 1 * time.Second
+
+	// defaultInactiveFrequency is the minimum
+	// number of blocks the reconciler should wait between
+	// inactive reconciliations for each account.
+	defaultInactiveFrequency = 200
+
+	// defaultReconcilerConcurrency is the number of goroutines
+	// to start for reconciliation. Half of the goroutines are assigned
+	// to inactive reconciliation and half are assigned to active
+	// reconciliation.
+	defaultReconcilerConcurrency = 8
+
+	// safeBalancePruneDepth is the depth from the last balance
+	// change that we consider safe to prune. We are very conservative
+	// here to prevent removing balances we may need in a reorg.
+	safeBalancePruneDepth = int64(500) // nolint:gomnd
+)
+
+// Helper functions are used by Reconciler to compare
+// computed balances from a block with the balance calculated
+// by the node. Defining an interface allows the client to determine
+// what sort of storage layer they want to use to provide the required
+// information.
+type Helper interface {
+	DatabaseTransaction(ctx context.Context) storage.DatabaseTransaction
+
+	CurrentBlock(
+		ctx context.Context,
+		dbTx storage.DatabaseTransaction,
+	) (*types.BlockIdentifier, error)
+
+	IndexAtTip(
+		ctx context.Context,
+		index int64,
+	) (bool, error)
+
+	CanonicalBlock(
+		ctx context.Context,
+		dbTx storage.DatabaseTransaction,
+		block *types.BlockIdentifier,
+	) (bool, error)
+
+	ComputedBalance(
+		ctx context.Context,
+		dbTx storage.DatabaseTransaction,
+		account *types.AccountIdentifier,
+		currency *types.Currency,
+		index int64,
+	) (*types.Amount, error)
+
+	LiveBalance(
+		ctx context.Context,
+		account *types.AccountIdentifier,
+		currency *types.Currency,
+		index int64,
+	) (*types.Amount, *types.BlockIdentifier, error)
+
+	// PruneBalances is invoked by the reconciler
+	// to indicate that all historical balance states
+	// <= to index can be removed.
+	PruneBalances(
+		ctx context.Context,
+		account *types.AccountIdentifier,
+		currency *types.Currency,
+		index int64,
+	) error
+}
+
+// Handler is called by Reconciler after a reconciliation
+// is performed. When a reconciliation failure is observed,
+// it is up to the client to halt syncing or log the result.
+type Handler interface {
+	ReconciliationFailed(
+		ctx context.Context,
+		reconciliationType string,
+		account *types.AccountIdentifier,
+		currency *types.Currency,
+		computedBalance string,
+		liveBalance string,
+		block *types.BlockIdentifier,
+	) error
+
+	ReconciliationSucceeded(
+		ctx context.Context,
+		reconciliationType string,
+		account *types.AccountIdentifier,
+		currency *types.Currency,
+		balance string,
+		block *types.BlockIdentifier,
+	) error
+
+	ReconciliationExempt(
+		ctx context.Context,
+		reconciliationType string,
+		account *types.AccountIdentifier,
+		currency *types.Currency,
+		computedBalance string,
+		liveBalance string,
+		block *types.BlockIdentifier,
+		exemption *types.BalanceExemption,
+	) error
+
+	ReconciliationSkipped(
+		ctx context.Context,
+		reconciliationType string,
+		account *types.AccountIdentifier,
+		currency *types.Currency,
+		cause string,
+	) error
+}
+
+// InactiveEntry is used to track the last
+// time that an *types.AccountCurrency was reconciled.
+type InactiveEntry struct {
+	Entry     *types.AccountCurrency
+	LastCheck *types.BlockIdentifier
+}
+
+// Reconciler contains all logic to reconcile balances of
+// types.AccountIdentifiers returned in types.Operations
+// by a Rosetta Server.
+type Reconciler struct {
+	helper  Helper
+	handler Handler
+	parser  *parser.Parser
+
+	lookupBalanceByBlock bool
+	interestingAccounts  []*types.AccountCurrency
+	backlogSize          int
+	changeQueue          chan *parser.BalanceChange
+	inactiveFrequency    int64
+	debugLogging         bool
+	balancePruning       bool
+
+	// Reconciler concurrency is separated between
+	// active and inactive concurrency to allow for
+	// fine-grained tuning of reconciler behavior.
+	// When there are many transactions in a block
+	// on a resource-constrained machine (laptop),
+	// it is useful to allocate more resources to
+	// active reconciliation as it is synchronous
+	// (when lookupBalanceByBlock is enabled).
+	ActiveConcurrency   int
+	InactiveConcurrency int
+
+	// highWaterMark is used to skip requests when
+	// we are very far behind the live head.
+	highWaterMark int64
+
+	// seenAccounts are stored for inactive account
+	// reconciliation. seenAccounts must be stored
+	// separately from inactiveQueue to prevent duplicate
+	// accounts from being added to the inactive reconciliation
+	// queue. If this is not done, it is possible a goroutine
+	// could be processing an account (not in the queue) when
+	// we do a lookup to determine if we should add to the queue.
+	seenAccounts  map[string]struct{}
+	inactiveQueue []*InactiveEntry
+
+	// inactiveQueueMutex needed because we can't peek at the tip
+	// of a channel to determine when it is ready to look at.
+	inactiveQueueMutex sync.Mutex
+
+	// lastIndexChecked is the last block index reconciled actively.
+	lastIndexMutex   sync.Mutex
+	lastIndexChecked int64
+
+	// queueMap tracks the *types.AccountCurrency items
+	// in the active reconciliation queue and being actively
+	// reconciled. It ensures we don't accidentally attempt to prune
+	// computed balances being used by other goroutines.
+	queueMap      map[string]map[int64]int
+	queueMapMutex sync.Mutex
+}

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -152,7 +152,8 @@ type Helper interface {
 
 // Handler is called by Reconciler after a reconciliation
 // is performed. When a reconciliation failure is observed,
-// it is up to the client to halt syncing or log the result.
+// it is up to the client to trigger a halt (by returning
+// an error) or to continue (by returning nil).
 type Handler interface {
 	ReconciliationFailed(
 		ctx context.Context,

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/parser"
 	"github.com/coinbase/rosetta-sdk-go/storage"
 	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/coinbase/rosetta-sdk-go/utils"
 )
 
 const (
@@ -252,6 +253,6 @@ type Reconciler struct {
 	// in the active reconciliation queue and being actively
 	// reconciled. It ensures we don't accidentally attempt to prune
 	// computed balances being used by other goroutines.
-	queueMap      map[string]map[int64]int
+	queueMap      map[string]*utils.BST
 	queueMapMutex sync.Mutex
 }

--- a/utils/bst.go
+++ b/utils/bst.go
@@ -1,0 +1,149 @@
+package utils
+
+// inspiration: https://github.com/puneeth8994/binary-tree-go-impl/blob/master/main.go
+
+// BST is an implementation of a binary search tree.
+type BST struct {
+	root *Node
+}
+
+// Empty returns a boolean indicating
+// if there are any nodes in the BST.
+func (t *BST) Empty() bool {
+	return t.root == nil
+}
+
+// Set stores the key and value in the BST
+func (t *BST) Set(key int64, value int) {
+	if t.root == nil {
+		t.root = &Node{Key: key, Value: value}
+		return
+	}
+
+	t.root.set(key, value)
+}
+
+// Get gets the key in the BST and returns
+// its representative node (so that modifications
+// can be done in constant time).
+func (t *BST) Get(key int64) *Node {
+	return t.root.get(key)
+}
+
+// Delete removes the key from the BST.
+func (t *BST) Delete(key int64) {
+	t.root = t.root.remove(key)
+}
+
+// Min returns the smallest node in the BST.
+func (t *BST) Min() *Node {
+	return t.root.findMin()
+}
+
+// Node is a Node in a BST
+type Node struct {
+	Key   int64
+	Value int
+	left  *Node
+	right *Node
+}
+
+// set adds they key and value to the BST
+// if they key doesn't exist. If it does
+// exist, it is overwritten.
+func (n *Node) set(key int64, value int) {
+	if n.Key == key {
+		n.Value = value
+		return
+	}
+
+	if n.Key > key {
+		if n.left == nil {
+			n.left = &Node{Key: key, Value: value}
+			return
+		}
+
+		n.left.set(key, value)
+		return
+	}
+
+	if n.right == nil {
+		n.right = &Node{Key: key, Value: value}
+		return
+	}
+
+	n.right.set(key, value)
+}
+
+// get gets the *Node for a key in the BST,
+// returning nil if it doesn't exist.
+func (n *Node) get(key int64) *Node {
+	if n == nil {
+		return nil
+	}
+
+	switch {
+	case key == n.Key:
+		return n
+	case key < n.Key:
+		return n.left.get(key)
+	default:
+		return n.right.get(key)
+	}
+}
+
+// remove deletes the *Node for a key in the BST
+// and returns the new root.
+func (n *Node) remove(key int64) *Node {
+	if n == nil {
+		return nil
+	}
+
+	if key < n.Key {
+		n.left = n.left.remove(key)
+		return n
+	}
+
+	if key > n.Key {
+		n.right = n.right.remove(key)
+		return n
+	}
+
+	if n.left == nil && n.right == nil {
+		return nil
+	}
+
+	if n.left == nil {
+		return n.right
+	}
+
+	if n.right == nil {
+		return n.left
+	}
+
+	smallestKeyOnRight := n.right
+	for {
+		if smallestKeyOnRight != nil && smallestKeyOnRight.left != nil {
+			smallestKeyOnRight = smallestKeyOnRight.left
+		} else {
+			break
+		}
+	}
+
+	n.Key = smallestKeyOnRight.Key
+	n.right = n.right.remove(n.Key)
+	return n
+}
+
+// findMin returns the smallest key in
+// the BST
+func (n *Node) findMin() *Node {
+	if n == nil {
+		return nil
+	}
+
+	if n.left == nil {
+		return n
+	}
+	return n.left.findMin()
+}

--- a/utils/bst.go
+++ b/utils/bst.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 // inspiration: https://github.com/puneeth8994/binary-tree-go-impl/blob/master/main.go

--- a/utils/bst.go
+++ b/utils/bst.go
@@ -62,7 +62,7 @@ type Node struct {
 	right *Node
 }
 
-// set adds they key and value to the BST
+// set adds the key and value to the BST
 // if they key doesn't exist. If it does
 // exist, it is overwritten.
 func (n *Node) set(key int64, value int) {

--- a/utils/bst_test.go
+++ b/utils/bst_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBST(t *testing.T) {
+	bst := &BST{}
+	assert.Nil(t, bst.Get(1))
+	assert.Nil(t, bst.Min())
+	assert.True(t, bst.Empty())
+
+	bst.Set(1, 10)
+	assert.False(t, bst.Empty())
+	assert.Equal(t, 10, bst.Get(1).Value)
+	assert.Equal(t, int64(1), bst.Min().Key)
+	assert.Nil(t, bst.Get(10))
+
+	bst.Set(1, 11)
+	assert.Equal(t, 11, bst.Get(1).Value)
+	assert.Equal(t, int64(1), bst.Min().Key)
+
+	bst.Set(0, 11)
+	assert.Equal(t, 11, bst.Get(0).Value)
+	assert.Equal(t, int64(0), bst.Min().Key)
+
+	bst.Delete(1)
+	assert.Equal(t, 11, bst.Get(0).Value)
+	assert.Equal(t, int64(0), bst.Min().Key)
+	assert.Nil(t, bst.Get(1))
+
+	bst.Set(3, 33)
+	bst.Set(2, 22)
+	bst.Delete(1)
+	assert.False(t, bst.Empty())
+	bst.Delete(0)
+	bst.Delete(0)
+	assert.False(t, bst.Empty())
+	assert.Equal(t, int64(2), bst.Min().Key)
+	bst.Delete(3)
+	bst.Delete(2)
+	assert.True(t, bst.Empty())
+	assert.Nil(t, bst.Min())
+}

--- a/utils/bst_test.go
+++ b/utils/bst_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/utils/bst_test.go
+++ b/utils/bst_test.go
@@ -22,37 +22,54 @@ import (
 
 func TestBST(t *testing.T) {
 	bst := &BST{}
+
+	// Test empty BST
 	assert.Nil(t, bst.Get(1))
 	assert.Nil(t, bst.Min())
 	assert.True(t, bst.Empty())
 
+	// Set 1 key and ensure it is the min
 	bst.Set(1, 10)
 	assert.False(t, bst.Empty())
 	assert.Equal(t, 10, bst.Get(1).Value)
 	assert.Equal(t, int64(1), bst.Min().Key)
 	assert.Nil(t, bst.Get(10))
 
+	// Overwrite existing key
 	bst.Set(1, 11)
 	assert.Equal(t, 11, bst.Get(1).Value)
 	assert.Equal(t, int64(1), bst.Min().Key)
 
+	// Add a key that will be put in "left"
+	// of root
 	bst.Set(0, 11)
 	assert.Equal(t, 11, bst.Get(0).Value)
 	assert.Equal(t, int64(0), bst.Min().Key)
 
+	// Delete root
 	bst.Delete(1)
 	assert.Equal(t, 11, bst.Get(0).Value)
 	assert.Equal(t, int64(0), bst.Min().Key)
 	assert.Nil(t, bst.Get(1))
 
+	// Add keys to the "right" of new root
 	bst.Set(3, 33)
 	bst.Set(2, 22)
+
+	// Delete already deleted item
 	bst.Delete(1)
 	assert.False(t, bst.Empty())
+
+	// Delete root again
 	bst.Delete(0)
 	bst.Delete(0)
 	assert.False(t, bst.Empty())
+
+	// Ensure 2 is the min key after root
+	// deleted
 	assert.Equal(t, int64(2), bst.Min().Key)
+
+	// Delete all items
 	bst.Delete(3)
 	bst.Delete(2)
 	assert.True(t, bst.Empty())


### PR DESCRIPTION
This PR fixes a potential race condition in the optimistic balance pruning logic. This was observed in our own testing when syncing and reconciling with high concurrency.

### Changes
- [x] Reproduce race condition with a test
- [x] Update backlog default to 250k (some networks have congestion spikes)
- [x] Fix race condition
- [x] Add test with multiple changes for same account at same index (different block hashes)
- [x] Increase reconciler safe depth
- [x] Test happy path pruning with 2 calls
- [x] add `BST` implementation to get fast lookup when popular `*types.AccountCurrency` (instead of sorting all keys in a map)