### PR TITLE
[asserter] Backwards Compatibility for Operation.Status

### DIFF
--- a/asserter/block.go
+++ b/asserter/block.go
@@ -143,7 +143,12 @@ func (a *Asserter) OperationStatus(status *string, construction bool) error {
 		return ErrAsserterNotInitialized
 	}
 
-	if status == nil {
+	// As of rosetta-specifications@v1.4.7, populating
+	// the Operation.Status field is deprecated for construction,
+	// however, many implementations may still do this. Therefore,
+	// we need to handle a populated but empty Operation.Status
+	// field gracefully.
+	if status == nil || len(*status) == 0 {
 		if construction {
 			return nil
 		}
@@ -153,10 +158,6 @@ func (a *Asserter) OperationStatus(status *string, construction bool) error {
 
 	if construction {
 		return ErrOperationStatusNotEmptyForConstruction
-	}
-
-	if len(*status) == 0 {
-		return ErrOperationStatusMissing
 	}
 
 	if _, ok := a.operationStatusMap[*status]; !ok {

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -405,6 +405,21 @@ func TestOperation(t *testing.T) {
 			construction: true,
 			err:          nil,
 		},
+		"valid construction operation (empty status)": {
+			operation: &types.Operation{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(1),
+				},
+				Type:    "PAYMENT",
+				Status:  types.String(""),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+			index:        int64(1),
+			successful:   false,
+			construction: true,
+			err:          nil,
+		},
 		"invalid construction operation": {
 			operation: &types.Operation{
 				OperationIdentifier: &types.OperationIdentifier{


### PR DESCRIPTION
Related: #231 

This PR adds backwards compatibility for implementations that populate the `Operation.Status` field in the `/construction/parse` response. This support was accidentally removed when upgrading the `rosetta-sdk-go` to support `rosetta-specifications@v1.4.7`.