### PR TITLE
[constructor] Transactional KV Store

### DIFF
--- a/constructor/coordinator/types.go
+++ b/constructor/coordinator/types.go
@@ -190,7 +190,7 @@ type Helper interface {
 		value []byte,
 	) error
 
-	// GetBlob transactionally persists
+	// GetBlob transactionally retrieves
 	// a key and value.
 	GetBlob(
 		ctx context.Context,

--- a/constructor/coordinator/types.go
+++ b/constructor/coordinator/types.go
@@ -180,6 +180,23 @@ type Helper interface {
 		context.Context,
 		[]*types.SigningPayload,
 	) ([]*types.Signature, error)
+
+	// SetBlob transactionally persists
+	// a key and value.
+	SetBlob(
+		ctx context.Context,
+		dbTx database.Transaction,
+		key string,
+		value string,
+	) error
+
+	// GetBlob transactionally persists
+	// a key and value.
+	GetBlob(
+		ctx context.Context,
+		dbTx database.Transaction,
+		key string,
+	) (bool, string, error)
 }
 
 // Handler is an interface called by the coordinator whenever

--- a/constructor/coordinator/types.go
+++ b/constructor/coordinator/types.go
@@ -187,7 +187,7 @@ type Helper interface {
 		ctx context.Context,
 		dbTx database.Transaction,
 		key string,
-		value string,
+		value []byte,
 	) error
 
 	// GetBlob transactionally persists
@@ -196,7 +196,7 @@ type Helper interface {
 		ctx context.Context,
 		dbTx database.Transaction,
 		key string,
-	) (bool, string, error)
+	) (bool, []byte, error)
 }
 
 // Handler is an interface called by the coordinator whenever

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -294,6 +294,19 @@ type HTTPRequestInput struct {
 	Body string `json:"body"`
 }
 
