### PR TITLE
[utils] Add MutexMap

### DIFF
--- a/utils/priority_mutex_map.go
+++ b/utils/priority_mutex_map.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"sync"
+)
+
+// MutexMap is a struct that allows for
+// acquiring a *PriorityMutex via a string identifier
+// or for acquiring a global mutex that blocks
+// the acquisition of any identifier mutexes.
+//
+// This is useful for coordinating concurrent, non-overlapping
+// writes in the storage package.
+type MutexMap struct {
+	table map[string]*PriorityMutex
+	m     sync.Mutex
+
+	globalMutex sync.RWMutex
+}
+
+// NewMutexMap returns a new *MutexMap.
+func NewMutexMap() *MutexMap {
+	return &MutexMap{
+		table: map[string]*PriorityMutex{},
+	}
+}
+
+// GLock acquires an exclusive lock across
+// an entire *MutexMap.
+func (m *MutexMap) GLock() {
+	m.globalMutex.Lock()
+}
+
+// GUnlock releases an exclusive lock
+// held for an entire *MutexMap.
+func (m *MutexMap) GUnlock() {
+	m.globalMutex.Unlock()
+}
+
+// Lock acquires a lock for a particular identifier, as long
+// as no other caller has the global mutex or a lock
+// by the same identifier.
+func (m *MutexMap) Lock(identifier string, priority bool) {
+	// We acquire m when adding items to m.table
+	// so that we don't accidentally overwrite
+	// lock created by another goroutine.
+	m.m.Lock()
+	l, ok := m.table[identifier]
+	if !ok {
+		l = new(PriorityMutex)
+		m.table[identifier] = l
+	}
+	m.m.Unlock()
+
+	// We acquire a RLock on m.globalMutex before
+	// acquiring our identifier lock to ensure no
+	// goroutine holds an identifier mutex while
+	// the m.globalMutex is also held.
+	m.globalMutex.RLock()
+
+	// Once we have a m.globalMutex.RLock, it is
+	// safe to acquire an identifier lock.
+	l.Lock(priority)
+}
+
+// Unlock releases a lock held for a particular identifier.
+func (m *MutexMap) Unlock(identifier string) {
+	// The lock at a particular identifier MUST
+	// exist by the time we unlock, otherwise
+	// it would not have been possible to get
+	// the lock to begin with.
+	m.table[identifier].Unlock()
+
+	// We release the globalMutex after unlocking
+	// the identifier lock, otherwise it would be possible
+	// for GLock to be acquired while still holding some
+	// lock in the table.
+	m.globalMutex.RUnlock()
+}

