### PR TITLE
[storage] Interface Overhaul

### DIFF
--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -244,7 +244,7 @@ func TestProcess(t *testing.T) {
 	// all responses from the database and "write" transactions require a
 	// lock. While it would be possible to orchestrate these locks in this
 	// test, it is simpler to just use a "read" transaction.
-	dbTxFail := db.NewDatabaseTransaction(ctx, false)
+	dbTxFail := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
 	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTxFail, "transfer").Return([]*job.Job{}, nil).Once()
@@ -261,7 +261,7 @@ func TestProcess(t *testing.T) {
 	// Determine account must be created
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
 
-	dbTx := db.NewDatabaseTransaction(ctx, false)
+	dbTx := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx).Once()
 	jobStorage.On("Ready", ctx, dbTx).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Broadcasting", ctx, dbTx).Return([]*job.Job{}, nil).Once()
@@ -292,7 +292,7 @@ func TestProcess(t *testing.T) {
 
 	// Attempt to run transfer again (but determine funds are needed)
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTxFail2 := db.NewDatabaseTransaction(ctx, false)
+	dbTxFail2 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail2).Once()
 	jobStorage.On("Ready", ctx, dbTxFail2).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTxFail2, "transfer").Return([]*job.Job{}, nil).Once()
@@ -323,7 +323,7 @@ func TestProcess(t *testing.T) {
 	// Attempt funds request
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
 
-	dbTx2 := db.NewDatabaseTransaction(ctx, false)
+	dbTx2 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx2).Once()
 	jobStorage.On("Ready", ctx, dbTx2).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Broadcasting", ctx, dbTx2).Return([]*job.Job{}, nil).Once()
@@ -370,7 +370,7 @@ func TestProcess(t *testing.T) {
 
 	// Load funds
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTxExtra := db.NewDatabaseTransaction(ctx, false)
+	dbTxExtra := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxExtra).Once()
 	jobStorage.On("Ready", ctx, dbTxExtra).Return([]*job.Job{&jobExtra}, nil).Once()
 	helper.On("AllAccounts", ctx, dbTxExtra).Return([]*types.AccountIdentifier{
@@ -403,7 +403,7 @@ func TestProcess(t *testing.T) {
 
 	// Attempt to transfer again
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTxFail3 := db.NewDatabaseTransaction(ctx, false)
+	dbTxFail3 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail3).Once()
 	jobStorage.On("Ready", ctx, dbTxFail3).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTxFail3, "transfer").Return([]*job.Job{}, nil).Once()
@@ -437,7 +437,7 @@ func TestProcess(t *testing.T) {
 
 	// Attempt to create recipient
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx3 := db.NewDatabaseTransaction(ctx, false)
+	dbTx3 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx3).Once()
 	jobStorage.On("Ready", ctx, dbTx3).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Broadcasting", ctx, dbTx3).Return([]*job.Job{}, nil).Once()
@@ -468,7 +468,7 @@ func TestProcess(t *testing.T) {
 
 	// Attempt to create transfer
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx4 := db.NewDatabaseTransaction(ctx, false)
+	dbTx4 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx4).Once()
 	jobStorage.On("Ready", ctx, dbTx4).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTx4, "transfer").Return([]*job.Job{}, nil).Once()
@@ -676,7 +676,7 @@ func TestProcess(t *testing.T) {
 
 	// Wait for transfer to complete
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx5 := db.NewDatabaseTransaction(ctx, false)
+	dbTx5 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx5).Once()
 	jobStorage.On("Ready", ctx, dbTx5).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTx5, "transfer").Return([]*job.Job{&job4}, nil).Once()
@@ -720,7 +720,7 @@ func TestProcess(t *testing.T) {
 	}
 	go func() {
 		<-markConfirmed
-		dbTx6 := db.NewDatabaseTransaction(ctx, false)
+		dbTx6 := db.ReadTransaction(ctx)
 		jobStorage.On("Get", ctx, dbTx6, "job4").Return(&job4, nil).Once()
 		jobStorage.On(
 			"Update",
@@ -745,7 +745,7 @@ func TestProcess(t *testing.T) {
 	}()
 
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx7 := db.NewDatabaseTransaction(ctx, false)
+	dbTx7 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx7).Once()
 	jobStorage.On("Ready", ctx, dbTx7).Return([]*job.Job{&job4}, nil).Once()
 	jobStorage.On(
@@ -880,7 +880,7 @@ func TestProcess_Failed(t *testing.T) {
 
 	// Attempt to create transfer
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx := db.NewDatabaseTransaction(ctx, false)
+	dbTx := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx).Once()
 	jobStorage.On("Ready", ctx, dbTx).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTx, "transfer").Return([]*job.Job{}, nil).Once()
@@ -1147,7 +1147,7 @@ func TestProcess_Failed(t *testing.T) {
 
 	// Wait for transfer to complete
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx2 := db.NewDatabaseTransaction(ctx, false)
+	dbTx2 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx2).Once()
 	jobStorage.On("Ready", ctx, dbTx2).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTx2, "transfer").Return([]*job.Job{&j}, nil).Once()