+// SaveBlobInput is the input to
+// SaveBlob.
+type SaveBlobInput struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// GetBlobInput is the input to
+// GetBlob.
+type GetBlobInput struct {
+	Key string `json:"key"`
+}
+
 // Scenario is a collection of Actions with a specific
 // confirmation depth.
 //

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -135,15 +135,15 @@ const (
 	// testing.
 	HTTPRequest ActionType = "http_request"
 
-	// SaveBlob stores an arbitrary blob at some key (any valid JSON is
+	// SetBlob stores an arbitrary blob at some key (any valid JSON is
 	// accepted as a key). If a value at a key already exists,
 	// it will be overwritten.
 	//
-	// SaveBlob is often used when there is some metadata created
+	// SetBlob is often used when there is some metadata created
 	// during a workflow execution that needs to be accessed
 	// in another workflow (i.e. a mapping between different generated
 	// addresses).
-	SaveBlob ActionType = "save_blob"
+	SetBlob ActionType = "set_blob"
 
 	// GetBlob attempts to retrieve some previously saved blob.
 	// If the blob is not accessible, it will return an error.
@@ -294,17 +294,17 @@ type HTTPRequestInput struct {
 	Body string `json:"body"`
 }
 
-// SaveBlobInput is the input to
-// SaveBlob.
-type SaveBlobInput struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+// SetBlobInput is the input to
+// SetBlob.
+type SetBlobInput struct {
+	Key   interface{} `json:"key"`
+	Value string      `json:"value"`
 }
 
 // GetBlobInput is the input to
 // GetBlob.
 type GetBlobInput struct {
-	Key string `json:"key"`
+	Key interface{} `json:"key"`
 }
 
 // Scenario is a collection of Actions with a specific

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -15,6 +15,7 @@
 package job
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/coinbase/rosetta-sdk-go/keys"
@@ -297,8 +298,8 @@ type HTTPRequestInput struct {
 // SetBlobInput is the input to
 // SetBlob.
 type SetBlobInput struct {
-	Key   interface{} `json:"key"`
-	Value string      `json:"value"`
+	Key   interface{}     `json:"key"`
+	Value json.RawMessage `json:"value"`
 }
 
 // GetBlobInput is the input to

--- a/constructor/job/types.go
+++ b/constructor/job/types.go
@@ -134,6 +134,20 @@ const (
 	// for making a request to a faucet to automate Construction API
 	// testing.
 	HTTPRequest ActionType = "http_request"
+
+	// SaveBlob stores an arbitrary blob at some key (any valid JSON is
+	// accepted as a key). If a value at a key already exists,
+	// it will be overwritten.
+	//
+	// SaveBlob is often used when there is some metadata created
+	// during a workflow execution that needs to be accessed
+	// in another workflow (i.e. a mapping between different generated
+	// addresses).
+	SaveBlob ActionType = "save_blob"
+
+	// GetBlob attempts to retrieve some previously saved blob.
+	// If the blob is not accessible, it will return an error.
+	GetBlob ActionType = "get_blob"
 )
 
 // Action is a step of computation that

--- a/constructor/worker/types.go
+++ b/constructor/worker/types.go
@@ -80,7 +80,7 @@ type Helper interface {
 		value []byte,
 	) error
 
-	// GetBlob transactionally persists
+	// GetBlob transactionally retrieves
 	// a key and value.
 	GetBlob(
 		ctx context.Context,

--- a/constructor/worker/types.go
+++ b/constructor/worker/types.go
@@ -77,7 +77,7 @@ type Helper interface {
 		ctx context.Context,
 		dbTx database.Transaction,
 		key string,
-		value string,
+		value []byte,
 	) error
 
 	// GetBlob transactionally persists
@@ -86,7 +86,7 @@ type Helper interface {
 		ctx context.Context,
 		dbTx database.Transaction,
 		key string,
-	) (bool, string, error)
+	) (bool, []byte, error)
 }
 
 // Worker processes jobs.

--- a/constructor/worker/types.go
+++ b/constructor/worker/types.go
@@ -70,6 +70,23 @@ type Helper interface {
 		*types.PublicKey,
 		map[string]interface{},
 	) (*types.AccountIdentifier, map[string]interface{}, error)
+
+	// SetBlob transactionally persists
+	// a key and value.
+	SetBlob(
+		ctx context.Context,
+		dbTx database.Transaction,
+		key string,
+		value string,
+	) error
+
+	// GetBlob transactionally persists
+	// a key and value.
+	GetBlob(
+		ctx context.Context,
+		dbTx database.Transaction,
+		key string,
+	) (bool, string, error)
 }
 
 // Worker processes jobs.

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -862,7 +862,11 @@ func (w *Worker) GetBlobWorker(
 	}
 
 	if !exists {
-		return "", fmt.Errorf("%w: key %s does not exist", ErrActionFailed, types.PrintStruct(input.Key))
+		return "", fmt.Errorf(
+			"%w: key %s does not exist",
+			ErrActionFailed,
+			types.PrintStruct(input.Key),
+		)
 	}
 
 	return string(val), nil

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -836,7 +836,7 @@ func (w *Worker) SetBlobWorker(
 		return fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
 	}
 
