### PR TITLE
[bug][storage] Fix `FindTransaction` Regression

### DIFF
--- a/storage/modules/block_storage.go
+++ b/storage/modules/block_storage.go
@@ -1056,7 +1056,7 @@ func (b *BlockStorage) FindTransaction(
 		return nil, nil, nil
 	}
 
-	head, err := b.GetHeadBlockIdentifier(ctx)
+	head, err := b.GetHeadBlockIdentifierTransactional(ctx, txn)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR fixes a regression introduced by #269 where `FindTransaction` returns a pruning-related error when querying for a transaction added in the same `DatabaseTransaction`. Turns out we never testing `FindTransaction` in the same way it is called in `BroadcastStorage`.

### Changes
- [x] [reproduce issue with test](https://github.com/coinbase/rosetta-sdk-go/pull/280/commits/fd4438b6b1fd2659690ec9c42ee56d0f517e23bd) (ensure we run `FindTransaction` at least once during `AddBlock` transaction)
- [x] fix issue (`GetHeadBlock` -> `GetHeadBlockTransactional`)