### PR TITLE
[constructor] Add `set_blob` and `get_blob` to DSL

### DIFF
--- a/constructor/dsl/dsl_test.go
+++ b/constructor/dsl/dsl_test.go
@@ -53,6 +53,11 @@ func TestParse(t *testing.T) {
 									Input: `{"key":"currency","value":{{currency}}}`,
 								},
 								{
+									Type:       job.GetBlob,
+									Input:      `{"key":"currency"}`,
+									OutputPath: "fetched_currency",
+								},
+								{
 									Type:       job.LoadEnv,
 									Input:      `"MIN_BALANCE"`,
 									OutputPath: "env",

--- a/constructor/dsl/dsl_test.go
+++ b/constructor/dsl/dsl_test.go
@@ -49,6 +49,10 @@ func TestParse(t *testing.T) {
 									OutputPath: "currency",
 								},
 								{
+									Type:  job.SetBlob,
+									Input: `{"key":"currency","value":{{currency}}}`,
+								},
+								{
 									Type:       job.LoadEnv,
 									Input:      `"MIN_BALANCE"`,
 									OutputPath: "env",

--- a/constructor/dsl/parser.go
+++ b/constructor/dsl/parser.go
@@ -131,7 +131,8 @@ func parseActionType(line string) (job.ActionType, string, string, error) {
 			return job.SetVariable, outputPath, tokens[1], nil
 		case job.GenerateKey, job.Derive, job.SaveAccount, job.PrintMessage,
 			job.RandomString, job.Math, job.FindBalance, job.RandomNumber, job.Assert,
-			job.FindCurrencyAmount, job.LoadEnv, job.HTTPRequest:
+			job.FindCurrencyAmount, job.LoadEnv, job.HTTPRequest, job.SetBlob,
+			job.GetBlob:
 			return thisAction, outputPath, tokens[1], nil
 		default:
 			return "", "", "", ErrInvalidActionType

--- a/constructor/dsl/testdata/simple.ros
+++ b/constructor/dsl/testdata/simple.ros
@@ -6,6 +6,10 @@ request_funds(1){
       "symbol":"ETH",
       "decimals":18
     };
+    set_blob({
+      "key":"currency",
+      "value":{{currency}}
+    });
     env = load_env("MIN_BALANCE");
     random_account = find_balance({
       "minimum_balance":{

--- a/constructor/dsl/testdata/simple.ros
+++ b/constructor/dsl/testdata/simple.ros
@@ -10,6 +10,9 @@ request_funds(1){
       "key":"currency",
       "value":{{currency}}
     });
+    fetched_currency = get_blob({
+      "key":"currency"
+    });
     env = load_env("MIN_BALANCE");
     random_account = find_balance({
       "minimum_balance":{


### PR DESCRIPTION
Related: #276 

This PR adds support for `set_blob` and `get_blob` to the Rosetta DSL parser.