### PR TITLE
[chore] rosetta-specifications@v1.4.8

### DIFF
--- a/asserter/server.go
+++ b/asserter/server.go
@@ -513,10 +513,12 @@ func (a *Asserter) SearchTransactionsRequest( // nolint:gocognit
 		return err
 	}
 
-	switch request.Operator {
-	case types.AND, types.OR:
-	default:
-		return ErrOperatorInvalid
+	if request.Operator != nil {
+		switch *request.Operator {
+		case types.AND, types.OR:
+		default:
+			return ErrOperatorInvalid
+		}
 	}
 
 	if request.MaxBlock != nil && *request.MaxBlock < 0 {

--- a/asserter/server_test.go
+++ b/asserter/server_test.go
@@ -1525,17 +1525,23 @@ func TestSearchTransactionsRequest(t *testing.T) {
 		request *types.SearchTransactionsRequest
 		err     error
 	}{
+		"valid request no operator": {
+			request: &types.SearchTransactionsRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+			},
+			err: nil,
+		},
 		"valid request": {
 			request: &types.SearchTransactionsRequest{
 				NetworkIdentifier: validNetworkIdentifier,
-				Operator:          types.AND,
+				Operator:          types.OperatorP(types.AND),
 			},
 			err: nil,
 		},
 		"invalid request wrong network": {
 			request: &types.SearchTransactionsRequest{
 				NetworkIdentifier: wrongNetworkIdentifier,
-				Operator:          types.OR,
+				Operator:          types.OperatorP(types.OR),
 			},
 			err: fmt.Errorf(
 				"%w: %+v",
@@ -1550,7 +1556,7 @@ func TestSearchTransactionsRequest(t *testing.T) {
 		"negative max block": {
 			request: &types.SearchTransactionsRequest{
 				NetworkIdentifier: validNetworkIdentifier,
-				Operator:          types.OR,
+				Operator:          types.OperatorP(types.OR),
 				MaxBlock:          types.Int64(-1),
 			},
 			err: ErrMaxBlockInvalid,
@@ -1558,7 +1564,7 @@ func TestSearchTransactionsRequest(t *testing.T) {
 		"negative offset": {
 			request: &types.SearchTransactionsRequest{
 				NetworkIdentifier: validNetworkIdentifier,
-				Operator:          types.OR,
+				Operator:          types.OperatorP(types.OR),
 				Offset:            types.Int64(-1),
 			},
 			err: ErrOffsetIsNegative,
@@ -1566,7 +1572,7 @@ func TestSearchTransactionsRequest(t *testing.T) {
 		"negative limit": {
 			request: &types.SearchTransactionsRequest{
 				NetworkIdentifier: validNetworkIdentifier,
-				Operator:          types.OR,
+				Operator:          types.OperatorP(types.OR),
 				Limit:             types.Int64(-1),
 			},
 			err: ErrLimitIsNegative,
@@ -1574,7 +1580,7 @@ func TestSearchTransactionsRequest(t *testing.T) {
 		"invalid operator": {
 			request: &types.SearchTransactionsRequest{
 				NetworkIdentifier: validNetworkIdentifier,
-				Operator:          "NOR",
+				Operator:          types.OperatorP("NOR"),
 			},
 			err: ErrOperatorInvalid,
 		},

--- a/client/client.go
+++ b/client/client.go
@@ -41,7 +41,7 @@ var (
 	ErrRetriable = errors.New("retriable http status code received")
 )
 
-// APIClient manages communication with the Rosetta API v1.4.7
+// APIClient manages communication with the Rosetta API v1.4.8
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,7 +53,7 @@ done
 rm -rf tmp;
 
 # Download spec file from releases
-ROSETTA_SPEC_VERSION=1.4.7
+ROSETTA_SPEC_VERSION=1.4.8
 curl -L https://github.com/coinbase/rosetta-specifications/releases/download/v${ROSETTA_SPEC_VERSION}/api.json -o api.json;
 
 # Generate client + types code
@@ -119,7 +119,6 @@ sed "${SED_IFLAG[@]}" 's/*CurveType/CurveType/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/*SignatureType/SignatureType/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/*CoinAction/CoinAction/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/*ExemptionType/ExemptionType/g' client/* server/*;
-sed "${SED_IFLAG[@]}" 's/*Operator/Operator/g' client/* server/*;
 sed "${SED_IFLAG[@]}" 's/*BlockEventType/BlockEventType/g' client/* server/*;
 
 # Fix CurveTypes, SignatureTypes, CoinActions, ExemptionTypes 

--- a/fetcher/search_test.go
+++ b/fetcher/search_test.go
@@ -32,7 +32,6 @@ import (
 var (
 	basicSearchTransactionsRequest = &types.SearchTransactionsRequest{
 		NetworkIdentifier: basicNetwork,
-		Operator:          types.AND,
 		TransactionIdentifier: &types.TransactionIdentifier{
 			Hash: "tx",
 		},

--- a/types/operator.go
+++ b/types/operator.go
@@ -16,7 +16,8 @@
 
 package types
 
-// Operator Operator is used by query-related endpoints to determine how to apply conditions.
+// Operator Operator is used by query-related endpoints to determine how to apply conditions. If
+// this field is not populated, the default `and` value will be used.
 type Operator string
 
 // List of Operator

--- a/types/search_transactions_request.go
+++ b/types/search_transactions_request.go
@@ -20,7 +20,7 @@ package types
 // set of provided conditions in canonical blocks.
 type SearchTransactionsRequest struct {
 	NetworkIdentifier *NetworkIdentifier `json:"network_identifier"`
-	Operator          Operator           `json:"operator"`
+	Operator          *Operator          `json:"operator,omitempty"`
 	// max_block is the largest block index to consider when searching for transactions. If this
 	// field is not populated, the current block is considered the max_block. If you do not specify
 	// a max_block, it is possible a newly synced block will interfere with paginated transaction

--- a/types/types.go
+++ b/types/types.go
@@ -18,5 +18,5 @@ const (
 	// RosettaAPIVersion is the version of the Rosetta API
 	// specification used to generate code for this release
 	// of the SDK.
-	RosettaAPIVersion = "1.4.7"
+	RosettaAPIVersion = "1.4.8"
 )

--- a/types/utils.go
+++ b/types/utils.go
@@ -297,3 +297,13 @@ func Int64(i int64) *int64 {
 func Bool(b bool) *bool {
 	return &b
 }
+
+// OperatorP returns a pointer to the
+// Operator passed as an argument.
+//
+// We can't just use Operator because
+// the types package already declares
+// the Operator type.
+func OperatorP(o Operator) *Operator {
+	return &o
+}


### PR DESCRIPTION
This PR updates `rosetta-sdk-go` to [`rosetta-specifications@v1.4.8`](https://github.com/coinbase/rosetta-specifications/releases/tag/v1.4.8).

### Changes
- [x] add new `types.OperatorP` function
- [x] update codegen
- [x] update `asserter` 