### PR TITLE
[chore] `rosetta-specifications@v1.4.9`

### DIFF
--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -266,7 +266,8 @@ func TestNew(t *testing.T) {
 		networkStatus  *types.NetworkStatusResponse
 		networkOptions *types.NetworkOptionsResponse
 
-		err error
+		err          error
+		skipLoadTest bool
 	}{
 		"valid responses": {
 			network:        validNetwork,
@@ -301,7 +302,8 @@ func TestNew(t *testing.T) {
 			networkStatus:  invalidNetworkStatusSyncStatus,
 			networkOptions: validNetworkOptions,
 
-			err: errors.New("BlockIdentifier is nil"),
+			err:          errors.New("SyncStatus.CurrentIndex is negative"),
+			skipLoadTest: true,
 		},
 		"invalid network options": {
 			network:        validNetwork,
@@ -378,6 +380,10 @@ func TestNew(t *testing.T) {
 				assert.Equal(t, test.networkStatus.GenesisBlockIdentifier.Index+1, configuration.AllowedTimestampStartIndex)
 			}
 		})
+
+		if test.skipLoadTest {
+			continue
+		}
 
 		t.Run(fmt.Sprintf("%s with file", name), func(t *testing.T) {
 			fileConfig := &Configuration{

--- a/asserter/asserter_test.go
+++ b/asserter/asserter_test.go
@@ -51,6 +51,27 @@ func TestNew(t *testing.T) {
 			},
 		}
 
+		validNetworkStatusSyncStatus = &types.NetworkStatusResponse{
+			GenesisBlockIdentifier: &types.BlockIdentifier{
+				Index: 0,
+				Hash:  "block 0",
+			},
+			CurrentBlockIdentifier: &types.BlockIdentifier{
+				Index: 100,
+				Hash:  "block 100",
+			},
+			CurrentBlockTimestamp: MinUnixEpoch + 1,
+			Peers: []*types.Peer{
+				{
+					PeerID: "peer 1",
+				},
+			},
+			SyncStatus: &types.SyncStatus{
+				CurrentIndex: types.Int64(100),
+				Stage:        types.String("pre-sync"),
+			},
+		}
+
 		invalidNetworkStatus = &types.NetworkStatusResponse{
 			CurrentBlockIdentifier: &types.BlockIdentifier{
 				Index: 100,
@@ -61,6 +82,27 @@ func TestNew(t *testing.T) {
 				{
 					PeerID: "peer 1",
 				},
+			},
+		}
+
+		invalidNetworkStatusSyncStatus = &types.NetworkStatusResponse{
+			GenesisBlockIdentifier: &types.BlockIdentifier{
+				Index: 0,
+				Hash:  "block 0",
+			},
+			CurrentBlockIdentifier: &types.BlockIdentifier{
+				Index: 100,
+				Hash:  "block 100",
+			},
+			CurrentBlockTimestamp: MinUnixEpoch + 1,
+			Peers: []*types.Peer{
+				{
+					PeerID: "peer 1",
+				},
+			},
+			SyncStatus: &types.SyncStatus{
+				CurrentIndex: types.Int64(-100),
+				Stage:        types.String("pre-sync"),
 			},
 		}
 
@@ -233,6 +275,13 @@ func TestNew(t *testing.T) {
 
 			err: nil,
 		},
+		"valid responses (with sync status)": {
+			network:        validNetwork,
+			networkStatus:  validNetworkStatusSyncStatus,
+			networkOptions: validNetworkOptions,
+
+			err: nil,
+		},
 		"valid responses (with start index)": {
 			network:        validNetwork,
 			networkStatus:  validNetworkStatus,
@@ -243,6 +292,13 @@ func TestNew(t *testing.T) {
 		"invalid network status": {
 			network:        validNetwork,
 			networkStatus:  invalidNetworkStatus,
+			networkOptions: validNetworkOptions,
+
+			err: errors.New("BlockIdentifier is nil"),
+		},
+		"invalid network status (with SyncStatus)": {
+			network:        validNetwork,
+			networkStatus:  invalidNetworkStatusSyncStatus,
 			networkOptions: validNetworkOptions,
 
 			err: errors.New("BlockIdentifier is nil"),

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -282,6 +282,15 @@ var (
 	ErrTimestampStartIndexInvalid = errors.New(
 		"TimestampStartIndex is invalid",
 	)
+	ErrSyncStatusCurrentIndexNegative = errors.New(
+		"SyncStatus.CurrentIndex is negative",
+	)
+	ErrSyncStatusTargetIndexNegative = errors.New(
+		"SyncStatus.TargetIndex is negative",
+	)
+	ErrSyncStatusStageInvalid = errors.New(
+		"SyncStatus.Stage is invalid",
+	)
 
 	NetworkErrs = []error{
 		ErrSubNetworkIdentifierInvalid,
@@ -307,6 +316,9 @@ var (
 		ErrBalanceExemptionSubAccountAddressEmpty,
 		ErrBalanceExemptionNoHistoricalLookup,
 		ErrTimestampStartIndexInvalid,
+		ErrSyncStatusCurrentIndexNegative,
+		ErrSyncStatusTargetIndexNegative,
+		ErrSyncStatusStageInvalid,
 	}
 )
 
@@ -431,9 +443,11 @@ var (
 // Search Errors
 var (
 	ErrNextOffsetInvalid = errors.New("next offset invalid")
+	ErrTotalCountInvalid = errors.New("total count invalid")
 
 	SearchErrs = []error{
 		ErrNextOffsetInvalid,
+		ErrTotalCountInvalid,
 	}
 )
 

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -78,6 +78,27 @@ func Version(version *types.Version) error {
 	return nil
 }
 
+// SyncStatus ensures any types.SyncStatus is valid.
+func SyncStatus(status *types.SyncStatus) error {
+	if status == nil {
+		return nil
+	}
+
+	if status.CurrentIndex != nil && *status.CurrentIndex < 0 {
+		return ErrSyncStatusCurrentIndexNegative
+	}
+
+	if status.TargetIndex != nil && *status.TargetIndex < 0 {
+		return ErrSyncStatusTargetIndexNegative
+	}
+
+	if status.Stage != nil && len(*status.Stage) == 0 {
+		return ErrSyncStatusStageInvalid
+	}
+
+	return nil
+}
+
 // NetworkStatusResponse ensures any types.NetworkStatusResponse
 // is valid.
 func NetworkStatusResponse(response *types.NetworkStatusResponse) error {
@@ -101,6 +122,10 @@ func NetworkStatusResponse(response *types.NetworkStatusResponse) error {
 		if err := Peer(peer); err != nil {
 			return err
 		}
+	}
+
+	if err := SyncStatus(response.SyncStatus); err != nil {
+		return err
 	}
 
 	return nil

--- a/asserter/search.go
+++ b/asserter/search.go
@@ -31,6 +31,10 @@ func (a *Asserter) SearchTransactionsResponse(
 		return ErrNextOffsetInvalid
 	}
 
+	if response.TotalCount < 0 {
+		return ErrTotalCountInvalid
+	}
+
 	for _, blockTransaction := range response.Transactions {
 		if err := BlockIdentifier(blockTransaction.BlockIdentifier); err != nil {
 			return err

--- a/asserter/search_test.go
+++ b/asserter/search_test.go
@@ -80,6 +80,7 @@ func TestSearchTransactionsResponse(t *testing.T) {
 			response: &types.SearchTransactionsResponse{
 				TotalCount: -1,
 			},
+			err: ErrTotalCountInvalid,
 		},
 		"valid next + transaction": {
 			response: &types.SearchTransactionsResponse{

--- a/asserter/search_test.go
+++ b/asserter/search_test.go
@@ -71,6 +71,16 @@ func TestSearchTransactionsResponse(t *testing.T) {
 			},
 			err: ErrNextOffsetInvalid,
 		},
+		"valid count": {
+			response: &types.SearchTransactionsResponse{
+				TotalCount: 0,
+			},
+		},
+		"invalid count": {
+			response: &types.SearchTransactionsResponse{
+				TotalCount: -1,
+			},
+		},
 		"valid next + transaction": {
 			response: &types.SearchTransactionsResponse{
 				NextOffset: types.Int64(1),

--- a/client/client.go
+++ b/client/client.go
@@ -41,7 +41,7 @@ var (
 	ErrRetriable = errors.New("retriable http status code received")
 )
 
-// APIClient manages communication with the Rosetta API v1.4.8
+// APIClient manages communication with the Rosetta API v1.4.9
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
 	cfg    *Configuration

--- a/codegen.sh
+++ b/codegen.sh
@@ -53,7 +53,7 @@ done
 rm -rf tmp;
 
 # Download spec file from releases
-ROSETTA_SPEC_VERSION=1.4.8
+ROSETTA_SPEC_VERSION=1.4.9
 curl -L https://github.com/coinbase/rosetta-specifications/releases/download/v${ROSETTA_SPEC_VERSION}/api.json -o api.json;
 
 # Generate client + types code

--- a/types/block_response.go
+++ b/types/block_response.go
@@ -18,8 +18,8 @@ package types
 
 // BlockResponse A BlockResponse includes a fully-populated block or a partially-populated block
 // with a list of other transactions to fetch (other_transactions). As a result of the consensus
-// algorithm of some blockchains, blocks can be omitted (i.e. certain block indexes can be skipped).
-// If a query for one of these omitted indexes is made, the response should not include a `Block`
+// algorithm of some blockchains, blocks can be omitted (i.e. certain block indices can be skipped).
+// If a query for one of these omitted indices is made, the response should not include a `Block`
 // object. It is VERY important to note that blocks MUST still form a canonical, connected chain of
 // blocks where each block has a unique index. In other words, the `PartialBlockIdentifier` of a
 // block after an omitted block should reference the last non-omitted block.

--- a/types/operation.go
+++ b/types/operation.go
@@ -23,7 +23,7 @@ package types
 // blockchains.
 type Operation struct {
 	OperationIdentifier *OperationIdentifier `json:"operation_identifier"`
-	// Restrict referenced related_operations to identifier indexes < the current
+	// Restrict referenced related_operations to identifier indices < the current
 	// operation_identifier.index. This ensures there exists a clear DAG-structure of relations.
 	// Since operations are one-sided, one could imagine relating operations in a single transfer or
 	// linking operations in a call tree.

--- a/types/search_transactions_response.go
+++ b/types/search_transactions_response.go
@@ -20,12 +20,16 @@ package types
 // BlockTransactions that match the query in SearchTransactionsRequest. These BlockTransactions are
 // sorted from most recent block to oldest block.
 type SearchTransactionsResponse struct {
-	// next_offset is the next offset to use when paginating through transaction results. If this
-	// field is not populated, there are no more transactions to query.
-	NextOffset *int64 `json:"next_offset,omitempty"`
 	// transactions is an array of BlockTransactions sorted by most recent BlockIdentifier (meaning
 	// that transactions in recent blocks appear first). If there are many transactions for a
 	// particular search, transactions may not contain all matching transactions. It is up to the
 	// caller to paginate these transactions using the max_block field.
 	Transactions []*BlockTransaction `json:"transactions"`
+	// total_count is the number of results for a given search. Callers typically use this value to
+	// concurrently fetch results by offset or to display a virtual page number associated with
+	// results.
+	TotalCount int64 `json:"total_count"`
+	// next_offset is the next offset to use when paginating through transaction results. If this
+	// field is not populated, there are no more transactions to query.
+	NextOffset *int64 `json:"next_offset,omitempty"`
 }

--- a/types/sync_status.go
+++ b/types/sync_status.go
@@ -17,15 +17,26 @@
 package types
 
 // SyncStatus SyncStatus is used to provide additional context about an implementation's sync
-// status. It is often used to indicate that an implementation is healthy when it cannot be queried
-// until some sync phase occurs. If an implementation is immediately queryable, this model is often
-// not populated.
+// status. This object is often used by implementations to indicate healthiness when block data
+// cannot be queried until some sync phase completes or cannot be determined by comparing the
+// timestamp of the most recent block with the current time.
 type SyncStatus struct {
-	// CurrentIndex is the index of the last synced block in the current stage.
-	CurrentIndex int64 `json:"current_index"`
+	// CurrentIndex is the index of the last synced block in the current stage. This is a separate
+	// field from current_block_identifier in NetworkStatusResponse because blocks with indices up
+	// to and including the current_index may not yet be queryable by the caller. To reiterate, all
+	// indices up to and including current_block_identifier in NetworkStatusResponse must be
+	// queryable via the /block endpoint (excluding indices less than oldest_block_identifier).
+	CurrentIndex *int64 `json:"current_index,omitempty"`
 	// TargetIndex is the index of the block that the implementation is attempting to sync to in the
 	// current stage.
 	TargetIndex *int64 `json:"target_index,omitempty"`
 	// Stage is the phase of the sync process.
 	Stage *string `json:"stage,omitempty"`
+	// sycned is a boolean that indicates if an implementation has synced up to the most recent
+	// block. If this field is not populated, the caller should rely on a traditional tip timestamp
+	// comparison to determine if an implementation is synced. This field is particularly useful for
+	// quiescent blockchains (blocks only produced when there are pending transactions). In these
+	// blockchains, the most recent block could have a timestamp far behind the current time but the
+	// node could be healthy and at tip.
+	Synced *bool `json:"synced,omitempty"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -18,5 +18,5 @@ const (
 	// RosettaAPIVersion is the version of the Rosetta API
 	// specification used to generate code for this release
 	// of the SDK.
-	RosettaAPIVersion = "1.4.8"
+	RosettaAPIVersion = "1.4.9"
 )


### PR DESCRIPTION
This PR updates `rosetta-sdk-go` to the [latest release of `rosetta-specifications`](https://github.com/coinbase/rosetta-specifications/releases/tag/v1.4.9). This is a pretty minor release compared to other recent releases.

### Changelog
- [x] Assert `SyncStatus`
- [x] Assert `SearchTransactionsResponse.TotalCount`

### `rosetta-specifications` Changelog
- Return `Synced` Status [`#71`](https://github.com/coinbase/rosetta-specifications/pull/71)
- [indexer] Add `total_count` field [`#70`](https://github.com/coinbase/rosetta-specifications/pull/70)