@@ -1161,7 +1161,7 @@ func TestProcess_Failed(t *testing.T) {
 
 	go func() {
 		<-markConfirmed
-		dbTx3 := db.NewDatabaseTransaction(ctx, false)
+		dbTx3 := db.ReadTransaction(ctx)
 		jobStorage.On("Get", ctx, dbTx3, jobIdentifier).Return(&j, nil).Once()
 		jobStorage.On(
 			"Update",
@@ -1398,7 +1398,7 @@ func TestProcess_DryRun(t *testing.T) {
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
 
 	// Attempt to transfer
-	dbTx := db.NewDatabaseTransaction(ctx, false)
+	dbTx := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx).Once()
 	jobStorage.On("Ready", ctx, dbTx).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTx, "transfer").Return([]*job.Job{}, nil).Once()
@@ -1509,7 +1509,7 @@ func TestProcess_DryRun(t *testing.T) {
 
 	// Process second scenario
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx2 := db.NewDatabaseTransaction(ctx, false)
+	dbTx2 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx2).Once()
 	jobStorage.On("Ready", ctx, dbTx2).Return([]*job.Job{&j}, nil).Once()
 	jobStorage.On("Update", ctx, dbTx2, mock.Anything).Run(func(args mock.Arguments) {
@@ -1683,7 +1683,7 @@ func TestReturnFunds_NoBalance(t *testing.T) {
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
 
 	// Attempt to transfer
-	dbTxFail := db.NewDatabaseTransaction(ctx, false)
+	dbTxFail := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
 	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
 	jobStorage.On(
@@ -1748,7 +1748,7 @@ func TestReturnFunds_NoBalance(t *testing.T) {
 
 	// Will exit this round because we've tried all workflows.
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx2 := db.NewDatabaseTransaction(ctx, false)
+	dbTx2 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx2).Once()
 	jobStorage.On("Ready", ctx, dbTx2).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Broadcasting", ctx, dbTx2).Return([]*job.Job{}, nil).Once()
@@ -2015,7 +2015,7 @@ func TestReturnFunds(t *testing.T) {
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
 
 	// Attempt to transfer
-	dbTxFail := db.NewDatabaseTransaction(ctx, false)
+	dbTxFail := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
 	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
 	jobStorage.On(
@@ -2214,7 +2214,7 @@ func TestReturnFunds(t *testing.T) {
 
 	// Wait for transfer to complete
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx := db.NewDatabaseTransaction(ctx, false)
+	dbTx := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx).Once()
 	jobStorage.On("Ready", ctx, dbTx).Return([]*job.Job{}, nil).Once()
 	jobStorage.On(
@@ -2266,7 +2266,7 @@ func TestReturnFunds(t *testing.T) {
 	}
 	go func() {
 		<-markConfirmed
-		dbTx2 := db.NewDatabaseTransaction(ctx, false)
+		dbTx2 := db.ReadTransaction(ctx)
 		jobStorage.On("Get", ctx, dbTx2, jobIdentifier).Return(&j, nil).Once()
 		jobStorage.On(
 			"Update",
@@ -2291,7 +2291,7 @@ func TestReturnFunds(t *testing.T) {
 
 	// No balance remaining
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx3 := db.NewDatabaseTransaction(ctx, false)
+	dbTx3 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx3).Once()
 	jobStorage.On("Ready", ctx, dbTx3).Return([]*job.Job{}, nil).Once()
 	jobStorage.On(
@@ -2329,7 +2329,7 @@ func TestReturnFunds(t *testing.T) {
 
 	// Will exit this round because we've tried all workflows.
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx4 := db.NewDatabaseTransaction(ctx, false)
+	dbTx4 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx4).Once()
 	jobStorage.On("Ready", ctx, dbTx4).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Broadcasting", ctx, dbTx4).Return([]*job.Job{}, nil).Once()
@@ -2444,7 +2444,7 @@ func TestNoReservedWorkflows(t *testing.T) {
 	// all responses from the database and "write" transactions require a
 	// lock. While it would be possible to orchestrate these locks in this
 	// test, it is simpler to just use a "read" transaction.
-	dbTxFail := db.NewDatabaseTransaction(ctx, false)
+	dbTxFail := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTxFail).Once()
 	jobStorage.On("Ready", ctx, dbTxFail).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Processing", ctx, dbTxFail, "transfer").Return([]*job.Job{}, nil).Once()
@@ -2458,7 +2458,7 @@ func TestNoReservedWorkflows(t *testing.T) {
 	}()
 
 	helper.On("HeadBlockExists", ctx).Return(true).Once()
-	dbTx2 := db.NewDatabaseTransaction(ctx, false)
+	dbTx2 := db.ReadTransaction(ctx)
 	helper.On("DatabaseTransaction", ctx).Return(dbTx2).Once()
 	jobStorage.On("Ready", ctx, dbTx2).Return([]*job.Job{}, nil).Once()
 	jobStorage.On("Broadcasting", ctx, dbTx2).Return([]*job.Job{}, nil).Once()

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -963,7 +963,7 @@ func TestFindBalanceWorker(t *testing.T) {
 			assert.NotNil(t, db)
 			defer db.Close(ctx)
 
-			dbTx := db.NewDatabaseTransaction(ctx, true)
+			dbTx := db.Transaction(ctx)
 			defer dbTx.Discard(ctx)
 
 			worker := New(test.mockHelper)
@@ -1125,7 +1125,7 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 	assert.NotNil(t, db)
 	defer db.Close(ctx)
 
-	dbTx := db.NewDatabaseTransaction(ctx, true)
+	dbTx := db.Transaction(ctx)
 
 	network := &types.NetworkIdentifier{
 		Blockchain: "Bitcoin",
@@ -1643,7 +1643,7 @@ func TestJob_Failures(t *testing.T) {
 			assert.NotNil(t, db)
 			defer db.Close(ctx)
 
-			dbTx := db.NewDatabaseTransaction(ctx, true)
+			dbTx := db.Transaction(ctx)
 
 			assert.False(t, j.CheckComplete())
 

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -197,6 +197,7 @@ func NewBadgerStorage(
 		closed:        make(chan struct{}),
 		pool:          NewBufferPool(),
 		compress:      true,
+		writer:        utils.NewMutexMap(utils.DefaultShards),
 	}
 	for _, opt := range storageOptions {
 		opt(b)

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -306,8 +306,8 @@ type BadgerTransaction struct {
 	buffersToReclaim []*bytes.Buffer
 }
 
-// GTransaction creates a new exclusive write BadgerTransaction.
-func (b *BadgerStorage) GTransaction(
+// Transaction creates a new exclusive write BadgerTransaction.
+func (b *BadgerStorage) Transaction(
 	ctx context.Context,
 ) DatabaseTransaction {
 	b.writer.GLock()
@@ -320,8 +320,8 @@ func (b *BadgerStorage) GTransaction(
 	}
 }
 
-// RTransaction creates a new read BadgerTransaction.
-func (b *BadgerStorage) RTransaction(
+// ReadTransaction creates a new read BadgerTransaction.
+func (b *BadgerStorage) ReadTransaction(
 	ctx context.Context,
 ) DatabaseTransaction {
 	return &BadgerTransaction{
@@ -331,8 +331,9 @@ func (b *BadgerStorage) RTransaction(
 	}
 }
 
-// WTransaction creates a new write BadgerTransaction.
-func (b *BadgerStorage) WTransaction(
+// WriteTransaction creates a new write BadgerTransaction
+// for a particular identifier.
+func (b *BadgerStorage) WriteTransaction(
 	ctx context.Context,
 	identifier string,
 	priority bool,
@@ -571,7 +572,7 @@ func recompress(
 	onDiskSize := float64(0)
 	newSize := float64(0)
 
-	txn := badgerDb.RTransaction(ctx)
+	txn := badgerDb.ReadTransaction(ctx)
 	defer txn.Discard(ctx)
 	_, err := txn.Scan(
 		ctx,
@@ -645,7 +646,7 @@ func BadgerTrain(
 	totalUncompressedSize := float64(0)
 	totalDiskSize := float64(0)
 	entriesSeen := 0
-	txn := badgerDb.RTransaction(ctx)
+	txn := badgerDb.ReadTransaction(ctx)
 	defer txn.Discard(ctx)
 	_, err = txn.Scan(
 		ctx,

--- a/storage/badger_storage.go
+++ b/storage/badger_storage.go
@@ -171,7 +171,7 @@ func PerformanceBadgerOptions(dir string) badger.Options {
 	// This option will have a significant effect the memory. If the level is kept
 	// in-memory, read are faster but the tables will be kept in memory. By default,
 	// this is set to false.
-	opts.KeepL0InMemory = false
+	opts.KeepL0InMemory = true
 
 	// We don't compact L0 on close as this can greatly delay shutdown time.
 	opts.CompactL0OnClose = false
@@ -179,7 +179,7 @@ func PerformanceBadgerOptions(dir string) badger.Options {
 	// LoadBloomsOnOpen=false will improve the db startup speed. This is also
 	// a waste to enable with a limited index cache size (as many of the loaded bloom
 	// filters will be immediately discarded from the cache).
-	opts.LoadBloomsOnOpen = false
+	opts.LoadBloomsOnOpen = true
 
 	return opts
 }

--- a/storage/badger_storage_configuration.go
+++ b/storage/badger_storage_configuration.go
@@ -56,3 +56,13 @@ func WithCustomSettings(settings badger.Options) BadgerOption {
 		b.badgerOptions = settings
 	}
 }
+
+// WithWriterShards overrides the default shards used
+// in the writer utils.MutexMap. It is recommended
+// to set this value to your write concurrency to prevent
+// lock contention.
+func WithWriterShards(shards int) BadgerOption {
+	return func(b *BadgerStorage) {
+		b.writerShards = shards
+	}
+}

--- a/storage/balance_storage.go
+++ b/storage/balance_storage.go
@@ -271,7 +271,7 @@ func (b *BalanceStorage) Reconciled(
 	currency *types.Currency,
 	block *types.BlockIdentifier,
 ) error {
-	dbTx := b.db.NewDatabaseTransaction(ctx, true)
+	dbTx := b.db.Transaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	err := b.updateAccountEntry(
@@ -496,7 +496,7 @@ func (b *BalanceStorage) PruneBalances(
 	currency *types.Currency,
 	index int64,
 ) error {
-	dbTx := b.db.NewDatabaseTransaction(ctx, true)
+	dbTx := b.db.Transaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	err := b.removeHistoricalBalances(
@@ -636,7 +636,7 @@ func (b *BalanceStorage) GetBalance(
 	currency *types.Currency,
 	index int64,
 ) (*types.Amount, error) {
-	dbTx := b.db.NewDatabaseTransaction(ctx, false)
+	dbTx := b.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	amount, err := b.GetBalanceTransactional(
@@ -749,7 +749,7 @@ func (b *BalanceStorage) GetOrSetBalance(
 	currency *types.Currency,
 	block *types.BlockIdentifier,
 ) (*types.Amount, error) {
-	dbTx := b.db.NewDatabaseTransaction(ctx, true)
+	dbTx := b.db.Transaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	amount, err := b.GetOrSetBalanceTransactional(
@@ -832,7 +832,7 @@ func (b *BalanceStorage) BootstrapBalances(
 	}
 
 	// Update balances in database
-	dbTransaction := b.db.NewDatabaseTransaction(ctx, true)
+	dbTransaction := b.db.Transaction(ctx)
 	defer dbTransaction.Discard(ctx)
 
 	for _, balance := range balances {
@@ -881,7 +881,7 @@ func (b *BalanceStorage) getAllAccountEntries(
 	ctx context.Context,
 	handler func(accountEntry),
 ) error {
-	txn := b.db.NewDatabaseTransaction(ctx, false)
+	txn := b.db.ReadTransaction(ctx)
 	defer txn.Discard(ctx)
 	_, err := txn.Scan(
 		ctx,
@@ -948,7 +948,7 @@ func (b *BalanceStorage) SetBalanceImported(
 	accountBalances []*utils.AccountBalance,
 ) error {
 	// Update balances in database
-	transaction := b.db.NewDatabaseTransaction(ctx, true)
+	transaction := b.db.Transaction(ctx)
 	defer transaction.Discard(ctx)
 
 	for _, accountBalance := range accountBalances {

--- a/storage/balance_storage_test.go
+++ b/storage/balance_storage_test.go
@@ -201,7 +201,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("Set and get genesis balance", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.SetBalance(
 			ctx,
 			txn,
@@ -224,7 +224,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("Set and get balance", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.SetBalance(
 			ctx,
 			txn,
@@ -246,7 +246,7 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Set and get balance with storage helper", func(t *testing.T) {
 		mockHelper.AccountBalanceAmount = "10"
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -269,7 +269,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("Set balance with nil currency", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -290,7 +290,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("Modify existing balance", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err = storage.UpdateBalance(
 			ctx,
 			txn,
@@ -311,7 +311,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("Discard transaction", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -326,7 +326,7 @@ func TestBalance(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Get balance during transaction
-		readTx := storage.db.NewDatabaseTransaction(ctx, false)
+		readTx := storage.db.ReadTransaction(ctx)
 		defer readTx.Discard(ctx)
 		retrievedAmount, err := storage.GetBalanceTransactional(
 			ctx,
@@ -342,7 +342,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("Attempt modification to push balance negative on existing account", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -359,7 +359,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("Attempt modification to push balance negative on new acct", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -377,7 +377,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("sub account set and get balance", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -403,7 +403,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("sub account metadata set and get balance", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -429,7 +429,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("sub account unique metadata set and get balance", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -455,7 +455,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("balance exemption update", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.SetBalance(
 			ctx,
 			txn,
@@ -471,7 +471,7 @@ func TestBalance(t *testing.T) {
 
 		// Successful (balance > computed and negative intermediate value)
 		mockHelper.AccountBalanceAmount = "150"
-		txn = storage.db.NewDatabaseTransaction(ctx, true)
+		txn = storage.db.Transaction(ctx)
 		err = storage.UpdateBalance(
 			ctx,
 			txn,
@@ -497,7 +497,7 @@ func TestBalance(t *testing.T) {
 
 		// Successful (balance == computed)
 		mockHelper.AccountBalanceAmount = "200"
-		txn = storage.db.NewDatabaseTransaction(ctx, true)
+		txn = storage.db.Transaction(ctx)
 		err = storage.UpdateBalance(
 			ctx,
 			txn,
@@ -523,7 +523,7 @@ func TestBalance(t *testing.T) {
 
 		// Unsuccessful (balance < computed)
 		mockHelper.AccountBalanceAmount = "10"
-		txn = storage.db.NewDatabaseTransaction(ctx, true)
+		txn = storage.db.Transaction(ctx)
 		err = storage.UpdateBalance(
 			ctx,
 			txn,
@@ -629,7 +629,7 @@ func TestBalance(t *testing.T) {
 	})
 
 	t.Run("update existing balance", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		orphanValue, _ := new(big.Int).SetString(largeDeduction.Value, 10)
 		err := storage.UpdateBalance(
 			ctx,
@@ -683,7 +683,7 @@ func TestBalance(t *testing.T) {
 			Currency: largeDeduction.Currency,
 		}, retrievedAmount)
 
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err = storage.OrphanBalance(
 			ctx,
 			txn,
@@ -938,7 +938,7 @@ func TestBootstrapBalances(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Attempt to update balance
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err = storage.UpdateBalance(
 			ctx,
 			txn,
@@ -1105,7 +1105,7 @@ func TestBalanceReconciliation(t *testing.T) {
 	})
 
 	t.Run("set balance", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err := storage.UpdateBalance(
 			ctx,
 			txn,
@@ -1129,7 +1129,7 @@ func TestBalanceReconciliation(t *testing.T) {
 		err := storage.Reconciled(ctx, account, currency, genesisBlock)
 		assert.NoError(t, err)
 
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err = storage.UpdateBalance(
 			ctx,
 			txn,
@@ -1181,7 +1181,7 @@ func TestBalanceReconciliation(t *testing.T) {
 	})
 
 	t.Run("add unreconciled", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		err = storage.UpdateBalance(
 			ctx,
 			txn,
@@ -1380,7 +1380,7 @@ func TestBlockSyncing(t *testing.T) {
 	}
 
 	t.Run("add genesis block", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		_, err = storage.AddingBlock(ctx, b0, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, dbTx.Commit(ctx))
@@ -1394,7 +1394,7 @@ func TestBlockSyncing(t *testing.T) {
 	})
 
 	t.Run("add block 1", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		_, err = storage.AddingBlock(ctx, b1, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, dbTx.Commit(ctx))
@@ -1417,7 +1417,7 @@ func TestBlockSyncing(t *testing.T) {
 	})
 
 	t.Run("add block 2", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		_, err = storage.AddingBlock(ctx, b2, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, dbTx.Commit(ctx))
@@ -1455,7 +1455,7 @@ func TestBlockSyncing(t *testing.T) {
 	})
 
 	t.Run("orphan block 2", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		_, err = storage.RemovingBlock(ctx, b2, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, dbTx.Commit(ctx))
@@ -1487,7 +1487,7 @@ func TestBlockSyncing(t *testing.T) {
 	})
 
 	t.Run("orphan block 1", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		_, err = storage.RemovingBlock(ctx, b1, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, dbTx.Commit(ctx))
@@ -1513,7 +1513,7 @@ func TestBlockSyncing(t *testing.T) {
 	})
 
 	t.Run("add block 1", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		_, err = storage.AddingBlock(ctx, b1, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, dbTx.Commit(ctx))
@@ -1545,7 +1545,7 @@ func TestBlockSyncing(t *testing.T) {
 	})
 
 	t.Run("add block 2a", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		_, err = storage.AddingBlock(ctx, b2a, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, dbTx.Commit(ctx))

--- a/storage/block_storage.go
+++ b/storage/block_storage.go
@@ -166,7 +166,7 @@ func (b *BlockStorage) GetOldestBlockIndexTransactional(
 func (b *BlockStorage) GetOldestBlockIndex(
 	ctx context.Context,
 ) (int64, error) {
-	dbTx := b.db.NewDatabaseTransaction(ctx, false)
+	dbTx := b.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return b.GetOldestBlockIndexTransactional(ctx, dbTx)
@@ -183,7 +183,7 @@ func (b *BlockStorage) pruneBlock(
 	// we don't hit the database tx size maximum. As a result, it is possible
 	// that we prune a collection of blocks, encounter an error, and cannot
 	// rollback the pruning operations.
-	dbTx := b.db.NewDatabaseTransaction(ctx, true)
+	dbTx := b.db.Transaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	oldestIndex, err := b.GetOldestBlockIndexTransactional(ctx, dbTx)
@@ -290,7 +290,7 @@ func (b *BlockStorage) Prune(
 func (b *BlockStorage) GetHeadBlockIdentifier(
 	ctx context.Context,
 ) (*types.BlockIdentifier, error) {
-	transaction := b.db.NewDatabaseTransaction(ctx, false)
+	transaction := b.db.ReadTransaction(ctx)
 	defer transaction.Discard(ctx)
 
 	return b.GetHeadBlockIdentifierTransactional(ctx, transaction)
@@ -406,7 +406,7 @@ func (b *BlockStorage) GetBlockLazy(
 	ctx context.Context,
 	blockIdentifier *types.PartialBlockIdentifier,
 ) (*types.BlockResponse, error) {
-	transaction := b.db.NewDatabaseTransaction(ctx, false)
+	transaction := b.db.ReadTransaction(ctx)
 	defer transaction.Discard(ctx)
 
 	return b.GetBlockLazyTransactional(ctx, blockIdentifier, transaction)
@@ -420,7 +420,7 @@ func (b *BlockStorage) CanonicalBlock(
 	ctx context.Context,
 	blockIdentifier *types.BlockIdentifier,
 ) (bool, error) {
-	dbTx := b.db.NewDatabaseTransaction(ctx, false)
+	dbTx := b.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return b.CanonicalBlockTransactional(ctx, blockIdentifier, dbTx)
@@ -507,7 +507,7 @@ func (b *BlockStorage) GetBlock(
 	ctx context.Context,
 	blockIdentifier *types.PartialBlockIdentifier,
 ) (*types.Block, error) {
-	transaction := b.db.NewDatabaseTransaction(ctx, false)
+	transaction := b.db.ReadTransaction(ctx)
 	defer transaction.Discard(ctx)
 
 	return b.GetBlockTransactional(ctx, transaction, blockIdentifier)
@@ -555,7 +555,7 @@ func (b *BlockStorage) AddBlock(
 	ctx context.Context,
 	block *types.Block,
 ) error {
-	transaction := b.db.NewDatabaseTransaction(ctx, true)
+	transaction := b.db.Transaction(ctx)
 	defer transaction.Discard(ctx)
 
 	// Store all transactions in order and check for duplicates
@@ -666,7 +666,7 @@ func (b *BlockStorage) RemoveBlock(
 	ctx context.Context,
 	blockIdentifier *types.BlockIdentifier,
 ) error {
-	transaction := b.db.NewDatabaseTransaction(ctx, true)
+	transaction := b.db.Transaction(ctx)
 	defer transaction.Discard(ctx)
 
 	block, err := b.GetBlockTransactional(
@@ -770,7 +770,7 @@ func (b *BlockStorage) SetNewStartIndex(
 
 	// Ensure we do not set a new start index less
 	// than the oldest block.
-	dbTx := b.db.NewDatabaseTransaction(ctx, false)
+	dbTx := b.db.ReadTransaction(ctx)
 	oldestIndex, err := b.GetOldestBlockIndexTransactional(ctx, dbTx)
 	dbTx.Discard(ctx)
 	if err != nil {
@@ -1035,7 +1035,7 @@ func (b *BlockStorage) GetBlockTransaction(
 	blockIdentifier *types.BlockIdentifier,
 	transactionIdentifier *types.TransactionIdentifier,
 ) (*types.Transaction, error) {
-	transaction := b.db.NewDatabaseTransaction(ctx, false)
+	transaction := b.db.ReadTransaction(ctx)
 	defer transaction.Discard(ctx)
 
 	return b.findBlockTransaction(ctx, blockIdentifier, transactionIdentifier, transaction)
@@ -1073,7 +1073,7 @@ func (b *BlockStorage) AtTip(
 	ctx context.Context,
 	tipDelay int64,
 ) (bool, *types.BlockIdentifier, error) {
-	transaction := b.db.NewDatabaseTransaction(ctx, false)
+	transaction := b.db.ReadTransaction(ctx)
 	defer transaction.Discard(ctx)
 
 	return b.AtTipTransactional(ctx, tipDelay, transaction)
@@ -1089,7 +1089,7 @@ func (b *BlockStorage) IndexAtTip(
 	tipDelay int64,
 	index int64,
 ) (bool, error) {
-	transaction := b.db.NewDatabaseTransaction(ctx, false)
+	transaction := b.db.ReadTransaction(ctx)
 	defer transaction.Discard(ctx)
 	headBlockResponse, err := b.GetBlockLazyTransactional(ctx, nil, transaction)
 	if errors.Is(err, ErrHeadBlockNotFound) {

--- a/storage/block_storage_test.go
+++ b/storage/block_storage_test.go
@@ -61,7 +61,7 @@ func TestHeadBlockIdentifier(t *testing.T) {
 	})
 
 	t.Run("Set and get head block", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		assert.NoError(t, storage.StoreHeadBlockIdentifier(ctx, txn, newBlockIdentifier))
 		assert.NoError(t, txn.Commit(ctx))
 
@@ -71,7 +71,7 @@ func TestHeadBlockIdentifier(t *testing.T) {
 	})
 
 	t.Run("Discard head block update", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		assert.NoError(t, storage.StoreHeadBlockIdentifier(ctx, txn,
 			&types.BlockIdentifier{
 				Hash:  "no blah",
@@ -86,7 +86,7 @@ func TestHeadBlockIdentifier(t *testing.T) {
 	})
 
 	t.Run("Multiple updates to head block", func(t *testing.T) {
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		assert.NoError(t, storage.StoreHeadBlockIdentifier(ctx, txn, newBlockIdentifier2))
 		assert.NoError(t, txn.Commit(ctx))
 
@@ -288,7 +288,7 @@ func findTransactionWithDbTransaction(
 	storage *BlockStorage,
 	transactionIdentifier *types.TransactionIdentifier,
 ) (*types.BlockIdentifier, *types.Transaction, error) {
-	txn := storage.db.NewDatabaseTransaction(ctx, false)
+	txn := storage.db.ReadTransaction(ctx)
 	defer txn.Discard(ctx)
 
 	return storage.FindTransaction(

--- a/storage/broadcast_storage.go
+++ b/storage/broadcast_storage.go
@@ -382,7 +382,7 @@ func (b *BroadcastStorage) getAllBroadcasts(
 
 // GetAllBroadcasts returns all currently in-process broadcasts.
 func (b *BroadcastStorage) GetAllBroadcasts(ctx context.Context) ([]*Broadcast, error) {
-	dbTx := b.db.NewDatabaseTransaction(ctx, false)
+	dbTx := b.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return b.getAllBroadcasts(ctx, dbTx)
@@ -399,7 +399,7 @@ func (b *BroadcastStorage) performBroadcast(
 		return fmt.Errorf("%w: %v", ErrBroadcastEncodeFailed, err)
 	}
 
-	txn := b.db.NewDatabaseTransaction(ctx, true)
+	txn := b.db.Transaction(ctx)
 	defer txn.Discard(ctx)
 
 	if err := txn.Set(ctx, key, bytes, true); err != nil {
@@ -485,7 +485,7 @@ func (b *BroadcastStorage) BroadcastAll(ctx context.Context, onlyEligible bool) 
 		}
 
 		if broadcast.Broadcasts >= b.broadcastLimit {
-			txn := b.db.NewDatabaseTransaction(ctx, true)
+			txn := b.db.Transaction(ctx)
 			defer txn.Discard(ctx)
 
 			_, key := getBroadcastKey(broadcast.TransactionIdentifier)
@@ -573,7 +573,7 @@ func (b *BroadcastStorage) ClearBroadcasts(ctx context.Context) ([]*Broadcast, e
 		return nil, fmt.Errorf("%w: %v", ErrBroadcastGetAllFailed, err)
 	}
 
-	txn := b.db.NewDatabaseTransaction(ctx, true)
+	txn := b.db.Transaction(ctx)
 	for _, broadcast := range broadcasts {
 		_, key := getBroadcastKey(broadcast.TransactionIdentifier)
 		if err := txn.Delete(ctx, key); err != nil {

--- a/storage/broadcast_storage_test.go
+++ b/storage/broadcast_storage_test.go
@@ -107,7 +107,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	mockHelper.AtSyncTip = true
 
 	t.Run("broadcast send 1 before block exists", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		err := storage.Broadcast(
@@ -150,7 +150,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	t.Run("add block 0", func(t *testing.T) {
 		block := blocks[0]
 
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		commitWorker, err := storage.AddingBlock(ctx, block, txn)
 		assert.NoError(t, err)
 		err = txn.Commit(ctx)
@@ -189,7 +189,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	t.Run("add block 1", func(t *testing.T) {
 		block := blocks[1]
 
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		commitWorker, err := storage.AddingBlock(ctx, block, txn)
 		assert.NoError(t, err)
 		err = txn.Commit(ctx)
@@ -226,7 +226,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	})
 
 	t.Run("broadcast send 2 after adding a block", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		err := storage.Broadcast(
@@ -282,7 +282,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	t.Run("add block 2", func(t *testing.T) {
 		block := blocks[2]
 
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		commitWorker, err := storage.AddingBlock(ctx, block, txn)
 		assert.NoError(t, err)
 
@@ -356,7 +356,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		block := blocks[3]
 		block.Transactions = []*types.Transaction{tx1}
 
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		commitWorker, err := storage.AddingBlock(ctx, block, txn)
 		assert.NoError(t, err)
 		err = txn.Commit(ctx)
@@ -412,7 +412,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		block := blocks[4]
 		block.Transactions = []*types.Transaction{tx2}
 
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		commitWorker, err := storage.AddingBlock(ctx, block, txn)
 		assert.NoError(t, err)
 
@@ -462,7 +462,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 	t.Run("add block 5", func(t *testing.T) {
 		block := blocks[5]
 
-		txn := storage.db.NewDatabaseTransaction(ctx, true)
+		txn := storage.db.Transaction(ctx)
 		commitWorker, err := storage.AddingBlock(ctx, block, txn)
 		assert.NoError(t, err)
 
@@ -527,7 +527,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 	storage.Initialize(mockHelper, mockHandler)
 
 	t.Run("locked addresses with no broadcasts", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, false)
+		dbTx := database.ReadTransaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		accounts, err := storage.LockedAccounts(ctx, dbTx)
@@ -549,7 +549,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 	send2 := opFiller("addr 2", 13)
 	network := &types.NetworkIdentifier{Blockchain: "Bitcoin", Network: "Testnet3"}
 	t.Run("broadcast", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		err := storage.Broadcast(
@@ -619,7 +619,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 		blocks := blockFiller(0, 10)
 		mockHelper.AtSyncTip = true
 		for _, block := range blocks {
-			txn := storage.db.NewDatabaseTransaction(ctx, true)
+			txn := storage.db.Transaction(ctx)
 			commitWorker, err := storage.AddingBlock(ctx, block, txn)
 			assert.NoError(t, err)
 			err = txn.Commit(ctx)
@@ -630,7 +630,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		dbTx := database.NewDatabaseTransaction(ctx, false)
+		dbTx := database.ReadTransaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		accounts, err := storage.LockedAccounts(ctx, dbTx)
@@ -693,7 +693,7 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 	send2 := opFiller("addr 2", 1)
 	network := &types.NetworkIdentifier{Blockchain: "Bitcoin", Network: "Testnet3"}
 	t.Run("broadcast", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		err := storage.Broadcast(
@@ -762,7 +762,7 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 
 	t.Run("add blocks behind tip", func(t *testing.T) {
 		for _, block := range blocks[:60] {
-			txn := storage.db.NewDatabaseTransaction(ctx, true)
+			txn := storage.db.Transaction(ctx)
 			commitWorker, err := storage.AddingBlock(ctx, block, txn)
 			assert.NoError(t, err)
 			err = txn.Commit(ctx)
@@ -773,7 +773,7 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		dbTx := database.NewDatabaseTransaction(ctx, false)
+		dbTx := database.ReadTransaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		accounts, err := storage.LockedAccounts(ctx, dbTx)
@@ -812,7 +812,7 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 	mockHelper.AtSyncTip = true
 	t.Run("add blocks close to tip", func(t *testing.T) {
 		for _, block := range blocks[60:71] {
-			txn := storage.db.NewDatabaseTransaction(ctx, true)
+			txn := storage.db.Transaction(ctx)
 			commitWorker, err := storage.AddingBlock(ctx, block, txn)
 			assert.NoError(t, err)
 			err = txn.Commit(ctx)
@@ -823,7 +823,7 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		dbTx := database.NewDatabaseTransaction(ctx, false)
+		dbTx := database.ReadTransaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		accounts, err := storage.LockedAccounts(ctx, dbTx)
@@ -889,7 +889,7 @@ func TestBroadcastStorageClearBroadcasts(t *testing.T) {
 
 	network := &types.NetworkIdentifier{Blockchain: "Bitcoin", Network: "Testnet3"}
 	t.Run("locked addresses with no broadcasts", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, false)
+		dbTx := database.ReadTransaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		accounts, err := storage.LockedAccounts(ctx, dbTx)
@@ -901,7 +901,7 @@ func TestBroadcastStorageClearBroadcasts(t *testing.T) {
 	send1 := opFiller("addr 1", 11)
 	send2 := opFiller("addr 2", 13)
 	t.Run("broadcast", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		err := storage.Broadcast(
@@ -983,7 +983,7 @@ func TestBroadcastStorageClearBroadcasts(t *testing.T) {
 			},
 		}, broadcasts)
 
-		dbTx := database.NewDatabaseTransaction(ctx, false)
+		dbTx := database.ReadTransaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		accounts, err := storage.LockedAccounts(ctx, dbTx)

--- a/storage/coin_storage.go
+++ b/storage/coin_storage.go
@@ -127,7 +127,7 @@ func (c *CoinStorage) AddCoins(
 	ctx context.Context,
 	accountCoins []*AccountCoin,
 ) error {
-	dbTransaction := c.db.NewDatabaseTransaction(ctx, true)
+	dbTransaction := c.db.Transaction(ctx)
 	defer dbTransaction.Discard(ctx)
 
 	for _, accountCoin := range accountCoins {
@@ -419,7 +419,7 @@ func (c *CoinStorage) GetCoins(
 	ctx context.Context,
 	accountIdentifier *types.AccountIdentifier,
 ) ([]*types.Coin, *types.BlockIdentifier, error) {
-	dbTx := c.db.NewDatabaseTransaction(ctx, false)
+	dbTx := c.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return c.GetCoinsTransactional(ctx, dbTx, accountIdentifier)
@@ -449,7 +449,7 @@ func (c *CoinStorage) GetCoin(
 	ctx context.Context,
 	coinIdentifier *types.CoinIdentifier,
 ) (*types.Coin, *types.AccountIdentifier, error) {
-	dbTx := c.db.NewDatabaseTransaction(ctx, false)
+	dbTx := c.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return c.GetCoinTransactional(ctx, dbTx, coinIdentifier)

--- a/storage/coin_storage_test.go
+++ b/storage/coin_storage_test.go
@@ -495,7 +495,7 @@ func TestCoinStorage(t *testing.T) {
 	})
 
 	t.Run("add block", func(t *testing.T) {
-		tx := c.db.NewDatabaseTransaction(ctx, true)
+		tx := c.db.Transaction(ctx)
 		commitFunc, err := c.AddingBlock(ctx, coinBlock, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
@@ -508,7 +508,7 @@ func TestCoinStorage(t *testing.T) {
 	})
 
 	t.Run("add duplicate coin", func(t *testing.T) {
-		tx := c.db.NewDatabaseTransaction(ctx, true)
+		tx := c.db.Transaction(ctx)
 		commitFunc, err := c.AddingBlock(ctx, coinBlock, tx)
 		assert.Nil(t, commitFunc)
 		assert.Error(t, err)
@@ -521,7 +521,7 @@ func TestCoinStorage(t *testing.T) {
 	})
 
 	t.Run("add duplicate coin in same block", func(t *testing.T) {
-		tx := c.db.NewDatabaseTransaction(ctx, true)
+		tx := c.db.Transaction(ctx)
 		commitFunc, err := c.AddingBlock(ctx, coinBlockRepeat, tx)
 		assert.Nil(t, commitFunc)
 		assert.Error(t, err)
@@ -534,7 +534,7 @@ func TestCoinStorage(t *testing.T) {
 	})
 
 	t.Run("remove block", func(t *testing.T) {
-		tx := c.db.NewDatabaseTransaction(ctx, true)
+		tx := c.db.Transaction(ctx)
 		commitFunc, err := c.RemovingBlock(ctx, coinBlock, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
@@ -552,7 +552,7 @@ func TestCoinStorage(t *testing.T) {
 	})
 
 	t.Run("spend coin", func(t *testing.T) {
-		tx := c.db.NewDatabaseTransaction(ctx, true)
+		tx := c.db.Transaction(ctx)
 		commitFunc, err := c.AddingBlock(ctx, coinBlock, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
@@ -563,7 +563,7 @@ func TestCoinStorage(t *testing.T) {
 		assert.Equal(t, accountCoins, coins)
 		assert.Equal(t, blockIdentifier, block)
 
-		tx = c.db.NewDatabaseTransaction(ctx, true)
+		tx = c.db.Transaction(ctx)
 		commitFunc, err = c.AddingBlock(ctx, coinBlock2, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
@@ -581,7 +581,7 @@ func TestCoinStorage(t *testing.T) {
 	})
 
 	t.Run("add block with multiple outputs for 1 account", func(t *testing.T) {
-		tx := c.db.NewDatabaseTransaction(ctx, true)
+		tx := c.db.Transaction(ctx)
 		commitFunc, err := c.AddingBlock(ctx, coinBlock3, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
@@ -611,13 +611,13 @@ func TestCoinStorage(t *testing.T) {
 	})
 
 	t.Run("remove block that creates and spends single coin", func(t *testing.T) {
-		tx := c.db.NewDatabaseTransaction(ctx, true)
+		tx := c.db.Transaction(ctx)
 		commitFunc, err := c.RemovingBlock(ctx, coinBlock3, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
 		assert.NoError(t, tx.Commit(ctx))
 
-		tx = c.db.NewDatabaseTransaction(ctx, true)
+		tx = c.db.Transaction(ctx)
 		commitFunc, err = c.AddingBlock(ctx, coinBlock3, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)

--- a/storage/counter_storage.go
+++ b/storage/counter_storage.go
@@ -144,7 +144,7 @@ func (c *CounterStorage) Update(
 	counter string,
 	amount *big.Int,
 ) (*big.Int, error) {
-	dbTx := c.db.NewDatabaseTransaction(ctx, true)
+	dbTx := c.db.Transaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	newVal, err := c.UpdateTransactional(ctx, dbTx, counter, amount)
@@ -161,7 +161,7 @@ func (c *CounterStorage) Update(
 
 // Get returns the current value of a counter.
 func (c *CounterStorage) Get(ctx context.Context, counter string) (*big.Int, error) {
-	transaction := c.db.NewDatabaseTransaction(ctx, false)
+	transaction := c.db.ReadTransaction(ctx)
 	defer transaction.Discard(ctx)
 
 	return transactionalGet(ctx, counter, transaction)

--- a/storage/job_storage.go
+++ b/storage/job_storage.go
@@ -125,7 +125,7 @@ func (j *JobStorage) Processing(
 
 // AllProcessing gets all processing *job.Jobs.
 func (j *JobStorage) AllProcessing(ctx context.Context) ([]*job.Job, error) {
-	dbTx := j.db.NewDatabaseTransaction(ctx, false)
+	dbTx := j.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return j.getAllJobs(ctx, dbTx, getJobMetadataKey(processingKey))
@@ -133,7 +133,7 @@ func (j *JobStorage) AllProcessing(ctx context.Context) ([]*job.Job, error) {
 
 // Failed returns all failed *job.Job of a certain workflow.
 func (j *JobStorage) Failed(ctx context.Context, workflow string) ([]*job.Job, error) {
-	dbTx := j.db.NewDatabaseTransaction(ctx, false)
+	dbTx := j.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return j.getAllJobs(ctx, dbTx, getJobMetadataKey(getJobFailedKey(workflow)))
@@ -141,7 +141,7 @@ func (j *JobStorage) Failed(ctx context.Context, workflow string) ([]*job.Job, e
 
 // AllFailed returns all failed *job.Jobs.
 func (j *JobStorage) AllFailed(ctx context.Context) ([]*job.Job, error) {
-	dbTx := j.db.NewDatabaseTransaction(ctx, false)
+	dbTx := j.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return j.getAllJobs(ctx, dbTx, getJobMetadataKey(failedKey))
@@ -149,7 +149,7 @@ func (j *JobStorage) AllFailed(ctx context.Context) ([]*job.Job, error) {
 
 // Completed gets all successfully completed *job.Job of a certain workflow.
 func (j *JobStorage) Completed(ctx context.Context, workflow string) ([]*job.Job, error) {
-	dbTx := j.db.NewDatabaseTransaction(ctx, false)
+	dbTx := j.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return j.getAllJobs(ctx, dbTx, getJobMetadataKey(getJobCompletedKey(workflow)))
@@ -157,7 +157,7 @@ func (j *JobStorage) Completed(ctx context.Context, workflow string) ([]*job.Job
 
 // AllCompleted gets all successfully completed *job.Jobs.
 func (j *JobStorage) AllCompleted(ctx context.Context) ([]*job.Job, error) {
-	dbTx := j.db.NewDatabaseTransaction(ctx, false)
+	dbTx := j.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return j.getAllJobs(ctx, dbTx, getJobMetadataKey(completedKey))

--- a/storage/job_storage_test.go
+++ b/storage/job_storage_test.go
@@ -38,7 +38,7 @@ func TestJobStorage(t *testing.T) {
 	storage := NewJobStorage(database)
 
 	t.Run("get non-existent job", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, false)
+		dbTx := database.ReadTransaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		job, err := storage.Get(ctx, dbTx, "job1")
@@ -71,7 +71,7 @@ func TestJobStorage(t *testing.T) {
 		Status:   job.Broadcasting,
 	}
 	t.Run("add job", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		jobIdentifier, err := storage.Update(ctx, dbTx, newJob)
@@ -118,7 +118,7 @@ func TestJobStorage(t *testing.T) {
 		Status:   job.Ready,
 	}
 	t.Run("add another job", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		jobIdentifier, err := storage.Update(ctx, dbTx, newJob2)
@@ -165,7 +165,7 @@ func TestJobStorage(t *testing.T) {
 		Status:   job.Completed,
 	}
 	t.Run("add another job", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		jobIdentifier, err := storage.Update(ctx, dbTx, newJob3)
@@ -212,7 +212,7 @@ func TestJobStorage(t *testing.T) {
 	})
 
 	t.Run("update job 1", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		newJob.Status = job.Completed
@@ -262,7 +262,7 @@ func TestJobStorage(t *testing.T) {
 	})
 
 	t.Run("fail job 2", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		newJob2.Status = job.Failed
@@ -320,7 +320,7 @@ func TestJobStorage(t *testing.T) {
 	})
 
 	t.Run("attempt to update job 2", func(t *testing.T) {
-		dbTx := database.NewDatabaseTransaction(ctx, true)
+		dbTx := database.Transaction(ctx)
 		defer dbTx.Discard(ctx)
 
 		newJob2.Status = job.Completed

--- a/storage/key_storage.go
+++ b/storage/key_storage.go
@@ -112,7 +112,7 @@ func (k *KeyStorage) Store(
 	account *types.AccountIdentifier,
 	keyPair *keys.KeyPair,
 ) error {
-	dbTx := k.db.NewDatabaseTransaction(ctx, true)
+	dbTx := k.db.Transaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	if err := k.StoreTransactional(ctx, account, keyPair, dbTx); err != nil {
@@ -155,7 +155,7 @@ func (k *KeyStorage) Get(
 	ctx context.Context,
 	account *types.AccountIdentifier,
 ) (*keys.KeyPair, error) {
-	transaction := k.db.NewDatabaseTransaction(ctx, false)
+	transaction := k.db.ReadTransaction(ctx)
 	defer transaction.Discard(ctx)
 
 	return k.GetTransactional(ctx, transaction, account)
@@ -193,7 +193,7 @@ func (k *KeyStorage) GetAllAccountsTransactional(
 
 // GetAllAccounts returns all AccountIdentifiers in key storage.
 func (k *KeyStorage) GetAllAccounts(ctx context.Context) ([]*types.AccountIdentifier, error) {
-	dbTx := k.db.NewDatabaseTransaction(ctx, false)
+	dbTx := k.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
 	return k.GetAllAccountsTransactional(ctx, dbTx)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -21,7 +21,10 @@ import (
 // Database is an interface that provides transactional
 // access to a KV store.
 type Database interface {
-	NewDatabaseTransaction(context.Context, bool) DatabaseTransaction
+	GTransaction(context.Context) DatabaseTransaction
+	RTransaction(context.Context) DatabaseTransaction
+	WTransaction(ctx context.Context, identifier string, priority bool) DatabaseTransaction
+
 	Close(context.Context) error
 	Encoder() *Encoder
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -21,11 +21,30 @@ import (
 // Database is an interface that provides transactional
 // access to a KV store.
 type Database interface {
-	GTransaction(context.Context) DatabaseTransaction
-	RTransaction(context.Context) DatabaseTransaction
-	WTransaction(ctx context.Context, identifier string, priority bool) DatabaseTransaction
+	// Transaction acquires an exclusive write lock on the database.
+	// This ensures all other calls to Transaction and WriteTransaction
+	// will block until the returned DatabaseTransaction is committed or
+	// discarded. This is useful for making changes across
+	// multiple prefixes but incurs a large performance overhead.
+	Transaction(context.Context) DatabaseTransaction
 
+	// ReadTransaction allows for consistent, read-only access
+	// to the database. This does not acquire any lock
+	// on the database.
+	ReadTransaction(context.Context) DatabaseTransaction
+
+	// WriteTransaction acquires a granular write lock for a particular
+	// identifier. All subsequent calls to WriteTransaction with the same
+	// identifier will block until the DatabaseTransaction returned is either
+	// committed or discarded.
+	WriteTransaction(ctx context.Context, identifier string, priority bool) DatabaseTransaction
+
+	// Close shuts down the database.
 	Close(context.Context) error
+
+	// Encoder returns the *Encoder used to store/read data
+	// in the database. This *Encoder often performs some
+	// form of compression on data.
 	Encoder() *Encoder
 }
 


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/tree/patrick/priority-lock

This PR updates the `storage` interface to provide access to more granular database locking and updates all files in `storage` to use this new interface.

### Future Work
Overhaul `BlockStorage`, `BalanceStorage`, and `CoinStorage` to use `WriteTransaction` to reduce usage of global locking (i.e. pruning/reconciliation don't need to acquire the global database lock).