### PR TITLE
[reconciler] Performance Overhaul

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -29,6 +29,10 @@ import (
 )
 
 const (
+	// shardBuffer is multiplied by inactive concurrency +
+	// active concurrency to determine how many shards should
+	// be created in the queueMap. The more shards created,
+	// the less lock contention we will encounter.
 	shardBuffer = 2
 )
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -28,6 +28,10 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/utils"
 )
 
+const (
+	shardBuffer = 2
+)
+
 // New creates a new Reconciler.
 func New(
 	helper Helper,
@@ -45,9 +49,9 @@ func New(
 		highWaterMark:       -1,
 		seenAccounts:        map[string]struct{}{},
 		inactiveQueue:       []*InactiveEntry{},
+		inactiveQueueMutex:  new(utils.PriorityMutex),
 		backlogSize:         defaultBacklogSize,
 		lastIndexChecked:    -1,
-		queueMap:            map[string]*utils.BST{},
 	}
 
 	for _, opt := range options {
@@ -56,6 +60,10 @@ func New(
 
 	// Create change queue
 	r.changeQueue = make(chan *parser.BalanceChange, r.backlogSize)
+
+	// Create queueMap
+	desiredShardCount := shardBuffer * (r.ActiveConcurrency + r.InactiveConcurrency)
+	r.queueMap = utils.NewShardedMap(desiredShardCount)
 
 	return r
 }
@@ -98,7 +106,7 @@ func (r *Reconciler) wrappedInactiveEnqueue(
 	accountCurrency *types.AccountCurrency,
 	liveBlock *types.BlockIdentifier,
 ) {
-	if err := r.inactiveAccountQueue(true, accountCurrency, liveBlock); err != nil {
+	if err := r.inactiveAccountQueue(true, accountCurrency, liveBlock, false); err != nil {
 		log.Printf(
 			"%s: unable to queue account %s",
 			err.Error(),
@@ -110,17 +118,18 @@ func (r *Reconciler) wrappedInactiveEnqueue(
 // addToQueueMap adds a *types.AccountCurrency
 // to the prune map at the provided index.
 func (r *Reconciler) addToQueueMap(
-	acctCurrency *types.AccountCurrency,
+	m map[string]interface{},
+	key string,
 	index int64,
 ) {
-	key := types.Hash(acctCurrency)
-	if _, ok := r.queueMap[key]; !ok {
-		r.queueMap[key] = &utils.BST{}
+	if _, ok := m[key]; !ok {
+		m[key] = &utils.BST{}
 	}
 
-	existing := r.queueMap[key].Get(index)
+	bst := m[key].(*utils.BST)
+	existing := bst.Get(index)
 	if existing == nil {
-		r.queueMap[key].Set(index, 1)
+		bst.Set(index, 1)
 	} else {
 		existing.Value++
 	}
@@ -183,16 +192,20 @@ func (r *Reconciler) QueueChanges(
 			Account:  change.Account,
 			Currency: change.Currency,
 		}
-		err := r.inactiveAccountQueue(false, acctCurrency, block)
+
+		r.inactiveQueueMutex.Lock(true)
+		err := r.inactiveAccountQueue(false, acctCurrency, block, true)
+		r.inactiveQueueMutex.Unlock()
 		if err != nil {
 			return err
 		}
 
 		// Add change to queueMap before enqueuing to ensure
 		// there is no possible race.
-		r.queueMapMutex.Lock()
-		r.addToQueueMap(acctCurrency, change.Block.Index)
-		r.queueMapMutex.Unlock()
+		key := types.Hash(acctCurrency)
+		m := r.queueMap.Lock(key, true)
+		r.addToQueueMap(m, key, change.Block.Index)
+		r.queueMap.Unlock(key)
 
 		// Add change to active queue
 		r.wrappedActiveEnqueue(ctx, change)
@@ -499,8 +512,12 @@ func (r *Reconciler) inactiveAccountQueue(
 	inactive bool,
 	accountCurrency *types.AccountCurrency,
 	liveBlock *types.BlockIdentifier,
+	hasLock bool,
 ) error {
-	r.inactiveQueueMutex.Lock()
+	if !hasLock {
+		r.inactiveQueueMutex.Lock(false)
+		defer r.inactiveQueueMutex.Unlock()
+	}
 
 	// Only enqueue the first time we see an account on an active reconciliation.
 	shouldEnqueueInactive := false
@@ -594,33 +611,34 @@ func (r *Reconciler) updateQueueMap(
 	prune bool,
 ) error {
 	key := types.Hash(acctCurrency)
+	m := r.queueMap.Lock(key, false)
+	bst := m[key].(*utils.BST)
 
-	r.queueMapMutex.Lock()
-	existing := r.queueMap[key].Get(index)
+	existing := bst.Get(index)
 	existing.Value--
 	if existing.Value > 0 {
-		r.queueMapMutex.Unlock()
+		r.queueMap.Unlock(key)
 		return nil
 	}
 
 	// Cleanup indexes when we don't need them anymore
-	r.queueMap[key].Delete(index)
+	bst.Delete(index)
 
 	// Don't prune if there are items for this AccountCurrency
 	// less than this change.
-	if !r.queueMap[key].Empty() &&
-		index >= r.queueMap[key].Min().Key {
-		r.queueMapMutex.Unlock()
+	if !bst.Empty() &&
+		index >= bst.Min().Key {
+		r.queueMap.Unlock(key)
 		return nil
 	}
 
 	// Cleanup keys when we don't need them anymore
-	if r.queueMap[key].Empty() {
-		delete(r.queueMap, key)
+	if bst.Empty() {
+		delete(m, key)
 	}
 
 	// Unlock before pruning as this could take some time
-	r.queueMapMutex.Unlock()
+	r.queueMap.Unlock(key)
 
 	// Attempt to prune historical balances that will not be used
 	// anymore.
@@ -760,24 +778,10 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 			return ctx.Err()
 		}
 
-		// Lock BST while determining if we should attempt reconciliation
-		// to ensure we don't allow any accounts to be pruned at retrieved
-		// head index. Although this appears to be a long time to hold
-		// this mutex, this lookup takes less than a millisecond.
-		r.queueMapMutex.Lock()
-
-		shouldAttempt, head := r.shouldAttemptInactiveReconciliation(ctx)
-		if !shouldAttempt {
-			r.queueMapMutex.Unlock()
-			time.Sleep(inactiveReconciliationSleep)
-			continue
-		}
-
-		r.inactiveQueueMutex.Lock()
+		r.inactiveQueueMutex.Lock(false)
 		queueLen := len(r.inactiveQueue)
 		if queueLen == 0 {
 			r.inactiveQueueMutex.Unlock()
-			r.queueMapMutex.Unlock()
 			r.debugLog(
 				"no accounts ready for inactive reconciliation (0 accounts in queue)",
 			)
@@ -786,6 +790,21 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 		}
 
 		nextAcct := r.inactiveQueue[0]
+		key := types.Hash(nextAcct.Entry)
+
+		// Lock BST while determining if we should attempt reconciliation
+		// to ensure we don't allow any accounts to be pruned at retrieved
+		// head index. Although this appears to be a long time to hold
+		// this mutex, this lookup takes less than a millisecond.
+		m := r.queueMap.Lock(key, false)
+
+		shouldAttempt, head := r.shouldAttemptInactiveReconciliation(ctx)
+		if !shouldAttempt {
+			r.queueMap.Unlock(key)
+			time.Sleep(inactiveReconciliationSleep)
+			continue
+		}
+
 		nextValidIndex := int64(-1)
 		if nextAcct.LastCheck != nil { // block is set to nil when loaded from previous run
 			nextValidIndex = nextAcct.LastCheck.Index + r.inactiveFrequency
@@ -797,8 +816,8 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 
 			// Add nextAcct to queueMap before returning
 			// queueMapMutex lock.
-			r.addToQueueMap(nextAcct.Entry, head.Index)
-			r.queueMapMutex.Unlock()
+			r.addToQueueMap(m, key, head.Index)
+			r.queueMap.Unlock(key)
 
 			amount, block, err := r.bestLiveBalance(
 				ctx,
@@ -872,13 +891,13 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 			// Always re-enqueue accounts after they have been inactively
 			// reconciled. If we don't re-enqueue, we will never check
 			// these accounts again.
-			err = r.inactiveAccountQueue(true, nextAcct.Entry, block)
+			err = r.inactiveAccountQueue(true, nextAcct.Entry, block, false)
 			if err != nil {
 				return err
 			}
 		} else {
 			r.inactiveQueueMutex.Unlock()
-			r.queueMapMutex.Unlock()
+			r.queueMap.Unlock(key)
 			r.debugLog(
 				"no accounts ready for inactive reconciliation (%d accounts in queue, will reconcile next account at index %d)",
 				queueLen,

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -1100,7 +1100,8 @@ func TestReconcile_HighWaterMark(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, r.QueueSize(), 4) // includes interesting accounts
+	assert.Equal(t, 2, len(r.processQueue))
+	assert.Equal(t, 0, r.QueueSize()) // queue size is 0 before starting worker
 
 	go func() {
 		err := r.Reconcile(ctx)
@@ -1109,6 +1110,9 @@ func TestReconcile_HighWaterMark(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 	cancel()
+
+	assert.Equal(t, 0, len(r.processQueue))
+	assert.Equal(t, 0, r.QueueSize())
 
 	mockHelper.AssertExpectations(t)
 	mockHandler.AssertExpectations(t)
@@ -1270,7 +1274,8 @@ func TestReconcile_FailureOnlyActive(t *testing.T) {
 				},
 			})
 			assert.NoError(t, err)
-			assert.Equal(t, r.QueueSize(), 1)
+			assert.Equal(t, 1, len(r.processQueue))
+			assert.Equal(t, 0, r.QueueSize()) // queue size is 0 before starting worker
 
 			go func() {
 				err := r.Reconcile(ctx)
@@ -1279,6 +1284,8 @@ func TestReconcile_FailureOnlyActive(t *testing.T) {
 			}()
 
 			time.Sleep(1 * time.Second)
+			assert.Equal(t, 0, len(r.processQueue))
+			assert.Equal(t, 0, r.QueueSize())
 
 			mockHelper.AssertExpectations(t)
 			mockHandler.AssertExpectations(t)
@@ -2215,7 +2222,8 @@ func TestReconcile_EnqueueCancel(t *testing.T) {
 		change,
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, r.QueueSize(), 1)
+	assert.Equal(t, 1, len(r.processQueue))
+	assert.Equal(t, 0, r.QueueSize()) // queue size is 0 before starting worker
 
 	go func() {
 		err := r.Reconcile(ctx)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -771,11 +771,11 @@ func shardsEmpty(m *utils.ShardedMap, keys []string) bool {
 		s := m.Lock(k, false)
 		m.Unlock(k)
 		if len(s) > 0 {
-			return true
+			return false
 		}
 	}
 
-	return false
+	return true
 }
 
 func TestReconcile_SuccessOnlyActive(t *testing.T) {

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -2123,8 +2123,6 @@ func TestReconcile_FailureOnlyInactive(t *testing.T) {
 				opts...,
 			)
 			ctx := context.Background()
-			ctx, cancel := context.WithCancel(ctx)
-
 			mtxn := &mockDatabase.Transaction{}
 			mtxn.On("Discard", mock.Anything).Once()
 			mockHelper.On("DatabaseTransaction", mock.Anything).Return(mtxn).Once()
@@ -2133,10 +2131,6 @@ func TestReconcile_FailureOnlyInactive(t *testing.T) {
 			mtxn2.On(
 				"Discard",
 				mock.Anything,
-			).Run(
-				func(args mock.Arguments) {
-					cancel()
-				},
 			).Once()
 			mockHelper.On("DatabaseTransaction", mock.Anything).Return(mtxn2).Once()
 			mockReconcilerCalls(

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -254,7 +254,7 @@ type Reconciler struct {
 
 	// inactiveQueueMutex needed because we can't peek at the tip
 	// of a channel to determine when it is ready to look at.
-	inactiveQueueMutex sync.Mutex
+	inactiveQueueMutex *utils.PriorityMutex
 
 	// lastIndexChecked is the last block index reconciled actively.
 	lastIndexMutex   sync.Mutex
@@ -264,6 +264,7 @@ type Reconciler struct {
 	// in the active reconciliation queue and being actively
 	// reconciled. It ensures we don't accidentally attempt to prune
 	// computed balances being used by other goroutines.
-	queueMap      map[string]*utils.BST
-	queueMapMutex sync.Mutex
+	queueMap *utils.ShardedMap
+	// queueMap      map[string]*utils.BST
+	// queueMapMutex sync.Mutex
 }

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -265,6 +265,4 @@ type Reconciler struct {
 	// reconciled. It ensures we don't accidentally attempt to prune
 	// computed balances being used by other goroutines.
 	queueMap *utils.ShardedMap
-	// queueMap      map[string]*utils.BST
-	// queueMapMutex sync.Mutex
 }

--- a/statefulsyncer/stateful_syncer.go
+++ b/statefulsyncer/stateful_syncer.go
@@ -35,7 +35,7 @@ var _ syncer.Helper = (*StatefulSyncer)(nil)
 const (
 	// DefaultPruneSleepTime is how long we sleep between
 	// pruning attempts.
-	DefaultPruneSleepTime = 30 * time.Minute
+	DefaultPruneSleepTime = 10 * time.Minute
 
 	// pruneBuffer is the cushion we apply to pastBlockLimit
 	// when pruning.

--- a/storage/modules/counter_storage.go
+++ b/storage/modules/counter_storage.go
@@ -163,7 +163,7 @@ func (c *CounterStorage) Update(
 	counter string,
 	amount *big.Int,
 ) (*big.Int, error) {
-	dbTx := c.db.Transaction(ctx)
+	dbTx := c.db.WriteTransaction(ctx, counter, false)
 	defer dbTx.Discard(ctx)
 
 	newVal, err := c.UpdateTransactional(ctx, dbTx, counter, amount)

--- a/storage/modules/counter_storage.go
+++ b/storage/modules/counter_storage.go
@@ -110,6 +110,8 @@ func getCounterKey(counter string) []byte {
 	return []byte(fmt.Sprintf("%s/%s", counterNamespace, counter))
 }
 
+// BigIntGet attempts to fetch a *big.Int
+// from a given key in a database.Transaction.
 func BigIntGet(
 	ctx context.Context,
 	key []byte,


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-sdk-go/tree/patrick/priority-lock

This PR introduces performance optimizations in the `reconciler` that reduce lock contention in the syncing loop. This PR also migrates `BalanceStorage`, `BlockStorage`, and `CoinStorage` to use `github.com/neilotoole/errgroup` (in practice, significantly reduces memory usage without impacting performance).

### Changes
#### reconciler
- [x] introduce `utils.ShardedMap` to track currently used accounts
- [x] update tests
  - [x] fix failing test where `context.Canceled` returned instead of `reconciliation fails`
- [x] make enqueuing block changes async
#### statefulsyncer
- [x] change `statefulsyncer` default pruning frequency to 10 minutes
#### storage
- [x] explicitly set `errgroup` limit with `runtime.NumCPU`
- [x] ensure `BlockStorage` is not using a global database transaction
- [x] migrate `BlockStorage` to use `github.com/neilotoole/errgroup`
- [x] migrate `CoinStorage` to use `github.com/neilotoole/errgroup`