### PR TITLE
[syncer] Only invoke cancel when successful

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -565,14 +565,13 @@ func (s *Syncer) Tip() *types.BlockIdentifier {
 }
 
 // Sync cycles endlessly until there is an error
-// or the requested range is synced.
+// or the requested range is synced. When the requested
+// range is synced, context is canceled.
 func (s *Syncer) Sync(
 	ctx context.Context,
 	startIndex int64,
 	endIndex int64,
 ) error {
-	defer s.cancel()
-
 	if err := s.setStart(ctx, startIndex); err != nil {
 		return fmt.Errorf("%w: %v", ErrSetStartIndexFailed, err)
 	}
@@ -615,6 +614,7 @@ func (s *Syncer) Sync(
 		startIndex = s.genesisBlock.Index
 	}
 
+	s.cancel()
 	log.Printf("Finished syncing %d-%d\n", startIndex, endIndex)
 	return nil
 }


### PR DESCRIPTION
In #228, we introduced a regression into `syncer` where a `non-nil` error could be silenced by `context.Canceled`. This PR fixes this regression.

In short, we were always calling `context.Cancel()` when `syncer.Sync` returned (with `defer`). Because of the extra locking on exit added in #228, this delayed the return of `Sync` but not the invocation of cancel. This caused other functions to return with a non-nil error before `syncer.Sync` (which had the useful error) and `rosetta-cli` to return `context.Canceled` as the error instead of something interesting (as the [expected behavior](https://godoc.org/golang.org/x/sync/errgroup#Group.Wait) of `errgroup` is to return the first non-nil error from `Wait`).