--- a/utils/priority_mutex_map_test.go
+++ b/utils/priority_mutex_map_test.go
@@ -34,7 +34,7 @@ func TestMutexMap(t *testing.T) {
 	// Add another GLock
 	g.Go(func() error {
 		m.GLock()
-		arr = append(arr, "global")
+		arr = append(arr, "global-b")
 		m.GUnlock()
 		return nil
 	})
@@ -69,17 +69,17 @@ func TestMutexMap(t *testing.T) {
 
 	// Ensure number of expected locks is correct
 	assert.Len(t, m.entries, 0)
-	arr = append(arr, "global")
+	arr = append(arr, "global-a")
 	m.GUnlock()
 	assert.NoError(t, g.Wait())
 
 	// Check results array to ensure all of the high priority items processed first,
 	// followed by all of the low priority items.
 	assert.Equal(t, []string{
-		"global",
+		"global-a",
 		"a",
 		"b",
-		"global", // must wait until all other locks complete
+		"global-b", // must wait until all other locks complete
 	}, arr)
 
 	// Ensure lock is no longer occupied

--- a/utils/priority_mutex_map_test.go
+++ b/utils/priority_mutex_map_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (
@@ -33,7 +47,7 @@ func TestMutexMap(t *testing.T) {
 
 	g.Go(func() error {
 		m.Lock("a", false)
-		assert.Equal(t, m.table["a"].count, 1)
+		assert.Equal(t, m.entries["a"].count, 1)
 		<-a
 		arr = append(arr, "a")
 		close(b)
@@ -43,7 +57,7 @@ func TestMutexMap(t *testing.T) {
 
 	g.Go(func() error {
 		m.Lock("b", false)
-		assert.Equal(t, m.table["b"].count, 1)
+		assert.Equal(t, m.entries["b"].count, 1)
 		close(a)
 		<-b
 		arr = append(arr, "b")
@@ -54,7 +68,7 @@ func TestMutexMap(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Ensure number of expected locks is correct
-	assert.Len(t, m.table, 0)
+	assert.Len(t, m.entries, 0)
 	arr = append(arr, "global")
 	m.GUnlock()
 	assert.NoError(t, g.Wait())
@@ -69,5 +83,5 @@ func TestMutexMap(t *testing.T) {
 	}, arr)
 
 	// Ensure lock is no longer occupied
-	assert.Len(t, m.table, 0)
+	assert.Len(t, m.entries, 0)
 }

--- a/utils/priority_mutex_map_test.go
+++ b/utils/priority_mutex_map_test.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestMutexMap(t *testing.T) {
+	arr := []string{}
+	m := NewMutexMap()
+	g, _ := errgroup.WithContext(context.Background())
+
+	// Lock while adding all locks
+	m.GLock()
+
+	// Add another GLock
+	g.Go(func() error {
+		m.GLock()
+		arr = append(arr, "global")
+		m.GUnlock()
+		return nil
+	})
+
+	// To test locking, we use channels
+	// that will cause deadlock if not executed
+	// concurrently.
+	a := make(chan struct{})
+	b := make(chan struct{})
+
+	g.Go(func() error {
+		m.Lock("a", false)
+		assert.Equal(t, m.table["a"].count, 1)
+		<-a
+		arr = append(arr, "a")
+		close(b)
+		m.Unlock("a")
+		return nil
+	})
+
+	g.Go(func() error {
+		m.Lock("b", false)
+		assert.Equal(t, m.table["b"].count, 1)
+		close(a)
+		<-b
+		arr = append(arr, "b")
+		m.Unlock("b")
+		return nil
+	})
+
+	time.Sleep(1 * time.Second)
+
+	// Ensure number of expected locks is correct
+	assert.Len(t, m.table, 0)
+	arr = append(arr, "global")
+	m.GUnlock()
+	assert.NoError(t, g.Wait())
+
+	// Check results array to ensure all of the high priority items processed first,
+	// followed by all of the low priority items.
+	assert.Equal(t, []string{
+		"global",
+		"a",
+		"b",
+		"global", // must wait until all other locks complete
+	}, arr)
+
+	// Ensure lock is no longer occupied
+	assert.Len(t, m.table, 0)
+}

--- a/utils/priority_mutex_test.go
+++ b/utils/priority_mutex_test.go
@@ -69,5 +69,5 @@ func TestPriorityMutex(t *testing.T) {
 	assert.Equal(t, expected, arr)
 
 	// Ensure lock is no longer occupied
-	assert.False(t, l.l)
+	assert.False(t, l.lock)
 }


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/tree/patrick/priority-lock

This PR implements a new data structure called a `MutexMap`. `MutexMap` allows the caller to acquire a global lock across any number of `*PriorityMutex` and to identify locks by some identifier (which enables very fine-grained locking). This data structure can be used to implement concurrent, non-conflicting database transactions in `storage`.

### Changes
- [x] Implement `MutexMap`
- [x] Add tests
- [x] Cleanup style of `PriorityMutex` and `MutexMap`: https://github.com/coinbase/rosetta-sdk-go/pull/244#discussion_r528938275

### Future Work
In a subsequent PR, we will implement another new data structure called `ShardedMap` that removes the need to acquire a global lock on `entries`.