### PR TITLE
[client] Handle 408 Status Code as Retriable

### DIFF
--- a/client/api_account.go
+++ b/client/api_account.go
@@ -111,7 +111,8 @@ func (a *AccountAPIService) AccountBalance(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -205,7 +206,8 @@ func (a *AccountAPIService) AccountCoins(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,

--- a/client/api_block.go
+++ b/client/api_block.go
@@ -108,7 +108,8 @@ func (a *BlockAPIService) Block(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -205,7 +206,8 @@ func (a *BlockAPIService) BlockTransaction(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,

--- a/client/api_call.go
+++ b/client/api_call.go
@@ -111,7 +111,8 @@ func (a *CallAPIService) Call(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,

--- a/client/api_construction.go
+++ b/client/api_construction.go
@@ -103,7 +103,8 @@ func (a *ConstructionAPIService) ConstructionCombine(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -188,7 +189,8 @@ func (a *ConstructionAPIService) ConstructionDerive(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -273,7 +275,8 @@ func (a *ConstructionAPIService) ConstructionHash(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -365,7 +368,8 @@ func (a *ConstructionAPIService) ConstructionMetadata(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -451,7 +455,8 @@ func (a *ConstructionAPIService) ConstructionParse(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -542,7 +547,8 @@ func (a *ConstructionAPIService) ConstructionPayloads(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -631,7 +637,8 @@ func (a *ConstructionAPIService) ConstructionPreprocess(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -719,7 +726,8 @@ func (a *ConstructionAPIService) ConstructionSubmit(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,

--- a/client/api_events.go
+++ b/client/api_events.go
@@ -106,7 +106,8 @@ func (a *EventsAPIService) EventsBlocks(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,

--- a/client/api_mempool.go
+++ b/client/api_mempool.go
@@ -101,7 +101,8 @@ func (a *MempoolAPIService) Mempool(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -191,7 +192,8 @@ func (a *MempoolAPIService) MempoolTransaction(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,

--- a/client/api_network.go
+++ b/client/api_network.go
@@ -101,7 +101,8 @@ func (a *NetworkAPIService) NetworkList(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -188,7 +189,8 @@ func (a *NetworkAPIService) NetworkOptions(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,
@@ -273,7 +275,8 @@ func (a *NetworkAPIService) NetworkStatus(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,

--- a/client/api_search.go
+++ b/client/api_search.go
@@ -106,7 +106,8 @@ func (a *SearchAPIService) SearchTransactions(
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,

--- a/templates/client/api.mustache
+++ b/templates/client/api.mustache
@@ -109,7 +109,8 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 		return nil, &v, fmt.Errorf("%+v", v)
 	case _nethttp.StatusBadGateway,
 		_nethttp.StatusServiceUnavailable,
-		_nethttp.StatusGatewayTimeout:
+		_nethttp.StatusGatewayTimeout,
+		_nethttp.StatusRequestTimeout:
 		return nil, nil, fmt.Errorf(
 			"%w: code: %d body: %s",
 			ErrRetriable,


### PR DESCRIPTION
This PR updates `client` to treat a [`408`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) as `ErrRetriable`.

### Changes
- [x] update `templates`
- [x] run `make gen`