-	if err := w.helper.SetBlob(ctx, dbTx, types.Hash(input.Key), input.Value); err != nil {
+	if err := w.helper.SetBlob(ctx, dbTx, types.Hash(input.Key), string(input.Value)); err != nil {
 		return fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
 	}
 

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -836,6 +836,9 @@ func (w *Worker) SetBlobWorker(
 		return fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
 	}
 
+	// By using interface{} for key, we can ensure that JSON
+	// objects with the same keys but in a different order are
+	// treated as equal.
 	if err := w.helper.SetBlob(ctx, dbTx, types.Hash(input.Key), input.Value); err != nil {
 		return fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
 	}
@@ -856,6 +859,9 @@ func (w *Worker) GetBlobWorker(
 		return "", fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
 	}
 
+	// By using interface{} for key, we can ensure that JSON
+	// objects with the same keys but in a different order are
+	// treated as equal.
 	exists, val, err := w.helper.GetBlob(ctx, dbTx, types.Hash(input.Key))
 	if err != nil {
 		return "", fmt.Errorf("%w: %s", ErrActionFailed, err.Error())

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -836,7 +836,7 @@ func (w *Worker) SetBlobWorker(
 		return fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
 	}
 
-	if err := w.helper.SetBlob(ctx, dbTx, types.Hash(input.Key), string(input.Value)); err != nil {
+	if err := w.helper.SetBlob(ctx, dbTx, types.Hash(input.Key), input.Value); err != nil {
 		return fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
 	}
 
@@ -865,5 +865,5 @@ func (w *Worker) GetBlobWorker(
 		return "", fmt.Errorf("%w: key %s does not exist", ErrActionFailed, types.PrintStruct(input.Key))
 	}
 
-	return val, nil
+	return string(val), nil
 }

--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -80,6 +80,10 @@ func (w *Worker) invokeWorker(
 		return LoadEnvWorker(input)
 	case job.HTTPRequest:
 		return HTTPRequestWorker(input)
+	case job.SetBlob:
+		return "", w.SetBlobWorker(ctx, dbTx, input)
+	case job.GetBlob:
+		return w.GetBlobWorker(ctx, dbTx, input)
 	default:
 		return "", fmt.Errorf("%w: %s", ErrInvalidActionType, action)
 	}
@@ -817,4 +821,49 @@ func HTTPRequestWorker(rawInput string) (string, error) {
 	}
 
 	return string(body), nil
+}
+
+// SetBlobWorker transactionally saves a key and value for use
+// across workflows.
+func (w *Worker) SetBlobWorker(
+	ctx context.Context,
+	dbTx database.Transaction,
+	rawInput string,
+) error {
+	var input job.SetBlobInput
+	err := job.UnmarshalInput([]byte(rawInput), &input)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
+	}
+
+	if err := w.helper.SetBlob(ctx, dbTx, types.Hash(input.Key), input.Value); err != nil {
+		return fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
+	}
+
+	return nil
+}
+
+// GetBlobWorker transactionally retrieves a value associated with
+// a key, if it exists.
+func (w *Worker) GetBlobWorker(
+	ctx context.Context,
+	dbTx database.Transaction,
+	rawInput string,
+) (string, error) {
+	var input job.GetBlobInput
+	err := job.UnmarshalInput([]byte(rawInput), &input)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrInvalidInput, err.Error())
+	}
+
+	exists, val, err := w.helper.GetBlob(ctx, dbTx, types.Hash(input.Key))
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrActionFailed, err.Error())
+	}
+
+	if !exists {
+		return "", fmt.Errorf("%w: key %s does not exist", ErrActionFailed, types.PrintStruct(input.Key))
+	}
+
+	return val, nil
 }

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1885,7 +1885,7 @@ func TestBlobWorkers(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					types.Hash("Testnet3"),
-					"\"Bitcoin\"",
+					[]byte(`"Bitcoin"`),
 				).Return(nil).Once()
 
 				h.On(
@@ -1893,7 +1893,7 @@ func TestBlobWorkers(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					types.Hash("Testnet3"),
-				).Return(true, "\"Bitcoin\"", nil).Once()
+				).Return(true, []byte(`"Bitcoin"`), nil).Once()
 
 				return h
 			}(),
@@ -1917,7 +1917,7 @@ func TestBlobWorkers(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 					types.Hash("Testnet3"),
-				).Return(false, "", nil).Once()
+				).Return(false, []byte{}, nil).Once()
 
 				return h
 			}(),
@@ -1967,7 +1967,7 @@ func TestBlobWorkers(t *testing.T) {
 							Address: "neat",
 						},
 					}),
-					`{"stuff":"neat"}`,
+					[]byte(`{"stuff":"neat"}`),
 				).Return(nil).Once()
 				h.On(
 					"SetBlob",
@@ -1979,7 +1979,7 @@ func TestBlobWorkers(t *testing.T) {
 							Address: "neat2",
 						},
 					}),
