### PR TITLE
[reconciler] Don't Prune During Inactive Reconciliation

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -572,10 +572,15 @@ func (r *Reconciler) skipAndPrune(
 		return err
 	}
 
-	return r.updateQueueMap(ctx, &types.AccountCurrency{
-		Account:  change.Account,
-		Currency: change.Currency,
-	}, change.Block.Index, true)
+	return r.updateQueueMap(
+		ctx,
+		&types.AccountCurrency{
+			Account:  change.Account,
+			Currency: change.Currency,
+		},
+		change.Block.Index,
+		pruneActiveReconciliation,
+	)
 }
 
 // updateQueueMap removes a *parser.BalanceChange
@@ -697,10 +702,15 @@ func (r *Reconciler) reconcileActiveAccounts(ctx context.Context) error { // nol
 
 			// Attempt to prune historical balances that will not be used
 			// anymore.
-			if err := r.updateQueueMap(ctx, &types.AccountCurrency{
-				Account:  balanceChange.Account,
-				Currency: balanceChange.Currency,
-			}, balanceChange.Block.Index, true); err != nil {
+			if err := r.updateQueueMap(
+				ctx,
+				&types.AccountCurrency{
+					Account:  balanceChange.Account,
+					Currency: balanceChange.Currency,
+				},
+				balanceChange.Block.Index,
+				pruneActiveReconciliation,
+			); err != nil {
 				return err
 			}
 
@@ -819,7 +829,7 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 						ctx,
 						nextAcct.Entry,
 						head.Index,
-						false,
+						pruneInactiveReconciliation,
 					); err != nil {
 						return err
 					}
@@ -853,7 +863,7 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 				ctx,
 				nextAcct.Entry,
 				head.Index,
-				false,
+				pruneInactiveReconciliation,
 			); err != nil {
 				return err
 			}

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -572,19 +572,20 @@ func (r *Reconciler) skipAndPrune(
 		return err
 	}
 
-	return r.updateQueueMapAndPrune(ctx, &types.AccountCurrency{
+	return r.updateQueueMap(ctx, &types.AccountCurrency{
 		Account:  change.Account,
 		Currency: change.Currency,
-	}, change.Block.Index)
+	}, change.Block.Index, true)
 }
 
-// updateQueueMapAndPrune removes a *parser.BalanceChange
+// updateQueueMap removes a *parser.BalanceChange
 // from the queueMap and attempts to prune the associated
 // *types.AccountCurrency's balances, if appropriate.
-func (r *Reconciler) updateQueueMapAndPrune(
+func (r *Reconciler) updateQueueMap(
 	ctx context.Context,
 	acctCurrency *types.AccountCurrency,
 	index int64,
+	prune bool,
 ) error {
 	key := types.Hash(acctCurrency)
 
@@ -617,6 +618,10 @@ func (r *Reconciler) updateQueueMapAndPrune(
 
 	// Attempt to prune historical balances that will not be used
 	// anymore.
+	if !prune {
+		return nil
+	}
+
 	return r.pruneBalances(ctx, acctCurrency, index)
 }
 
@@ -692,10 +697,10 @@ func (r *Reconciler) reconcileActiveAccounts(ctx context.Context) error { // nol
 
 			// Attempt to prune historical balances that will not be used
 			// anymore.
-			if err := r.updateQueueMapAndPrune(ctx, &types.AccountCurrency{
+			if err := r.updateQueueMap(ctx, &types.AccountCurrency{
 				Account:  balanceChange.Account,
 				Currency: balanceChange.Currency,
-			}, balanceChange.Block.Index); err != nil {
+			}, balanceChange.Block.Index, true); err != nil {
 				return err
 			}
 
@@ -810,10 +815,11 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 						return err
 					}
 
-					if err := r.updateQueueMapAndPrune(
+					if err := r.updateQueueMap(
 						ctx,
 						nextAcct.Entry,
 						head.Index,
+						false,
 					); err != nil {
 						return err
 					}
@@ -843,10 +849,11 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 			// into the BST. If we end up performing a reconciliation
 			// at an index after head.Index (because historical balances
 			// are disabled), we will not prune relative to it.
-			if err := r.updateQueueMapAndPrune(
+			if err := r.updateQueueMap(
 				ctx,
 				nextAcct.Entry,
 				head.Index,
+				false,
 			); err != nil {
 				return err
 			}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -3151,6 +3151,10 @@ func TestPruningRaceConditionInactive(t *testing.T) {
 	mtxn3.On(
 		"Discard",
 		mock.Anything,
+	).Run(
+		func(args mock.Arguments) {
+			cancel()
+		},
 	).Once()
 	mockReconcilerCallsDelay(
 		mockHelper,
@@ -3162,19 +3166,6 @@ func TestPruningRaceConditionInactive(t *testing.T) {
 		0, // delay live response 0 ms
 		InactiveReconciliation,
 	)
-	mockHelper.On(
-		"PruneBalances",
-		mock.Anything,
-		accountCurrency.Account,
-		accountCurrency.Currency,
-		blockOld.Index-safeBalancePruneDepth,
-	).Run(
-		func(args mock.Arguments) {
-			cancel()
-		},
-	).Return(
-		nil,
-	).Once()
 
 	assert.Equal(t, int64(-1), r.LastIndexReconciled())
 

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -59,6 +59,16 @@ const (
 )
 
 const (
+	// pruneActiveReconciliation indicates if historical balances
+	// should be pruned during active reconciliation.
+	pruneActiveReconciliation = true
+
+	// pruneInactiveReconciliation indicates if historical balances
+	// should be pruned during inactive reconciliation.
+	pruneInactiveReconciliation = false
+)
+
+const (
 	// defaultBacklogSize is the limit of account lookups
 	// that can be enqueued to reconcile before new
 	// requests are dropped.


### PR DESCRIPTION
This PR fixes a regression in #221 where inactive reconciliation could result in pruning. It is a bad idea to prune during inactive reconciliation because we may accidentally prune the only historical balance record of an account (in active reconciliation there is always a new change stored).