### PR TITLE
[reconciler] Inactive Pruning Race + Inactive Pruning Support

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -111,12 +111,15 @@ func (r *Reconciler) wrappedInactiveEnqueue(
 func (r *Reconciler) addToQueueMap(
 	acctCurrency *types.AccountCurrency,
 	index int64,
-	holdsLock bool,
+	unsafe bool,
 ) {
 	key := types.Hash(acctCurrency)
 
-	if !holdsLock {
+	// We acquire the lock for the queueMap
+	// if the call is safe.
+	if !unsafe {
 		r.queueMapMutex.Lock()
+		defer r.queueMapMutex.Unlock()
 	}
 
 	if _, ok := r.queueMap[key]; !ok {
@@ -127,10 +130,6 @@ func (r *Reconciler) addToQueueMap(
 		r.queueMap[key].Set(index, 1)
 	} else {
 		existing.Value++
-	}
-
-	if !holdsLock {
-		r.queueMapMutex.Unlock()
 	}
 }
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -106,15 +106,19 @@ func (r *Reconciler) wrappedInactiveEnqueue(
 	}
 }
 
-// addToqueueMap adds a *types.AccountCurrency
+// addToQueueMap adds a *types.AccountCurrency
 // to the prune map at the provided index.
-func (r *Reconciler) addToqueueMap(
+func (r *Reconciler) addToQueueMap(
 	acctCurrency *types.AccountCurrency,
 	index int64,
+	holdsLock bool,
 ) {
 	key := types.Hash(acctCurrency)
 
-	r.queueMapMutex.Lock()
+	if !holdsLock {
+		r.queueMapMutex.Lock()
+	}
+
 	if _, ok := r.queueMap[key]; !ok {
 		r.queueMap[key] = &utils.BST{}
 	}
@@ -124,7 +128,10 @@ func (r *Reconciler) addToqueueMap(
 	} else {
 		existing.Value++
 	}
-	r.queueMapMutex.Unlock()
+
+	if !holdsLock {
+		r.queueMapMutex.Unlock()
+	}
 }
 
 // QueueChanges enqueues a slice of *BalanceChanges
@@ -191,7 +198,7 @@ func (r *Reconciler) QueueChanges(
 
 		// Add change to queueMap before enqueuing to ensure
 		// there is no possible race.
-		r.addToqueueMap(acctCurrency, change.Block.Index)
+		r.addToQueueMap(acctCurrency, change.Block.Index, false)
 
 		// Add change to active queue
 		r.wrappedActiveEnqueue(ctx, change)
@@ -538,16 +545,20 @@ func (r *Reconciler) updateLastChecked(index int64) {
 	}
 }
 
-func (r *Reconciler) pruneBalances(ctx context.Context, change *parser.BalanceChange) error {
+func (r *Reconciler) pruneBalances(
+	ctx context.Context,
+	acctCurrency *types.AccountCurrency,
+	index int64,
+) error {
 	if !r.balancePruning {
 		return nil
 	}
 
 	return r.helper.PruneBalances(
 		ctx,
-		change.Account,
-		change.Currency,
-		change.Block.Index-safeBalancePruneDepth,
+		acctCurrency.Account,
+		acctCurrency.Currency,
+		index-safeBalancePruneDepth,
 	)
 }
 
@@ -568,7 +579,10 @@ func (r *Reconciler) skipAndPrune(
 		return err
 	}
 
-	return r.updateQueueMapAndPrune(ctx, change)
+	return r.updateQueueMapAndPrune(ctx, &types.AccountCurrency{
+		Account:  change.Account,
+		Currency: change.Currency,
+	}, change.Block.Index)
 }
 
 // updateQueueMapAndPrune removes a *parser.BalanceChange
@@ -576,15 +590,13 @@ func (r *Reconciler) skipAndPrune(
 // *types.AccountCurrency's balances, if appropriate.
 func (r *Reconciler) updateQueueMapAndPrune(
 	ctx context.Context,
-	change *parser.BalanceChange,
+	acctCurrency *types.AccountCurrency,
+	index int64,
 ) error {
-	key := types.Hash(&types.AccountCurrency{
-		Account:  change.Account,
-		Currency: change.Currency,
-	})
+	key := types.Hash(acctCurrency)
 
 	r.queueMapMutex.Lock()
-	existing := r.queueMap[key].Get(change.Block.Index)
+	existing := r.queueMap[key].Get(index)
 	existing.Value--
 	if existing.Value > 0 {
 		r.queueMapMutex.Unlock()
@@ -592,12 +604,12 @@ func (r *Reconciler) updateQueueMapAndPrune(
 	}
 
 	// Cleanup indexes when we don't need them anymore
-	r.queueMap[key].Delete(change.Block.Index)
+	r.queueMap[key].Delete(index)
 
 	// Don't prune if there are items for this AccountCurrency
 	// less than this change.
 	if !r.queueMap[key].Empty() &&
-		change.Block.Index >= r.queueMap[key].Min().Key {
+		index >= r.queueMap[key].Min().Key {
 		r.queueMapMutex.Unlock()
 		return nil
 	}
@@ -612,7 +624,7 @@ func (r *Reconciler) updateQueueMapAndPrune(
 
 	// Attempt to prune historical balances that will not be used
 	// anymore.
-	return r.pruneBalances(ctx, change)
+	return r.pruneBalances(ctx, acctCurrency, index)
 }
 
 // reconcileActiveAccounts selects an account
@@ -687,7 +699,10 @@ func (r *Reconciler) reconcileActiveAccounts(ctx context.Context) error { // nol
 
 			// Attempt to prune historical balances that will not be used
 			// anymore.
-			if err := r.updateQueueMapAndPrune(ctx, balanceChange); err != nil {
+			if err := r.updateQueueMapAndPrune(ctx, &types.AccountCurrency{
+				Account:  balanceChange.Account,
+				Currency: balanceChange.Currency,
+			}, balanceChange.Block.Index); err != nil {
 				return err
 			}
 
@@ -736,8 +751,14 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 			return ctx.Err()
 		}
 
+		// Lock BST while determining if we should attempt reconciliation
+		// to ensure we don't allow any accounts to be pruned at retrieved
+		// head index.
+		r.queueMapMutex.Lock()
+
 		shouldAttempt, head := r.shouldAttemptInactiveReconciliation(ctx)
 		if !shouldAttempt {
+			r.inactiveQueueMutex.Unlock()
 			time.Sleep(inactiveReconciliationSleep)
 			continue
 		}
@@ -746,6 +767,7 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 		queueLen := len(r.inactiveQueue)
 		if queueLen == 0 {
 			r.inactiveQueueMutex.Unlock()
+			r.queueMapMutex.Unlock()
 			r.debugLog(
 				"no accounts ready for inactive reconciliation (0 accounts in queue)",
 			)
@@ -763,6 +785,11 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 			r.inactiveQueue = r.inactiveQueue[1:]
 			r.inactiveQueueMutex.Unlock()
 
+			// Add nextAcct to queueMap before returning
+			// queueMapMutex lock.
+			r.addToQueueMap(nextAcct.Entry, head.Index, true)
+			r.queueMapMutex.Unlock()
+
 			amount, block, err := r.bestLiveBalance(
 				ctx,
 				nextAcct.Entry.Account,
@@ -772,7 +799,6 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 			if err != nil {
 				// Ensure we don't leak reconciliations
 				r.wrappedInactiveEnqueue(nextAcct.Entry, block)
-
 				if errors.Is(err, context.Canceled) {
 					return err
 				}
@@ -786,6 +812,14 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 						nextAcct.Entry.Account,
 						nextAcct.Entry.Currency,
 						TipFailure,
+					); err != nil {
+						return err
+					}
+
+					if err := r.updateQueueMapAndPrune(
+						ctx,
+						nextAcct.Entry,
+						head.Index,
 					); err != nil {
 						return err
 					}
@@ -811,6 +845,14 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 				return err
 			}
 
+			if err := r.updateQueueMapAndPrune(
+				ctx,
+				nextAcct.Entry,
+				head.Index,
+			); err != nil {
+				return err
+			}
+
 			// Always re-enqueue accounts after they have been inactively
 			// reconciled. If we don't re-enqueue, we will never check
 			// these accounts again.
@@ -820,6 +862,7 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 			}
 		} else {
 			r.inactiveQueueMutex.Unlock()
+			r.queueMapMutex.Unlock()
 			r.debugLog(
 				"no accounts ready for inactive reconciliation (%d accounts in queue, will reconcile next account at index %d)",
 				queueLen,

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -759,7 +759,7 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 
 		shouldAttempt, head := r.shouldAttemptInactiveReconciliation(ctx)
 		if !shouldAttempt {
-			r.inactiveQueueMutex.Unlock()
+			r.queueMapMutex.Unlock()
 			time.Sleep(inactiveReconciliationSleep)
 			continue
 		}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -2620,6 +2620,7 @@ func mockReconcilerCallsDelay(
 	headBlock *types.BlockIdentifier,
 	liveBlock *types.BlockIdentifier,
 	liveDelay int,
+	reconciliationType string,
 ) {
 	mockHelper.On("CurrentBlock", mock.Anything, mock.Anything).Return(headBlock, nil).Once()
 	lookupIndex := liveBlock.Index
@@ -2657,7 +2658,7 @@ func mockReconcilerCallsDelay(
 	mockHandler.On(
 		"ReconciliationSucceeded",
 		mock.Anything,
-		ActiveReconciliation,
+		reconciliationType,
 		accountCurrency.Account,
 		accountCurrency.Currency,
 		value,
@@ -2736,6 +2737,7 @@ func TestPruningRaceCondition(t *testing.T) {
 		block2,
 		block,
 		200, // delay live response 200 ms
+		ActiveReconciliation,
 	)
 
 	mockHelper.On(
@@ -2886,6 +2888,7 @@ func TestPruningHappyPath(t *testing.T) {
 		block2,
 		block,
 		0,
+		ActiveReconciliation,
 	)
 
 	mockHelper.On(
@@ -2912,6 +2915,7 @@ func TestPruningHappyPath(t *testing.T) {
 		block2,
 		block2,
 		200, // delay by 200 ms
+		ActiveReconciliation,
 	)
 
 	assert.Equal(t, int64(-1), r.LastIndexReconciled())
@@ -2998,6 +3002,7 @@ func TestPruningReorg(t *testing.T) {
 		block,
 		block,
 		0,
+		ActiveReconciliation,
 	)
 
 	mockHelper.On(
@@ -3024,6 +3029,7 @@ func TestPruningReorg(t *testing.T) {
 		blockB,
 		blockB,
 		200, // delay by 200 ms
+		ActiveReconciliation,
 	)
 
 	assert.Equal(t, int64(-1), r.LastIndexReconciled())
@@ -3105,18 +3111,17 @@ func TestPruningRaceConditionInactive(t *testing.T) {
 	// Start inactive fetch
 	mtxn := &mockStorage.DatabaseTransaction{}
 	mtxn.On("Discard", mock.Anything).Once()
-	a := make(chan struct{})
-	mockHelper.On("DatabaseTransaction", mock.Anything).Run(
-		func(args mock.Arguments) {
-			close(a)
-		},
-	).Return(mtxn).Once()
-	c := make(chan time.Time)
+	a := make(chan time.Time)
+	mockHelper.On("DatabaseTransaction", mock.Anything).Return(mtxn).Once()
 	mockHelper.On(
 		"CurrentBlock",
 		mock.Anything,
 		mtxn,
-	).Return(blockOld, nil).WaitUntil(c).Once()
+	).Return(blockOld, nil).Run(
+		func(args mock.Arguments) {
+			time.Sleep(time.Second)
+		},
+	).Once()
 
 	// Active balance fetch
 	mtxn2 := &mockStorage.DatabaseTransaction{}
@@ -3125,7 +3130,7 @@ func TestPruningRaceConditionInactive(t *testing.T) {
 		mock.Anything,
 	).Run(
 		func(args mock.Arguments) {
-			close(c)
+			close(a)
 		},
 	).Once()
 	mockHelper.On("DatabaseTransaction", mock.Anything).Return(mtxn2).Once()
@@ -3137,17 +3142,15 @@ func TestPruningRaceConditionInactive(t *testing.T) {
 		block,
 		block,
 		0, // delay live response 0 ms
+		ActiveReconciliation,
 	)
 
 	// Finish inactive fetch
 	mtxn3 := &mockStorage.DatabaseTransaction{}
+	mockHelper.On("DatabaseTransaction", mock.Anything).WaitUntil(a).Return(mtxn3).Once()
 	mtxn3.On(
 		"Discard",
 		mock.Anything,
-	).Run(
-		func(args mock.Arguments) {
-			cancel()
-		},
 	).Once()
 	mockReconcilerCallsDelay(
 		mockHelper,
@@ -3157,9 +3160,32 @@ func TestPruningRaceConditionInactive(t *testing.T) {
 		blockOld,
 		blockOld,
 		0, // delay live response 0 ms
+		InactiveReconciliation,
 	)
+	mockHelper.On(
+		"PruneBalances",
+		mock.Anything,
+		accountCurrency.Account,
+		accountCurrency.Currency,
+		blockOld.Index-safeBalancePruneDepth,
+	).Run(
+		func(args mock.Arguments) {
+			cancel()
+		},
+	).Return(
+		nil,
+	).Once()
 
 	assert.Equal(t, int64(-1), r.LastIndexReconciled())
+
+	err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
+		{
+			Account:  accountCurrency.Account,
+			Currency: accountCurrency.Currency,
+			Block:    block,
+		},
+	})
+	assert.NoError(t, err)
 
 	d := make(chan struct{})
 	go func() {
@@ -3170,14 +3196,6 @@ func TestPruningRaceConditionInactive(t *testing.T) {
 
 	// wait to queue changes until start inactive
 	<-a
-	err := r.QueueChanges(ctx, block, []*parser.BalanceChange{
-		{
-			Account:  accountCurrency.Account,
-			Currency: accountCurrency.Currency,
-			Block:    block,
-		},
-	})
-	assert.NoError(t, err)
 
 	<-d
 	assert.Equal(t, block.Index, r.LastIndexReconciled())


### PR DESCRIPTION
This PR fixes an inactive pruning race (where the active reconciliation loop prunes a balance being used by the inactive reconciliation loop).

### Changes
- [x] reproduce race condition in tests
- [x] fix race condition
- [x] enable inactive reconciliation pruning (now possible because of race fix)