-					`"addr2"`,
+					[]byte(`"addr2"`),
 				).Return(nil).Once()
 
 				h.On(
@@ -1994,7 +1994,7 @@ func TestBlobWorkers(t *testing.T) {
 					}),
 				).Return(
 					true,
-					`{"stuff":"neat"}`,
+					[]byte(`{"stuff":"neat"}`),
 					nil,
 				).Once()
 

--- a/mocks/constructor/coordinator/helper.go
+++ b/mocks/constructor/coordinator/helper.go
@@ -184,7 +184,7 @@ func (_m *Helper) Derive(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 
 }
 
 // GetBlob provides a mock function with given fields: ctx, dbTx, key
-func (_m *Helper) GetBlob(ctx context.Context, dbTx database.Transaction, key string) (bool, string, error) {
+func (_m *Helper) GetBlob(ctx context.Context, dbTx database.Transaction, key string) (bool, []byte, error) {
 	ret := _m.Called(ctx, dbTx, key)
 
 	var r0 bool
@@ -194,11 +194,13 @@ func (_m *Helper) GetBlob(ctx context.Context, dbTx database.Transaction, key st
 		r0 = ret.Get(0).(bool)
 	}
 
-	var r1 string
-	if rf, ok := ret.Get(1).(func(context.Context, database.Transaction, string) string); ok {
+	var r1 []byte
+	if rf, ok := ret.Get(1).(func(context.Context, database.Transaction, string) []byte); ok {
 		r1 = rf(ctx, dbTx, key)
 	} else {
-		r1 = ret.Get(1).(string)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]byte)
+		}
 	}
 
 	var r2 error
@@ -430,11 +432,11 @@ func (_m *Helper) Preprocess(_a0 context.Context, _a1 *types.NetworkIdentifier, 
 }
 
 // SetBlob provides a mock function with given fields: ctx, dbTx, key, value
