### PR TITLE
[reconciler] Inactive Reconciliation Bypass

### DIFF
--- a/mocks/reconciler/helper.go
+++ b/mocks/reconciler/helper.go
@@ -99,6 +99,20 @@ func (_m *Helper) DatabaseTransaction(ctx context.Context) database.Transaction 
 	return r0
 }
 
+// ForceInactiveReconciliation provides a mock function with given fields: ctx, account, currency, lastCheck
+func (_m *Helper) ForceInactiveReconciliation(ctx context.Context, account *types.AccountIdentifier, currency *types.Currency, lastCheck *types.BlockIdentifier) bool {
+	ret := _m.Called(ctx, account, currency, lastCheck)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, *types.AccountIdentifier, *types.Currency, *types.BlockIdentifier) bool); ok {
+		r0 = rf(ctx, account, currency, lastCheck)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // IndexAtTip provides a mock function with given fields: ctx, index
 func (_m *Helper) IndexAtTip(ctx context.Context, index int64) (bool, error) {
 	ret := _m.Called(ctx, index)

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -834,7 +834,13 @@ func (r *Reconciler) reconcileInactiveAccounts( // nolint:gocognit
 			nextValidIndex = nextAcct.LastCheck.Index + r.inactiveFrequency
 		}
 
-		if nextValidIndex <= head.Index {
+		if nextValidIndex <= head.Index ||
+			r.helper.ForceInactiveReconciliation(
+				ctx,
+				nextAcct.Entry.Account,
+				nextAcct.Entry.Currency,
+				nextAcct.LastCheck,
+			) {
 			r.inactiveQueue = r.inactiveQueue[1:]
 			r.inactiveQueueMutex.Unlock()
 

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -3345,7 +3345,15 @@ func TestReconcile_SuccessOnlyInactiveOverride(t *testing.T) {
 		},
 	).Once()
 	mockHelper.On("DatabaseTransaction", mock.Anything).Return(mtxn4).Once()
-	mockHelper.On("ForceInactiveReconciliation", mock.Anything, accountCurrency.Account, accountCurrency.Currency, block).Return(true).Once()
+	mockHelper.On(
+		"ForceInactiveReconciliation",
+		mock.Anything,
+		accountCurrency.Account,
+		accountCurrency.Currency,
+		block,
+	).Return(
+		true,
+	).Once()
 	mockReconcilerCalls(
 		mockHelper,
 		mockHandler,

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -168,6 +168,19 @@ type Helper interface {
 		currency *types.Currency,
 		index int64,
 	) error
+
+	// ForceInactiveReconciliation is invoked by the
+	// inactive reconciler when the next account to
+	// reconcile has been checked within the configured
+	// inactive reconciliation frequency. This allows
+	// the helper to dynamically force inactive reconciliation
+	// when desired (i.e. when at tip).
+	ForceInactiveReconciliation(
+		ctx context.Context,
+		account *types.AccountIdentifier,
+		currency *types.Currency,
+		lastCheck *types.BlockIdentifier,
+	) bool
 }
 
 // Handler is called by Reconciler after a reconciliation


### PR DESCRIPTION
This PR adds support for forcing inactive reconciliation eventhough it may not be strictly required (based on the inactive reconciliation configuration). This is helpful for exiting with a certain reconciliation coverage from tip in `rosetta-cli`.

### Changes
- [x] Add `ForceInactiveReconciliation` to helper
- [x] Test `ForceInactiveReconciliation`