### PR TITLE
[client/fetcher] Retry 502, 503, and 504 HTTP Codes

### DIFF
--- a/client/api_account.go
+++ b/client/api_account.go
@@ -92,7 +92,16 @@ func (a *AccountAPIService) AccountBalance(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.AccountBalanceResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -100,13 +109,20 @@ func (a *AccountAPIService) AccountBalance(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.AccountBalanceResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }

--- a/client/api_block.go
+++ b/client/api_block.go
@@ -89,7 +89,16 @@ func (a *BlockAPIService) Block(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.BlockResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -97,15 +106,22 @@ func (a *BlockAPIService) Block(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.BlockResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // BlockTransaction Get a transaction in a block by its Transaction Identifier. This endpoint should
@@ -170,7 +186,16 @@ func (a *BlockAPIService) BlockTransaction(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.BlockTransactionResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -178,13 +203,20 @@ func (a *BlockAPIService) BlockTransaction(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.BlockTransactionResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }

--- a/client/api_construction.go
+++ b/client/api_construction.go
@@ -84,7 +84,16 @@ func (a *ConstructionAPIService) ConstructionCombine(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.ConstructionCombineResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -92,15 +101,22 @@ func (a *ConstructionAPIService) ConstructionCombine(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.ConstructionCombineResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // ConstructionDerive Derive returns the AccountIdentifier associated with a public key. Blockchains
@@ -153,7 +169,16 @@ func (a *ConstructionAPIService) ConstructionDerive(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.ConstructionDeriveResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -161,15 +186,22 @@ func (a *ConstructionAPIService) ConstructionDerive(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.ConstructionDeriveResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // ConstructionHash TransactionHash returns the network-specific transaction hash for a signed
@@ -222,7 +254,16 @@ func (a *ConstructionAPIService) ConstructionHash(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.TransactionIdentifierResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -230,15 +271,22 @@ func (a *ConstructionAPIService) ConstructionHash(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.TransactionIdentifierResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // ConstructionMetadata Get any information required to construct a transaction for a specific
@@ -298,7 +346,16 @@ func (a *ConstructionAPIService) ConstructionMetadata(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.ConstructionMetadataResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -306,15 +363,22 @@ func (a *ConstructionAPIService) ConstructionMetadata(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.ConstructionMetadataResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // ConstructionParse Parse is called on both unsigned and signed transactions to understand the
@@ -368,7 +432,16 @@ func (a *ConstructionAPIService) ConstructionParse(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.ConstructionParseResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -376,15 +449,22 @@ func (a *ConstructionAPIService) ConstructionParse(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.ConstructionParseResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // ConstructionPayloads Payloads is called with an array of operations and the response from
@@ -443,7 +523,16 @@ func (a *ConstructionAPIService) ConstructionPayloads(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.ConstructionPayloadsResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -451,15 +540,22 @@ func (a *ConstructionAPIService) ConstructionPayloads(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.ConstructionPayloadsResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // ConstructionPreprocess Preprocess is called prior to /construction/payloads to construct a
@@ -516,7 +612,16 @@ func (a *ConstructionAPIService) ConstructionPreprocess(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.ConstructionPreprocessResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -524,15 +629,22 @@ func (a *ConstructionAPIService) ConstructionPreprocess(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.ConstructionPreprocessResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // ConstructionSubmit Submit a pre-signed transaction to the node. This call should not block on the
@@ -588,7 +700,16 @@ func (a *ConstructionAPIService) ConstructionSubmit(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.TransactionIdentifierResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -596,13 +717,20 @@ func (a *ConstructionAPIService) ConstructionSubmit(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.TransactionIdentifierResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }

--- a/client/api_mempool.go
+++ b/client/api_mempool.go
@@ -82,7 +82,16 @@ func (a *MempoolAPIService) Mempool(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.MempoolResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -90,15 +99,22 @@ func (a *MempoolAPIService) Mempool(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.MempoolResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // MempoolTransaction Get a transaction in the mempool by its Transaction Identifier. This is a
@@ -156,7 +172,16 @@ func (a *MempoolAPIService) MempoolTransaction(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.MempoolTransactionResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -164,13 +189,20 @@ func (a *MempoolAPIService) MempoolTransaction(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.MempoolTransactionResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }

--- a/client/api_network.go
+++ b/client/api_network.go
@@ -82,7 +82,16 @@ func (a *NetworkAPIService) NetworkList(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.NetworkListResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -90,15 +99,22 @@ func (a *NetworkAPIService) NetworkList(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.NetworkListResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // NetworkOptions This endpoint returns the version information and allowed network-specific types
@@ -153,7 +169,16 @@ func (a *NetworkAPIService) NetworkOptions(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.NetworkOptionsResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -161,15 +186,22 @@ func (a *NetworkAPIService) NetworkOptions(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.NetworkOptionsResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }
 
 // NetworkStatus This endpoint returns the current status of the network requested. Any
@@ -222,7 +254,16 @@ func (a *NetworkAPIService) NetworkStatus(
 		return nil, nil, err
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+		var v types.NetworkStatusResponse
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return &v, nil, nil
+	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -230,13 +271,20 @@ func (a *NetworkAPIService) NetworkStatus(
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	var v types.NetworkStatusResponse
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &v, nil, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -33,6 +34,11 @@ import (
 
 var (
 	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
+
+	// ErrRetriable is returned when a 502, 503, or 504 HTTP code is encountered.
+	// These status codes may be returned by intermediate services when a Rosetta
+	// implementation is overloaded and should not be considered failures.
+	ErrRetriable = errors.New("retriable http status code received")
 )
 
 // APIClient manages communication with the Rosetta API v1.4.6

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -57,7 +57,8 @@ func (f *Fetcher) RequestFailedError(
 	return &Error{
 		Err:       fmt.Errorf("%w: %s %s", ErrRequestFailed, message, err.Error()),
 		ClientErr: rosettaErr,
-		Retry:     ((rosettaErr != nil && rosettaErr.Retriable) || transientError(err)) && !errors.Is(err, context.Canceled),
+		Retry: ((rosettaErr != nil && rosettaErr.Retriable) || transientError(err)) &&
+			!errors.Is(err, context.Canceled),
 	}
 }
 

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -29,6 +29,11 @@ import (
 type Error struct {
 	Err       error        `json:"err"`
 	ClientErr *types.Error `json:"client_err"`
+
+	// Retry is a boolean that indicates if the request should be retried.
+	// It is the combination of the *types.Error.Retriable status and a
+	// collection of transient errors.
+	Retry bool `json:"retry"`
 }
 
 // RequestFailedError creates a new *Error and asserts the provided
@@ -52,6 +57,7 @@ func (f *Fetcher) RequestFailedError(
 	return &Error{
 		Err:       fmt.Errorf("%w: %s %s", ErrRequestFailed, message, err.Error()),
 		ClientErr: rosettaErr,
+		Retry:     ((rosettaErr != nil && rosettaErr.Retriable) || transientError(err)) && !errors.Is(err, context.Canceled),
 	}
 }
 

--- a/templates/client/api.mustache
+++ b/templates/client/api.mustache
@@ -89,6 +89,16 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 	}
 
 	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusOK:
+    {{#returnType}}
+    var v types.{{{returnType}}}
+    {{/returnType}}
+    err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+    if err != nil {
+      return nil, nil, err
+    }
+
+    return &v, nil, nil
 	case _nethttp.StatusInternalServerError:
 		var v types.Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -97,19 +107,22 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 		}
 
 		return nil, &v, fmt.Errorf("%+v", v)
-	case _nethttp.StatusBadGateway, _nethttp.StatusServiceUnavailable, _nethttp.StatusGatewayTimeout:
-		return nil, nil, fmt.Errorf("%w: code: %d body: %s", ErrRetriable, localVarHTTPResponse.StatusCode, string(localVarBody))
+	case _nethttp.StatusBadGateway,
+		_nethttp.StatusServiceUnavailable,
+		_nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf(
+			"%w: code: %d body: %s",
+			ErrRetriable,
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
+	default:
+		return nil, nil, fmt.Errorf(
+			"invalid status code: %d body: %s",
+			localVarHTTPResponse.StatusCode,
+			string(localVarBody),
+		)
 	}
-
-	{{#returnType}}
-  var v types.{{{returnType}}}
-	err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	{{/returnType}}
-	return &v, nil, nil
 }
 {{/operation}}
 {{/operations}}

--- a/templates/client/api.mustache
+++ b/templates/client/api.mustache
@@ -88,14 +88,17 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
     return nil, nil, err 
 	}
 
-	if localVarHTTPResponse.StatusCode != _nethttp.StatusOK {
-    var v types.Error
-    err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-    if err != nil {
-      return nil, nil, err 
-    }
+	switch localVarHTTPResponse.StatusCode {
+	case _nethttp.StatusInternalServerError:
+		var v types.Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
 
-		return nil, &v, fmt.Errorf("%+v", v) 
+		return nil, &v, fmt.Errorf("%+v", v)
+	case _nethttp.StatusBadGateway, _nethttp.StatusServiceUnavailable, _nethttp.StatusGatewayTimeout:
+		return nil, nil, fmt.Errorf("%w: code: %d body: %s", ErrRetriable, localVarHTTPResponse.StatusCode, string(localVarBody))
 	}
 
 	{{#returnType}}

--- a/templates/client/client.mustache
+++ b/templates/client/client.mustache
@@ -14,10 +14,16 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+  "errors"
 )
 
 var (
 	jsonCheck = regexp.MustCompile(`(?i:(?:application|text)/(?:vnd\.[^;]+\+)?json)`)
+
+  // ErrRetriable is returned when a 502, 503, or 504 HTTP code is encountered.
+  // These status codes may be returned by intermediate services when a Rosetta
+  // implementation is overloaded and should not be considered failures.
+  ErrRetriable = errors.New("retriable http status code received")
 )
 
 // APIClient manages communication with the {{appName}} API v{{version}}


### PR DESCRIPTION
In some cases, intermediate services will return a 502, 503, or 504 HTTP status code before making a request to a Rosetta implementation. This can cause clients to error hard instead of retrying gracefully. This PR ensures we treat these errors as retriable.

### Changes
- [x] return retriable error from `client`
- [x] respect `ErrRetriable` in `fetcher`