### PR TITLE
add Hash func (that returns error) to utils

### DIFF
--- a/utils/hash.go
+++ b/utils/hash.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+)
+
+// hashBytes returns a hex-encoded sha256 hash of the provided
+// byte slice.
+func hashBytes(data []byte) (string, error) {
+	h := sha256.New()
+	_, err := h.Write(data)
+	if err != nil {
+		return "", fmt.Errorf("%w: unable to hash data %s", err, string(data))
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+//NOTE: types package also contains similar Hash() but they panic
+//instead of returning error.
+
+// Hash returns a deterministic hash for any interface.
+// This works because Golang's JSON marshaler sorts all map keys, recursively.
+// Source: https://golang.org/pkg/encoding/json/#Marshal
+// Inspiration:
+// https://github.com/onsi/gomega/blob/c0be49994280db30b6b68390f67126d773bc5558/matchers/match_json_matcher.go#L16
+//
+// It is important to note that any interface that is a slice
+// or contains slices will not be equal if the slice ordering is
+// different.
+func Hash(i interface{}) (string, error) {
+	// Convert interface to JSON object (not necessarily ordered if struct
+	// contains json.RawMessage)
+	a, err := json.Marshal(i)
+	if err != nil {
+		return "", fmt.Errorf("%w: unable to marshal %+v", err, i)
+	}
+
+	// Convert JSON object to interface (all json.RawMessage converted to go types)
+	var b interface{}
+	if err := json.Unmarshal(a, &b); err != nil {
+		return "", fmt.Errorf("%w: unable to unmarshal %+v", err, a)
+	}
+
+	// Convert interface to JSON object (all map keys ordered)
+	c, err := json.Marshal(b)
+	if err != nil {
+		return "", fmt.Errorf("%w: unable to marshal %+v", err, b)
+	}
+
+	return hashBytes(c)
+}

--- a/utils/hash_test.go
+++ b/utils/hash_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHash(t *testing.T) {
+	var tests = map[string][]interface{}{
+		"simple": {
+			1,
+			1,
+		},
+		"complex": {
+			map[string]interface{}{
+				"a": "b",
+				"b": "c",
+				"c": "d",
+				"blahz": json.RawMessage(
+					`{"test":6, "wha":{"sweet":3, "nice":true}, "neat0":"hello"}`,
+				),
+				"d": map[string]interface{}{
+					"t": "p",
+					"e": 2,
+					"k": "l",
+					"blah": json.RawMessage(
+						`{"test":2, "neat":"hello", "cool":{"sweet":3, "nice":true}}`,
+					),
+				},
+			},
+			map[string]interface{}{
+				"b": "c",
+				"blahz": json.RawMessage(
+					`{"wha":{"sweet":3, "nice":true},"test":6, "neat0":"hello"}`,
+				),
+				"a": "b",
+				"d": map[string]interface{}{
+					"e": 2,
+					"k": "l",
+					"t": "p",
+					"blah": json.RawMessage(
+						`{"test":2, "neat":"hello", "cool":{"nice":true, "sweet":3}}`,
+					),
+				},
+				"c": "d",
+			},
+			map[string]interface{}{
+				"a": "b",
+				"d": map[string]interface{}{
+					"k": "l",
+					"t": "p",
+					"blah": json.RawMessage(
+						`{"test":2, "cool":{"nice":true, "sweet":3}, "neat":"hello"}`,
+					),
+					"e": 2,
+				},
+				"c": "d",
+				"blahz": json.RawMessage(
+					`{"wha":{"nice":true, "sweet":3},"test":6, "neat0":"hello"}`,
+				),
+				"b": "c",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var val string
+			for _, v := range test {
+				if val == "" {
+					val, _ = Hash(v)
+				} else {
+					h, err := Hash(v)
+					assert.Nil(t, err)
+					assert.Equal(t, val, h)
+				}
+			}
+		})
+	}
+
+	//Test invalid json should return err
+	errData := json.RawMessage(`{"neat0":withoutQuotes}`)
+	_, err := Hash(errData)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
### Fixes ###
The `types.Hash` panics on error. Adding a Hash func in utils that returns `(string , error)` .


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Current Hash func is a bit hard to use in codebase that don't want to log.Fatal

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
New one returns an error.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
We could migrate types.Hash usage in the codebase to utils.Hash in future.
