### PR TITLE
[storage] Protect against nil Helper and/or Handler in BalanceStorage

### DIFF
--- a/storage/errors/errors.go
+++ b/storage/errors/errors.go
@@ -334,6 +334,8 @@ var (
 	// to save cannot be parsed.
 	ErrInvalidValue = errors.New("invalid value")
 
+	ErrHelperHandlerMissing = errors.New("balance storage helper or handler is missing")
+
 	BalanceStorageErrs = []error{
 		ErrNegativeBalance,
 		ErrInvalidLiveBalance,
@@ -342,6 +344,7 @@ var (
 		ErrAccountMissing,
 		ErrInvalidChangeValue,
 		ErrInvalidValue,
+		ErrHelperHandlerMissing,
 	}
 )
 

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -187,6 +187,10 @@ func (b *BalanceStorage) AddingBlock(
 	block *types.Block,
 	transaction database.Transaction,
 ) (database.CommitWorker, error) {
+	if b.handler == nil {
+		return nil, storageErrs.ErrHelperHandlerMissing
+	}
+
 	changes, err := b.parser.BalanceChanges(ctx, block, false)
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to calculate balance changes", err)
@@ -262,6 +266,10 @@ func (b *BalanceStorage) RemovingBlock(
 	block *types.Block,
 	transaction database.Transaction,
 ) (database.CommitWorker, error) {
+	if b.handler == nil {
+		return nil, storageErrs.ErrHelperHandlerMissing
+	}
+
 	changes, err := b.parser.BalanceChanges(ctx, block, true)
 	if err != nil {
 		return nil, fmt.Errorf("%w: unable to calculate balance changes", err)
@@ -339,6 +347,10 @@ func (b *BalanceStorage) SetBalance(
 	amount *types.Amount,
 	block *types.BlockIdentifier,
 ) error {
+	if b.handler == nil {
+		return storageErrs.ErrHelperHandlerMissing
+	}
+
 	// Remove all account-related items
 	if err := b.deleteAccountRecords(
 		ctx,
@@ -447,6 +459,10 @@ func (b *BalanceStorage) Reconciled(
 // get an idea of the reconciliation coverage without
 // doing an expensive DB scan across all accounts.
 func (b *BalanceStorage) EstimatedReconciliationCoverage(ctx context.Context) (float64, error) {
+	if b.helper == nil {
+		return -1, storageErrs.ErrHelperHandlerMissing
+	}
+
 	dbTx := b.db.ReadTransaction(ctx)
 	defer dbTx.Discard(ctx)
 
@@ -521,6 +537,10 @@ func (b *BalanceStorage) existingValue(
 	parentBlock *types.BlockIdentifier,
 	existingValue string,
 ) (string, error) {
+	if b.helper == nil {
+		return "", storageErrs.ErrHelperHandlerMissing
+	}
+
 	if exists {
 		return existingValue, nil
 	}
@@ -570,6 +590,10 @@ func (b *BalanceStorage) applyExemptions(
 	change *parser.BalanceChange,
 	newVal string,
 ) (string, error) {
+	if b.helper == nil {
+		return "", storageErrs.ErrHelperHandlerMissing
+	}
+
 	// Find exemptions that are applicable to the *parser.BalanceChange
 	exemptions := b.parser.FindExemptions(change.Account, change.Currency)
 	if len(exemptions) == 0 {
@@ -633,6 +657,10 @@ func (b *BalanceStorage) deleteAccountRecords(
 	account *types.AccountIdentifier,
 	currency *types.Currency,
 ) error {
+	if b.handler == nil {
+		return storageErrs.ErrHelperHandlerMissing
+	}
+
 	// Remove historical balance records
 	if err := b.removeHistoricalBalances(
 		ctx,

--- a/storage/modules/balance_storage_test.go
+++ b/storage/modules/balance_storage_test.go
@@ -1034,7 +1034,6 @@ func TestBootstrapBalances(t *testing.T) {
 	mockHelper.On("Asserter").Return(baseAsserter())
 	mockHelper.On("ExemptFunc").Return(exemptFunc())
 	mockHelper.On("BalanceExemptions").Return([]*types.BalanceExemption{})
-	storage.Initialize(mockHelper, mockHandler)
 	bootstrapBalancesFile := path.Join(newDir, "balances.csv")
 
 	t.Run("File doesn't exist", func(t *testing.T) {
@@ -1046,29 +1045,40 @@ func TestBootstrapBalances(t *testing.T) {
 		assert.Contains(t, err.Error(), "no such file or directory")
 	})
 
-	t.Run("Set balance successfully", func(t *testing.T) {
-		amount := &types.Amount{
-			Value: "10",
-			Currency: &types.Currency{
-				Symbol:   "BTC",
-				Decimals: 8,
-			},
-		}
+	// Initialize file
+	amount := &types.Amount{
+		Value: "10",
+		Currency: &types.Currency{
+			Symbol:   "BTC",
+			Decimals: 8,
+		},
+	}
 
-		file, err := json.MarshalIndent([]*BootstrapBalance{
-			{
-				Account:  account,
-				Value:    amount.Value,
-				Currency: amount.Currency,
-			},
-		}, "", " ")
-		assert.NoError(t, err)
+	file, err := json.MarshalIndent([]*BootstrapBalance{
+		{
+			Account:  account,
+			Value:    amount.Value,
+			Currency: amount.Currency,
+		},
+	}, "", " ")
+	assert.NoError(t, err)
 
-		assert.NoError(
-			t,
-			ioutil.WriteFile(bootstrapBalancesFile, file, utils.DefaultFilePermissions),
+	assert.NoError(
+		t,
+		ioutil.WriteFile(bootstrapBalancesFile, file, utils.DefaultFilePermissions),
+	)
+
+	t.Run("run before initializing helper/handler", func(t *testing.T) {
+		err = storage.BootstrapBalances(
+			ctx,
+			bootstrapBalancesFile,
+			genesisBlockIdentifier,
 		)
+		assert.True(t, errors.Is(err, storageErrs.ErrHelperHandlerMissing))
+	})
 
+	storage.Initialize(mockHelper, mockHandler)
+	t.Run("Set balance successfully", func(t *testing.T) {
 		mockHandler.On("AccountsSeen", ctx, mock.Anything, 1).Return(nil).Once()
 		err = storage.BootstrapBalances(
 			ctx,
@@ -1247,8 +1257,14 @@ func TestBalanceReconciliation(t *testing.T) {
 	mockHelper.On("Asserter").Return(baseAsserter())
 	mockHelper.On("ExemptFunc").Return(exemptFunc())
 	mockHelper.On("BalanceExemptions").Return([]*types.BalanceExemption{})
-	storage.Initialize(mockHelper, mockHandler)
 
+	t.Run("test estimated before helper/handler", func(t *testing.T) {
+		coverage, err := storage.EstimatedReconciliationCoverage(ctx)
+		assert.Equal(t, float64(-1), coverage)
+		assert.True(t, errors.Is(err, storageErrs.ErrHelperHandlerMissing))
+	})
+
+	storage.Initialize(mockHelper, mockHandler)
 	t.Run("attempt to store reconciliation for non-existent account", func(t *testing.T) {
 		err := storage.Reconciled(ctx, account, currency, genesisBlock)
 		assert.NoError(t, err)


### PR DESCRIPTION
Someone was able to [force a panic in `rosetta-cli` because of an unpopulated BalanceStorage helper and handler](https://community.rosetta-api.org/t/operation-status-must-be-empty-for-construction/315/4?u=patrick.ogrady). This PR causes BalanceStorage to raise an error in these cases instead of panicking.

### Changes
- [x] Add new error
- [x] Check for nil helper or handler
- [x] Add new tests