### PR TITLE
[fetcher] Optionally Force Retry

### DIFF
--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -84,3 +84,16 @@ func WithMaxConnections(connections int) Option {
 		f.maxConnections = connections
 	}
 }
+
+// WithForceRetry overrides the default
+// retry handling logic and treats every error
+// as retriable. This is useful when accessing
+// Rosetta implementations via a load balancer
+// (where we could accidentally sent a request
+// for a block to a node that has not synced it yet,
+// for example).
+func WithForceRetry() Option {
+	return func(f *Fetcher) {
+		f.forceRetry = true
+	}
+}

--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -87,11 +87,13 @@ func WithMaxConnections(connections int) Option {
 
 // WithForceRetry overrides the default
 // retry handling logic and treats every error
-// as retriable. This is useful when accessing
-// Rosetta implementations via a load balancer
-// (where we could accidentally sent a request
-// for a block to a node that has not synced it yet,
-// for example).
+// as retriable.
+//
+// This is particularly useful when accessing a Rosetta
+// implementation via a load balancer where there may be
+// periods of inconsistency (i.e. we get a network status
+// from one implementation and query another that has not
+// yet synced the most recent block).
 func WithForceRetry() Option {
 	return func(f *Fetcher) {
 		f.forceRetry = true

--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -57,7 +57,7 @@ func (f *Fetcher) RequestFailedError(
 	return &Error{
 		Err:       fmt.Errorf("%w: %s %s", ErrRequestFailed, message, err.Error()),
 		ClientErr: rosettaErr,
-		Retry: ((rosettaErr != nil && rosettaErr.Retriable) || transientError(err)) &&
+		Retry: ((rosettaErr != nil && rosettaErr.Retriable) || transientError(err) || f.forceRetry) &&
 			!errors.Is(err, context.Canceled),
 	}
 }

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -73,6 +73,7 @@ type Fetcher struct {
 	maxRetries       uint64
 	retryElapsedTime time.Duration
 	insecureTLS      bool
+	forceRetry       bool
 
 	// connectionSemaphore is used to limit the
 	// number of concurrent requests we make.


### PR DESCRIPTION
This PR allows the caller to specify that all non-200 responses from a Rosetta implementation should be retried. This is particularly useful when accessing a Rosetta implementation through a load balancer where there may be periods of inconsistency (i.e. we get a network status from one implementation and query another that has not yet synced the most recent block).

### Changes
- [x] Add `WithForceRetry` option to fetcher
- [x] Add test

### Future Work
* Add `force_retry` to `rosetta-cli`