### PR TITLE
[chore] Fix Flaky Test (part 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_PACKAGES=./asserter/... ./fetcher/... ./types/... ./client/... ./server/... \
 	./parser/... ./syncer/... ./reconciler/... ./keys/... \
 	./statefulsyncer/... ./storage/... ./utils/... ./constructor/... ./errors/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
-TEST_SCRIPT=go test ${GO_PACKAGES} -p 1
+TEST_SCRIPT=go test ${GO_PACKAGES}
 LINT_SETTINGS=golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam
 
 deps:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_PACKAGES=./asserter/... ./fetcher/... ./types/... ./client/... ./server/... \
 	./parser/... ./syncer/... ./reconciler/... ./keys/... \
 	./statefulsyncer/... ./storage/... ./utils/... ./constructor/... ./errors/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
-TEST_SCRIPT=go test ${GO_PACKAGES}
+TEST_SCRIPT=go test ${GO_PACKAGES} -p 1
 LINT_SETTINGS=golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam
 
 deps:

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -3110,7 +3110,7 @@ func TestPruningRaceConditionInactive(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	b := make(chan struct{})
-	c := make(chan time.Time)
+	c := make(chan struct{})
 
 	// Start inactive fetch
 	mtxn := &mockStorage.DatabaseTransaction{}

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -664,6 +664,8 @@ func (s *Syncer) syncRange(
 			g.Go(func() error {
 				return s.fetchChannelBlocks(pipelineCtx, s.network, blockIndices, results)
 			})
+		} else {
+			s.concurrency--
 		}
 		s.doneLoadingLock.Unlock()
 


### PR DESCRIPTION
This PR makes a much more aggressive attempt to fix a flaky test that #224 did not fix. TL;DR tests of concurrent processing is hard.

### Changes
- [x] Fix flaky test in `reconciler`
- [x] Fix flaky test in `syncer` (unrelated to any recent change): https://app.circleci.com/pipelines/github/coinbase/rosetta-sdk-go/1472/workflows/e4eeef76-672a-4121-b5a9-6d1df380ef88/jobs/10824
- [x] Add safe shutdown in `syncer` to prevent panic on re-using WaitGroup

### Testing
```
go test -v ./reconciler/... -run PruningRaceConditionInactive -count 30 -race
```