### PR TITLE
[storage] Single Errgroup Pool for BlockWorkers

### DIFF
--- a/mocks/storage/modules/block_worker.go
+++ b/mocks/storage/modules/block_worker.go
@@ -5,6 +5,7 @@ package modules
 import (
 	context "context"
 
+	errgroup "github.com/neilotoole/errgroup"
 	mock "github.com/stretchr/testify/mock"
 
 	database "github.com/coinbase/rosetta-sdk-go/storage/database"
@@ -16,13 +17,13 @@ type BlockWorker struct {
 	mock.Mock
 }
 
-// AddingBlock provides a mock function with given fields: _a0, _a1, _a2
-func (_m *BlockWorker) AddingBlock(_a0 context.Context, _a1 *types.Block, _a2 database.Transaction) (database.CommitWorker, error) {
-	ret := _m.Called(_a0, _a1, _a2)
+// AddingBlock provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *BlockWorker) AddingBlock(_a0 context.Context, _a1 *errgroup.Group, _a2 *types.Block, _a3 database.Transaction) (database.CommitWorker, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 database.CommitWorker
-	if rf, ok := ret.Get(0).(func(context.Context, *types.Block, database.Transaction) database.CommitWorker); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(context.Context, *errgroup.Group, *types.Block, database.Transaction) database.CommitWorker); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(database.CommitWorker)
@@ -30,8 +31,8 @@ func (_m *BlockWorker) AddingBlock(_a0 context.Context, _a1 *types.Block, _a2 da
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *types.Block, database.Transaction) error); ok {
-		r1 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(1).(func(context.Context, *errgroup.Group, *types.Block, database.Transaction) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -39,13 +40,13 @@ func (_m *BlockWorker) AddingBlock(_a0 context.Context, _a1 *types.Block, _a2 da
 	return r0, r1
 }
 
-// RemovingBlock provides a mock function with given fields: _a0, _a1, _a2
-func (_m *BlockWorker) RemovingBlock(_a0 context.Context, _a1 *types.Block, _a2 database.Transaction) (database.CommitWorker, error) {
-	ret := _m.Called(_a0, _a1, _a2)
+// RemovingBlock provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *BlockWorker) RemovingBlock(_a0 context.Context, _a1 *errgroup.Group, _a2 *types.Block, _a3 database.Transaction) (database.CommitWorker, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 database.CommitWorker
-	if rf, ok := ret.Get(0).(func(context.Context, *types.Block, database.Transaction) database.CommitWorker); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(context.Context, *errgroup.Group, *types.Block, database.Transaction) database.CommitWorker); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(database.CommitWorker)
@@ -53,8 +54,8 @@ func (_m *BlockWorker) RemovingBlock(_a0 context.Context, _a1 *types.Block, _a2 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *types.Block, database.Transaction) error); ok {
-		r1 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(1).(func(context.Context, *errgroup.Group, *types.Block, database.Transaction) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/storage/modules/balance_storage_test.go
+++ b/storage/modules/balance_storage_test.go
@@ -1574,9 +1574,10 @@ func TestBlockSyncing(t *testing.T) {
 
 	t.Run("add block 1", func(t *testing.T) {
 		dbTx := database.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"AccountBalance",
-			mock.Anything,
+			gctx,
 			addr1,
 			curr,
 			b0.BlockIdentifier,
@@ -1584,8 +1585,7 @@ func TestBlockSyncing(t *testing.T) {
 			&types.Amount{Value: "1", Currency: curr},
 			nil,
 		).Once()
-		mockHandler.On("AccountsSeen", ctx, dbTx, 1).Return(nil).Once()
-		g, gctx := errgroup.WithContext(ctx)
+		mockHandler.On("AccountsSeen", gctx, dbTx, 1).Return(nil).Once()
 		_, err = storage.AddingBlock(gctx, g, b1, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())
@@ -1614,9 +1614,10 @@ func TestBlockSyncing(t *testing.T) {
 		assert.NoError(t, err)
 
 		dbTx := database.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"AccountBalance",
-			mock.Anything,
+			gctx,
 			addr2,
 			curr,
 			b1.BlockIdentifier,
@@ -1624,9 +1625,8 @@ func TestBlockSyncing(t *testing.T) {
 			&types.Amount{Value: "0", Currency: curr},
 			nil,
 		).Once()
-		mockHandler.On("AccountsSeen", ctx, dbTx, 1).Return(nil).Once()
-		mockHandler.On("AccountsReconciled", ctx, dbTx, 1).Return(nil).Once()
-		g, gctx := errgroup.WithContext(ctx)
+		mockHandler.On("AccountsSeen", gctx, dbTx, 1).Return(nil).Once()
+		mockHandler.On("AccountsReconciled", gctx, dbTx, 1).Return(nil).Once()
 		_, err = storage.AddingBlock(gctx, g, b2, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())
@@ -1735,9 +1735,10 @@ func TestBlockSyncing(t *testing.T) {
 
 	t.Run("add block 1", func(t *testing.T) {
 		dbTx := database.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"AccountBalance",
-			mock.Anything,
+			gctx,
 			addr1,
 			curr,
 			b0.BlockIdentifier,
@@ -1745,8 +1746,7 @@ func TestBlockSyncing(t *testing.T) {
 			&types.Amount{Value: "1", Currency: curr},
 			nil,
 		).Once()
-		mockHandler.On("AccountsSeen", ctx, dbTx, 1).Return(nil).Once()
-		g, gctx := errgroup.WithContext(ctx)
+		mockHandler.On("AccountsSeen", gctx, dbTx, 1).Return(nil).Once()
 		_, err = storage.AddingBlock(gctx, g, b1, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())
@@ -1780,9 +1780,10 @@ func TestBlockSyncing(t *testing.T) {
 
 	t.Run("add block 2a", func(t *testing.T) {
 		dbTx := database.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"AccountBalance",
-			mock.Anything,
+			gctx,
 			addr2,
 			curr,
 			b1.BlockIdentifier,
@@ -1790,8 +1791,7 @@ func TestBlockSyncing(t *testing.T) {
 			&types.Amount{Value: "0", Currency: curr},
 			nil,
 		).Once()
-		mockHandler.On("AccountsSeen", ctx, dbTx, 1).Return(nil).Once()
-		g, gctx := errgroup.WithContext(ctx)
+		mockHandler.On("AccountsSeen", gctx, dbTx, 1).Return(nil).Once()
 		_, err = storage.AddingBlock(gctx, g, b2a, dbTx)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())

--- a/storage/modules/balance_storage_test.go
+++ b/storage/modules/balance_storage_test.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/neilotoole/errgroup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -1557,8 +1558,10 @@ func TestBlockSyncing(t *testing.T) {
 
 	t.Run("add genesis block", func(t *testing.T) {
 		dbTx := database.Transaction(ctx)
-		_, err = storage.AddingBlock(ctx, b0, dbTx)
+		g, gctx := errgroup.WithContext(ctx)
+		_, err = storage.AddingBlock(gctx, g, b0, dbTx)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, dbTx.Commit(ctx))
 
 		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
@@ -1582,8 +1585,10 @@ func TestBlockSyncing(t *testing.T) {
 			nil,
 		).Once()
 		mockHandler.On("AccountsSeen", ctx, dbTx, 1).Return(nil).Once()
-		_, err = storage.AddingBlock(ctx, b1, dbTx)
+		g, gctx := errgroup.WithContext(ctx)
+		_, err = storage.AddingBlock(gctx, g, b1, dbTx)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, dbTx.Commit(ctx))
 
 		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
@@ -1621,8 +1626,10 @@ func TestBlockSyncing(t *testing.T) {
 		).Once()
 		mockHandler.On("AccountsSeen", ctx, dbTx, 1).Return(nil).Once()
 		mockHandler.On("AccountsReconciled", ctx, dbTx, 1).Return(nil).Once()
-		_, err = storage.AddingBlock(ctx, b2, dbTx)
+		g, gctx := errgroup.WithContext(ctx)
+		_, err = storage.AddingBlock(gctx, g, b2, dbTx)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, dbTx.Commit(ctx))
 
 		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
@@ -1659,8 +1666,10 @@ func TestBlockSyncing(t *testing.T) {
 
 	t.Run("orphan block 2", func(t *testing.T) {
 		dbTx := database.Transaction(ctx)
-		commitWorker, err := storage.RemovingBlock(ctx, b2, dbTx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitWorker, err := storage.RemovingBlock(gctx, g, b2, dbTx)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, dbTx.Commit(ctx))
 		mockHandler.On("BlockRemoved", ctx, b2, mock.Anything).Return(nil).Once()
 		mockHandler.On("AccountsSeen", ctx, mock.Anything, -1).Return(nil).Once()
@@ -1694,8 +1703,10 @@ func TestBlockSyncing(t *testing.T) {
 
 	t.Run("orphan block 1", func(t *testing.T) {
 		dbTx := database.Transaction(ctx)
-		commitWorker, err := storage.RemovingBlock(ctx, b1, dbTx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitWorker, err := storage.RemovingBlock(gctx, g, b1, dbTx)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, dbTx.Commit(ctx))
 		mockHandler.On("BlockRemoved", ctx, b1, mock.Anything).Return(nil).Once()
 		mockHandler.On("AccountsSeen", ctx, mock.Anything, -1).Return(nil).Once()
@@ -1735,8 +1746,10 @@ func TestBlockSyncing(t *testing.T) {
 			nil,
 		).Once()
 		mockHandler.On("AccountsSeen", ctx, dbTx, 1).Return(nil).Once()
-		_, err = storage.AddingBlock(ctx, b1, dbTx)
+		g, gctx := errgroup.WithContext(ctx)
+		_, err = storage.AddingBlock(gctx, g, b1, dbTx)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, dbTx.Commit(ctx))
 
 		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)
@@ -1778,8 +1791,10 @@ func TestBlockSyncing(t *testing.T) {
 			nil,
 		).Once()
 		mockHandler.On("AccountsSeen", ctx, dbTx, 1).Return(nil).Once()
-		_, err = storage.AddingBlock(ctx, b2a, dbTx)
+		g, gctx := errgroup.WithContext(ctx)
+		_, err = storage.AddingBlock(gctx, g, b2a, dbTx)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, dbTx.Commit(ctx))
 
 		amount, err := storage.GetBalance(ctx, addr1, curr, b0.BlockIdentifier.Index)

--- a/storage/modules/block_storage_test.go
+++ b/storage/modules/block_storage_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	minPruningDepth = 20
+	minPruningDepth        = 20
+	blockWorkerConcurrency = 10
 )
 
 func TestHeadBlockIdentifier(t *testing.T) {
@@ -53,7 +54,7 @@ func TestHeadBlockIdentifier(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(database)
+	storage := NewBlockStorage(database, blockWorkerConcurrency)
 
 	t.Run("No head block set", func(t *testing.T) {
 		blockIdentifier, err := storage.GetHeadBlockIdentifier(ctx)
@@ -310,7 +311,7 @@ func TestBlock(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(database)
+	storage := NewBlockStorage(database, blockWorkerConcurrency)
 
 	t.Run("Get non-existent tx", func(t *testing.T) {
 		newestBlock, transaction, err := findTransactionWithDbTransaction(
@@ -699,7 +700,7 @@ func TestManyBlocks(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(database)
+	storage := NewBlockStorage(database, blockWorkerConcurrency)
 
 	for i := int64(0); i < 10000; i++ {
 		blockIdentifier := &types.BlockIdentifier{
@@ -751,7 +752,7 @@ func TestCreateBlockCache(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(database)
+	storage := NewBlockStorage(database, blockWorkerConcurrency)
 
 	t.Run("no blocks processed", func(t *testing.T) {
 		assert.Equal(t, []*types.BlockIdentifier{}, storage.CreateBlockCache(ctx, minPruningDepth))
@@ -820,7 +821,7 @@ func TestAtTip(t *testing.T) {
 	assert.NoError(t, err)
 	defer database.Close(ctx)
 
-	storage := NewBlockStorage(database)
+	storage := NewBlockStorage(database, blockWorkerConcurrency)
 	tipDelay := int64(100)
 
 	t.Run("no blocks processed", func(t *testing.T) {

--- a/storage/modules/broadcast_storage.go
+++ b/storage/modules/broadcast_storage.go
@@ -20,6 +20,8 @@ import (
 	"log"
 	"sync"
 
+	"github.com/neilotoole/errgroup"
+
 	"github.com/coinbase/rosetta-sdk-go/storage/database"
 	"github.com/coinbase/rosetta-sdk-go/storage/errors"
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -213,6 +215,7 @@ func (b *BroadcastStorage) invokeAddBlockHandlers(
 // AddingBlock is called by BlockStorage when adding a block.
 func (b *BroadcastStorage) AddingBlock(
 	ctx context.Context,
+	g *errgroup.Group,
 	block *types.Block,
 	transaction database.Transaction,
 ) (database.CommitWorker, error) {
@@ -303,6 +306,7 @@ func (b *BroadcastStorage) AddingBlock(
 // TODO: error if transaction removed after confirmed (means confirmation depth not deep enough)
 func (b *BroadcastStorage) RemovingBlock(
 	ctx context.Context,
+	g *errgroup.Group,
 	block *types.Block,
 	transaction database.Transaction,
 ) (database.CommitWorker, error) {

--- a/storage/modules/broadcast_storage_test.go
+++ b/storage/modules/broadcast_storage_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/neilotoole/errgroup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -154,8 +155,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		block := blocks[0]
 
 		txn := storage.db.Transaction(ctx)
-		commitWorker, err := storage.AddingBlock(ctx, block, txn)
+		g, gctx := errgroup.WithContext(ctx)
+		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		err = txn.Commit(ctx)
 		assert.NoError(t, err)
 
@@ -216,8 +219,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 			nil,
 			nil,
 		).Once()
-		commitWorker, err := storage.AddingBlock(ctx, block, txn)
+		g, gctx := errgroup.WithContext(ctx)
+		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		err = txn.Commit(ctx)
 		assert.NoError(t, err)
 
@@ -370,8 +375,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 			&types.TransactionIdentifier{Hash: "tx 1"},
 			nil,
 		).Once()
-		commitWorker, err := storage.AddingBlock(ctx, block, txn)
+		g, gctx := errgroup.WithContext(ctx)
+		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 
 		accounts, err := storage.LockedAccounts(ctx, txn)
 		assert.NoError(t, err)
@@ -473,8 +480,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 			&types.TransactionIdentifier{Hash: "tx 2"},
 			nil,
 		).Once()
-		commitWorker, err := storage.AddingBlock(ctx, block, txn)
+		g, gctx := errgroup.WithContext(ctx)
+		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 
 		accounts, err := storage.LockedAccounts(ctx, txn)
 		assert.NoError(t, err)
@@ -561,8 +570,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Return(
 			nil,
 		).Once()
-		commitWorker, err := storage.AddingBlock(ctx, block, txn)
+		g, gctx := errgroup.WithContext(ctx)
+		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 
 		accounts, err := storage.LockedAccounts(ctx, txn)
 		assert.NoError(t, err)
@@ -627,8 +638,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Return(
 			nil,
 		).Once()
-		commitWorker, err := storage.AddingBlock(ctx, block, txn)
+		g, gctx := errgroup.WithContext(ctx)
+		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 
 		accounts, err := storage.LockedAccounts(ctx, txn)
 		assert.NoError(t, err)
@@ -866,8 +879,10 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 		for _, block := range blocks {
 			mockHelper.On("CurrentBlockIdentifier", ctx).Return(block.BlockIdentifier, nil).Once()
 			txn := storage.db.Transaction(ctx)
-			commitWorker, err := storage.AddingBlock(ctx, block, txn)
+			g, gctx := errgroup.WithContext(ctx)
+			commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 			assert.NoError(t, err)
+			assert.NoError(t, g.Wait())
 			err = txn.Commit(ctx)
 			assert.NoError(t, err)
 
@@ -993,8 +1008,10 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 		for _, block := range blocks[:60] {
 			mockHelper.On("CurrentBlockIdentifier", ctx).Return(block.BlockIdentifier, nil).Once()
 			txn := storage.db.Transaction(ctx)
-			commitWorker, err := storage.AddingBlock(ctx, block, txn)
+			g, gctx := errgroup.WithContext(ctx)
+			commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 			assert.NoError(t, err)
+			assert.NoError(t, g.Wait())
 			err = txn.Commit(ctx)
 			assert.NoError(t, err)
 
@@ -1086,8 +1103,10 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 		for _, block := range blocks[60:71] {
 			mockHelper.On("CurrentBlockIdentifier", ctx).Return(block.BlockIdentifier, nil).Once()
 			txn := storage.db.Transaction(ctx)
-			commitWorker, err := storage.AddingBlock(ctx, block, txn)
+			g, gctx := errgroup.WithContext(ctx)
+			commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 			assert.NoError(t, err)
+			assert.NoError(t, g.Wait())
 			err = txn.Commit(ctx)
 			assert.NoError(t, err)
 

--- a/storage/modules/broadcast_storage_test.go
+++ b/storage/modules/broadcast_storage_test.go
@@ -209,9 +209,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		block := blocks[1]
 
 		txn := storage.db.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			gctx,
 			&types.TransactionIdentifier{Hash: "tx 1"},
 			txn,
 		).Return(
@@ -219,7 +220,6 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 			nil,
 			nil,
 		).Once()
-		g, gctx := errgroup.WithContext(ctx)
 		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())
@@ -337,9 +337,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		mockHelper.On("AtTip", ctx, mock.Anything).Return(true, nil)
 
 		txn := storage.db.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			gctx,
 			&types.TransactionIdentifier{Hash: "tx 1"},
 			txn,
 		).Return(
@@ -349,7 +350,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Once()
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			gctx,
 			&types.TransactionIdentifier{Hash: "tx 2"},
 			txn,
 		).Return(
@@ -359,7 +360,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Once()
 		mockHandler.On(
 			"TransactionStale",
-			ctx,
+			gctx,
 			txn,
 			"broadcast 1",
 			&types.TransactionIdentifier{Hash: "tx 1"},
@@ -375,7 +376,6 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 			&types.TransactionIdentifier{Hash: "tx 1"},
 			nil,
 		).Once()
-		g, gctx := errgroup.WithContext(ctx)
 		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())
@@ -442,9 +442,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		block.Transactions = []*types.Transaction{tx1}
 
 		txn := storage.db.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			gctx,
 			&types.TransactionIdentifier{Hash: "tx 1"},
 			txn,
 		).Return(
@@ -454,7 +455,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Once()
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			gctx,
 			&types.TransactionIdentifier{Hash: "tx 2"},
 			txn,
 		).Return(
@@ -464,7 +465,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Once()
 		mockHandler.On(
 			"TransactionStale",
-			ctx,
+			gctx,
 			txn,
 			"broadcast 2",
 			&types.TransactionIdentifier{Hash: "tx 2"},
@@ -480,7 +481,6 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 			&types.TransactionIdentifier{Hash: "tx 2"},
 			nil,
 		).Once()
-		g, gctx := errgroup.WithContext(ctx)
 		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())
@@ -539,9 +539,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		block.Transactions = []*types.Transaction{tx2}
 
 		txn := storage.db.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			gctx,
 			&types.TransactionIdentifier{Hash: "tx 1"},
 			txn,
 		).Return(
@@ -551,7 +552,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Once()
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			gctx,
 			&types.TransactionIdentifier{Hash: "tx 2"},
 			txn,
 		).Return(
@@ -561,7 +562,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Once()
 		mockHandler.On(
 			"TransactionConfirmed",
-			ctx,
+			gctx,
 			txn,
 			"broadcast 1",
 			blocks[3].BlockIdentifier,
@@ -570,7 +571,6 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Return(
 			nil,
 		).Once()
-		g, gctx := errgroup.WithContext(ctx)
 		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())
@@ -617,9 +617,10 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		block := blocks[5]
 
 		txn := storage.db.Transaction(ctx)
+		g, gctx := errgroup.WithContext(ctx)
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			gctx,
 			&types.TransactionIdentifier{Hash: "tx 2"},
 			txn,
 		).Return(
@@ -629,7 +630,7 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Once()
 		mockHandler.On(
 			"TransactionConfirmed",
-			ctx,
+			gctx,
 			txn,
 			"broadcast 2",
 			blocks[4].BlockIdentifier,
@@ -638,7 +639,6 @@ func TestBroadcastStorageBroadcastSuccess(t *testing.T) {
 		).Return(
 			nil,
 		).Once()
-		g, gctx := errgroup.WithContext(ctx)
 		commitWorker, err := storage.AddingBlock(gctx, g, block, txn)
 		assert.NoError(t, err)
 		assert.NoError(t, g.Wait())
@@ -803,7 +803,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 		)
 		mockHandler.On(
 			"TransactionStale",
-			ctx,
+			mock.Anything,
 			mock.Anything,
 			"broadcast 1",
 			&types.TransactionIdentifier{Hash: "tx 1"},
@@ -835,7 +835,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 		)
 		mockHandler.On(
 			"TransactionStale",
-			ctx,
+			mock.Anything,
 			mock.Anything,
 			"broadcast 2",
 			&types.TransactionIdentifier{Hash: "tx 2"},
@@ -846,7 +846,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 		)
 		mockHandler.On(
 			"BroadcastFailed",
-			ctx,
+			mock.Anything,
 			mock.Anything,
 			"broadcast 2",
 			&types.TransactionIdentifier{Hash: "tx 2"},
@@ -858,7 +858,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 		// Never find in block
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			mock.Anything,
 			&types.TransactionIdentifier{Hash: "tx 1"},
 			mock.Anything,
 		).Return(
@@ -868,7 +868,7 @@ func TestBroadcastStorageBroadcastFailure(t *testing.T) {
 		)
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			mock.Anything,
 			&types.TransactionIdentifier{Hash: "tx 2"},
 			mock.Anything,
 		).Return(
@@ -1082,7 +1082,7 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 		// Never find in block
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			mock.Anything,
 			&types.TransactionIdentifier{Hash: "tx 1"},
 			mock.Anything,
 		).Return(
@@ -1092,7 +1092,7 @@ func TestBroadcastStorageBehindTip(t *testing.T) {
 		)
 		mockHelper.On(
 			"FindTransaction",
-			ctx,
+			mock.Anything,
 			&types.TransactionIdentifier{Hash: "tx 2"},
 			mock.Anything,
 		).Return(

--- a/storage/modules/coin_storage_test.go
+++ b/storage/modules/coin_storage_test.go
@@ -571,8 +571,8 @@ func TestCoinStorage(t *testing.T) {
 		g, gctx := errgroup.WithContext(ctx)
 		commitFunc, err := c.AddingBlock(gctx, g, coinBlock, tx)
 		assert.Nil(t, commitFunc)
-		assert.Error(t, err)
-		assert.NoError(t, g.Wait())
+		assert.NoError(t, err)
+		assert.Error(t, g.Wait())
 		tx.Discard(ctx)
 
 		mockHelper.On(

--- a/storage/modules/coin_storage_test.go
+++ b/storage/modules/coin_storage_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/neilotoole/errgroup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -544,9 +545,11 @@ func TestCoinStorage(t *testing.T) {
 
 	t.Run("add block", func(t *testing.T) {
 		tx := c.db.Transaction(ctx)
-		commitFunc, err := c.AddingBlock(ctx, coinBlock, tx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitFunc, err := c.AddingBlock(gctx, g, coinBlock, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, tx.Commit(ctx))
 
 		mockHelper.On(
@@ -565,9 +568,11 @@ func TestCoinStorage(t *testing.T) {
 
 	t.Run("add duplicate coin", func(t *testing.T) {
 		tx := c.db.Transaction(ctx)
-		commitFunc, err := c.AddingBlock(ctx, coinBlock, tx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitFunc, err := c.AddingBlock(gctx, g, coinBlock, tx)
 		assert.Nil(t, commitFunc)
 		assert.Error(t, err)
+		assert.NoError(t, g.Wait())
 		tx.Discard(ctx)
 
 		mockHelper.On(
@@ -586,9 +591,11 @@ func TestCoinStorage(t *testing.T) {
 
 	t.Run("add duplicate coin in same block", func(t *testing.T) {
 		tx := c.db.Transaction(ctx)
-		commitFunc, err := c.AddingBlock(ctx, coinBlockRepeat, tx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitFunc, err := c.AddingBlock(gctx, g, coinBlockRepeat, tx)
 		assert.Nil(t, commitFunc)
 		assert.Error(t, err)
+		assert.NoError(t, g.Wait())
 		tx.Discard(ctx)
 
 		mockHelper.On(
@@ -607,9 +614,11 @@ func TestCoinStorage(t *testing.T) {
 
 	t.Run("remove block", func(t *testing.T) {
 		tx := c.db.Transaction(ctx)
-		commitFunc, err := c.RemovingBlock(ctx, coinBlock, tx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitFunc, err := c.RemovingBlock(gctx, g, coinBlock, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, tx.Commit(ctx))
 
 		mockHelper.On(
@@ -641,9 +650,11 @@ func TestCoinStorage(t *testing.T) {
 
 	t.Run("spend coin", func(t *testing.T) {
 		tx := c.db.Transaction(ctx)
-		commitFunc, err := c.AddingBlock(ctx, coinBlock, tx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitFunc, err := c.AddingBlock(gctx, g, coinBlock, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, tx.Commit(ctx))
 
 		mockHelper.On(
@@ -660,9 +671,11 @@ func TestCoinStorage(t *testing.T) {
 		assert.Equal(t, blockIdentifier, block)
 
 		tx = c.db.Transaction(ctx)
-		commitFunc, err = c.AddingBlock(ctx, coinBlock2, tx)
+		g, gctx = errgroup.WithContext(ctx)
+		commitFunc, err = c.AddingBlock(gctx, g, coinBlock2, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, tx.Commit(ctx))
 
 		mockHelper.On(
@@ -694,9 +707,11 @@ func TestCoinStorage(t *testing.T) {
 
 	t.Run("add block with multiple outputs for 1 account", func(t *testing.T) {
 		tx := c.db.Transaction(ctx)
-		commitFunc, err := c.AddingBlock(ctx, coinBlock3, tx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitFunc, err := c.AddingBlock(gctx, g, coinBlock3, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, tx.Commit(ctx))
 
 		mockHelper.On(
@@ -756,15 +771,19 @@ func TestCoinStorage(t *testing.T) {
 
 	t.Run("remove block that creates and spends single coin", func(t *testing.T) {
 		tx := c.db.Transaction(ctx)
-		commitFunc, err := c.RemovingBlock(ctx, coinBlock3, tx)
+		g, gctx := errgroup.WithContext(ctx)
+		commitFunc, err := c.RemovingBlock(gctx, g, coinBlock3, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, tx.Commit(ctx))
 
 		tx = c.db.Transaction(ctx)
-		commitFunc, err = c.AddingBlock(ctx, coinBlock3, tx)
+		g, gctx = errgroup.WithContext(ctx)
+		commitFunc, err = c.AddingBlock(gctx, g, coinBlock3, tx)
 		assert.Nil(t, commitFunc)
 		assert.NoError(t, err)
+		assert.NoError(t, g.Wait())
 		assert.NoError(t, tx.Commit(ctx))
 
 		mockHelper.On(

--- a/storage/modules/counter_storage.go
+++ b/storage/modules/counter_storage.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/neilotoole/errgroup"
+
 	"github.com/coinbase/rosetta-sdk-go/storage/database"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/coinbase/rosetta-sdk-go/utils"
@@ -200,6 +202,7 @@ func (c *CounterStorage) GetTransactional(
 // AddingBlock is called by BlockStorage when adding a block.
 func (c *CounterStorage) AddingBlock(
 	ctx context.Context,
+	g *errgroup.Group,
 	block *types.Block,
 	transaction database.Transaction,
 ) (database.CommitWorker, error) {
@@ -243,6 +246,7 @@ func (c *CounterStorage) AddingBlock(
 // RemovingBlock is called by BlockStorage when removing a block.
 func (c *CounterStorage) RemovingBlock(
 	ctx context.Context,
+	g *errgroup.Group,
 	block *types.Block,
 	transaction database.Transaction,
 ) (database.CommitWorker, error) {


### PR DESCRIPTION
This PR updates `BlockWorkers` to use a single `errgroup` when adding/removing a block instead of a unique one for each worker (requiring synchronization at the end of each worker spawn).

### Changes
- [x] Update `BlockWorker` interface to accept `errgroup`
- [x] Update `BlockWorker` implementations to use single `errgroup`
- [x] Update tests
- [x] Add argument to block worker initializer to specify the number of BlockWorker executors to run