-func (_m *Helper) SetBlob(ctx context.Context, dbTx database.Transaction, key string, value string) error {
+func (_m *Helper) SetBlob(ctx context.Context, dbTx database.Transaction, key string, value []byte) error {
 	ret := _m.Called(ctx, dbTx, key, value)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.Transaction, string, string) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, database.Transaction, string, []byte) error); ok {
 		r0 = rf(ctx, dbTx, key, value)
 	} else {
 		r0 = ret.Error(0)

--- a/mocks/constructor/coordinator/helper.go
+++ b/mocks/constructor/coordinator/helper.go
@@ -183,6 +183,34 @@ func (_m *Helper) Derive(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 
 	return r0, r1, r2
 }
 
+// GetBlob provides a mock function with given fields: ctx, dbTx, key
+func (_m *Helper) GetBlob(ctx context.Context, dbTx database.Transaction, key string) (bool, string, error) {
+	ret := _m.Called(ctx, dbTx, key)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, database.Transaction, string) bool); ok {
+		r0 = rf(ctx, dbTx, key)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 string
+	if rf, ok := ret.Get(1).(func(context.Context, database.Transaction, string) string); ok {
+		r1 = rf(ctx, dbTx, key)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, database.Transaction, string) error); ok {
+		r2 = rf(ctx, dbTx, key)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // GetKey provides a mock function with given fields: _a0, _a1, _a2
 func (_m *Helper) GetKey(_a0 context.Context, _a1 database.Transaction, _a2 *types.AccountIdentifier) (*keys.KeyPair, error) {
 	ret := _m.Called(_a0, _a1, _a2)
@@ -399,6 +427,20 @@ func (_m *Helper) Preprocess(_a0 context.Context, _a1 *types.NetworkIdentifier, 
 	}
 
 	return r0, r1, r2
+}
+
+// SetBlob provides a mock function with given fields: ctx, dbTx, key, value
+func (_m *Helper) SetBlob(ctx context.Context, dbTx database.Transaction, key string, value string) error {
+	ret := _m.Called(ctx, dbTx, key, value)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, database.Transaction, string, string) error); ok {
+		r0 = rf(ctx, dbTx, key, value)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Sign provides a mock function with given fields: _a0, _a1

--- a/mocks/constructor/worker/helper.go
+++ b/mocks/constructor/worker/helper.go
@@ -118,6 +118,34 @@ func (_m *Helper) Derive(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 
 	return r0, r1, r2
 }
 
+// GetBlob provides a mock function with given fields: ctx, dbTx, key
+func (_m *Helper) GetBlob(ctx context.Context, dbTx database.Transaction, key string) (bool, string, error) {
+	ret := _m.Called(ctx, dbTx, key)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, database.Transaction, string) bool); ok {
+		r0 = rf(ctx, dbTx, key)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 string
+	if rf, ok := ret.Get(1).(func(context.Context, database.Transaction, string) string); ok {
+		r1 = rf(ctx, dbTx, key)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, database.Transaction, string) error); ok {
+		r2 = rf(ctx, dbTx, key)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // LockedAccounts provides a mock function with given fields: _a0, _a1
 func (_m *Helper) LockedAccounts(_a0 context.Context, _a1 database.Transaction) ([]*types.AccountIdentifier, error) {
 	ret := _m.Called(_a0, _a1)
@@ -139,6 +167,20 @@ func (_m *Helper) LockedAccounts(_a0 context.Context, _a1 database.Transaction) 
 	}
 
 	return r0, r1
+}
+
+// SetBlob provides a mock function with given fields: ctx, dbTx, key, value
+func (_m *Helper) SetBlob(ctx context.Context, dbTx database.Transaction, key string, value string) error {
+	ret := _m.Called(ctx, dbTx, key, value)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, database.Transaction, string, string) error); ok {
+		r0 = rf(ctx, dbTx, key, value)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // StoreKey provides a mock function with given fields: _a0, _a1, _a2, _a3

--- a/mocks/constructor/worker/helper.go
+++ b/mocks/constructor/worker/helper.go
@@ -119,7 +119,7 @@ func (_m *Helper) Derive(_a0 context.Context, _a1 *types.NetworkIdentifier, _a2 
 }
 
 // GetBlob provides a mock function with given fields: ctx, dbTx, key
-func (_m *Helper) GetBlob(ctx context.Context, dbTx database.Transaction, key string) (bool, string, error) {
+func (_m *Helper) GetBlob(ctx context.Context, dbTx database.Transaction, key string) (bool, []byte, error) {
 	ret := _m.Called(ctx, dbTx, key)
 
 	var r0 bool
@@ -129,11 +129,13 @@ func (_m *Helper) GetBlob(ctx context.Context, dbTx database.Transaction, key st
 		r0 = ret.Get(0).(bool)
 	}
 
-	var r1 string
-	if rf, ok := ret.Get(1).(func(context.Context, database.Transaction, string) string); ok {
+	var r1 []byte
+	if rf, ok := ret.Get(1).(func(context.Context, database.Transaction, string) []byte); ok {
 		r1 = rf(ctx, dbTx, key)
 	} else {
-		r1 = ret.Get(1).(string)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]byte)
+		}
 	}
 
 	var r2 error
@@ -170,11 +172,11 @@ func (_m *Helper) LockedAccounts(_a0 context.Context, _a1 database.Transaction) 
 }
 
 // SetBlob provides a mock function with given fields: ctx, dbTx, key, value
-func (_m *Helper) SetBlob(ctx context.Context, dbTx database.Transaction, key string, value string) error {
+func (_m *Helper) SetBlob(ctx context.Context, dbTx database.Transaction, key string, value []byte) error {
 	ret := _m.Called(ctx, dbTx, key, value)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, database.Transaction, string, string) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, database.Transaction, string, []byte) error); ok {
 		r0 = rf(ctx, dbTx, key, value)
 	} else {
 		r0 = ret.Error(0)


### PR DESCRIPTION
Related: https://github.com/coinbase/rosetta-cli/issues/205

This PR adds support for transactionally setting/getting arbitrary JSON across `workflows`. There is more context on why this is useful on the attached issue.

### Changes
- [x] Add `SetBlob` and `GetBlob` actions
- [x] Add `SetBlob` and `GetBlob` to helpers
- [x] Add tests