### PR TITLE
[chore] Miscellaneous Nits Before Release

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -563,8 +563,6 @@ func (r *Reconciler) inactiveAccountQueue(
 		})
 	}
 
-	r.inactiveQueueMutex.Unlock()
-
 	return nil
 }
 

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -1316,10 +1316,7 @@ func (b *BalanceStorage) removeHistoricalBalances(
 		}
 	}
 
-	// We only update the last pruned index
-	// if we are not orphaning and we actually
-	// deleted some key.
-	if orphan || len(foundKeys) == 0 {
+	if orphan {
 		return nil
 	}
 

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -1317,7 +1317,9 @@ func (b *BalanceStorage) removeHistoricalBalances(
 		}
 	}
 
-	if orphan {
+	// We don't update the pruned value when index is less
+	// than 0 because big.Int conversion doesn't support signed values.
+	if orphan || index < 0 {
 		return nil
 	}
 

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -1311,7 +1311,6 @@ func (b *BalanceStorage) removeHistoricalBalances(
 	}
 
 	for _, k := range foundKeys {
-		fmt.Println("deleting", string(k), "index", index)
 		if err := dbTx.Delete(ctx, k); err != nil {
 			return err
 		}

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -344,19 +344,7 @@ func (b *BalanceStorage) SetBalance(
 	amount *types.Amount,
 	block *types.BlockIdentifier,
 ) error {
-	// Remove all historical records
-	if err := b.removeHistoricalBalances(
-		ctx,
-		dbTransaction,
-		account,
-		amount.Currency,
-		-1,
-		true, // We want everything >= -1
-	); err != nil {
-		return err
-	}
-
-	// Remove all account keys
+	// Remove all account-related items
 	if err := b.deleteAccountRecords(
 		ctx,
 		dbTransaction,
@@ -647,6 +635,19 @@ func (b *BalanceStorage) deleteAccountRecords(
 	account *types.AccountIdentifier,
 	currency *types.Currency,
 ) error {
+	// Remove historical balance records
+	if err := b.removeHistoricalBalances(
+		ctx,
+		dbTx,
+		account,
+		currency,
+		-1,
+		true, // We want everything >= -1
+	); err != nil {
+		return err
+	}
+
+	// Remove single key records
 	for _, namespace := range []string{
 		accountNamespace,
 		reconciliationNamepace,

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -940,8 +940,9 @@ func (b *BalanceStorage) GetBalanceTransactional(
 
 	if exists && lastPruned.Int64() >= index {
 		return nil, fmt.Errorf(
-			"%w: last pruned %d",
+			"%w: desired %d last pruned %d",
 			storageErrs.ErrBalancePruned,
+			index,
 			lastPruned.Int64(),
 		)
 	}

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -1317,7 +1317,10 @@ func (b *BalanceStorage) removeHistoricalBalances(
 		}
 	}
 
-	if orphan {
+	// We only update the last pruned index
+	// if we are not orphaning and we actually
+	// deleted some key.
+	if orphan || len(foundKeys) == 0 {
 		return nil
 	}
 

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -763,10 +763,6 @@ func (b *BalanceStorage) PruneBalances(
 	currency *types.Currency,
 	index int64,
 ) error {
-	if index < 0 {
-		return nil
-	}
-
 	key := GetAccountKey(pruneNamespace, account, currency)
 	dbTx := b.db.WriteTransaction(ctx, string(key), false)
 	defer dbTx.Discard(ctx)
@@ -1315,6 +1311,7 @@ func (b *BalanceStorage) removeHistoricalBalances(
 	}
 
 	for _, k := range foundKeys {
+		fmt.Println("deleting", string(k), "index", index)
 		if err := dbTx.Delete(ctx, k); err != nil {
 			return err
 		}

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -763,6 +763,10 @@ func (b *BalanceStorage) PruneBalances(
 	currency *types.Currency,
 	index int64,
 ) error {
+	if index < 0 {
+		return nil
+	}
+
 	key := GetAccountKey(pruneNamespace, account, currency)
 	dbTx := b.db.WriteTransaction(ctx, string(key), false)
 	defer dbTx.Discard(ctx)

--- a/storage/modules/balance_storage_test.go
+++ b/storage/modules/balance_storage_test.go
@@ -723,7 +723,7 @@ func TestBalance(t *testing.T) {
 			ctx,
 			account,
 			largeDeduction.Currency,
-			-1,
+			-1238900,
 		)
 		assert.NoError(t, err)
 

--- a/storage/modules/counter_storage.go
+++ b/storage/modules/counter_storage.go
@@ -187,6 +187,16 @@ func (c *CounterStorage) Get(ctx context.Context, counter string) (*big.Int, err
 	return value, err
 }
 
+// GetTransactional returns the current value of a counter in a database.Transaction.
+func (c *CounterStorage) GetTransactional(
+	ctx context.Context,
+	dbTx database.Transaction,
+	counter string,
+) (*big.Int, error) {
+	_, value, err := BigIntGet(ctx, getCounterKey(counter), dbTx)
+	return value, err
+}
+
 // AddingBlock is called by BlockStorage when adding a block.
 func (c *CounterStorage) AddingBlock(
 	ctx context.Context,


### PR DESCRIPTION
This PR fixes a few miscellaneous issues found while integrating `rosetta-sdk-go` into `rosetta-cli` (https://github.com/coinbase/rosetta-cli/pull/193).

### Changes
- [x] Add `CounterStorage.GetTransactional`
- [x] Fix negative `big.Int` regression: https://play.golang.org/p/wD68BU8AACd
  - [x] find issue in docs: https://golang.org/pkg/math/big/#Int.Bytes
  - [x] reproduce with test
  - [x] don't store pruned if < 0 (otherwise will appear as positive when reading)
- [x] remove erroneous unlock
- [x] delete all historical balances in `deleteAccountRecords`