### PR TITLE
Add FindRelatedTransactions Function for Block Storage

### DIFF
--- a/asserter/block.go
+++ b/asserter/block.go
@@ -405,7 +405,7 @@ func (a *Asserter) RelatedTransactions(relatedTransactions []*types.RelatedTrans
 	return nil
 }
 
-// ContainsDuplicateCurrency returns nil if no duplicates are found in the array and
+// ContainsDuplicateRelatedTransaction returns nil if no duplicates are found in the array and
 // returns the first duplicated item found otherwise.
 func ContainsDuplicateRelatedTransaction(
 	items []*types.RelatedTransaction,

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -370,6 +370,10 @@ func (a *Asserter) Transaction(
 // any of the related transactions contain invalid types, invalid network identifiers,
 // invalid transaction identifiers, or a direction not defined by the enum.
 func (a *Asserter) RelatedTransactions(relatedTransactions []*types.RelatedTransaction) error {
+	if dup := ContainsDuplicateRelatedTransaction(relatedTransactions); dup != nil {
+		return fmt.Errorf("%w: %v", ErrDuplicateRelatedTransaction, dup)
+	}
+
 	for i, relatedTransaction := range relatedTransactions {
 		if relatedTransaction.NetworkIdentifier != nil {
 			if err := NetworkIdentifier(relatedTransaction.NetworkIdentifier); err != nil {
@@ -396,6 +400,24 @@ func (a *Asserter) RelatedTransactions(relatedTransactions []*types.RelatedTrans
 				i,
 			)
 		}
+	}
+
+	return nil
+}
+
+// ContainsDuplicateCurrency returns nil if no duplicates are found in the array and
+// returns the first duplicated item found otherwise.
+func ContainsDuplicateRelatedTransaction(
+	items []*types.RelatedTransaction,
+) *types.RelatedTransaction {
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		key := types.Hash(item)
+		if _, ok := seen[key]; ok {
+			return item
+		}
+
+		seen[key] = struct{}{}
 	}
 
 	return nil

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -370,7 +370,7 @@ func (a *Asserter) Transaction(
 // any of the related transactions contain invalid types, invalid network identifiers,
 // invalid transaction identifiers, or a direction not defined by the enum.
 func (a *Asserter) RelatedTransactions(relatedTransactions []*types.RelatedTransaction) error {
-	if dup := ContainsDuplicateRelatedTransaction(relatedTransactions); dup != nil {
+	if dup := DuplicateRelatedTransaction(relatedTransactions); dup != nil {
 		return fmt.Errorf("%w: %v", ErrDuplicateRelatedTransaction, dup)
 	}
 
@@ -405,9 +405,9 @@ func (a *Asserter) RelatedTransactions(relatedTransactions []*types.RelatedTrans
 	return nil
 }
 
-// ContainsDuplicateRelatedTransaction returns nil if no duplicates are found in the array and
+// DuplicateRelatedTransaction returns nil if no duplicates are found in the array and
 // returns the first duplicated item found otherwise.
-func ContainsDuplicateRelatedTransaction(
+func DuplicateRelatedTransaction(
 	items []*types.RelatedTransaction,
 ) *types.RelatedTransaction {
 	seen := map[string]struct{}{}

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -727,6 +727,59 @@ func TestBlock(t *testing.T) {
 			},
 		},
 	}
+	duplicateRelatedTransactions := &types.Transaction{
+		TransactionIdentifier: &types.TransactionIdentifier{
+			Hash: "blah",
+		},
+		Operations: []*types.Operation{
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(0),
+				},
+				Type:    "PAYMENT",
+				Status:  types.String("SUCCESS"),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(1),
+				},
+				RelatedOperations: []*types.OperationIdentifier{
+					{
+						Index: int64(0),
+					},
+				},
+				Type:    "PAYMENT",
+				Status:  types.String("SUCCESS"),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+		},
+		RelatedTransactions: []*types.RelatedTransaction{
+			{
+				NetworkIdentifier: &types.NetworkIdentifier{
+					Blockchain: "hello",
+					Network:    "world",
+				},
+				TransactionIdentifier: &types.TransactionIdentifier{
+					Hash: "blah",
+				},
+				Direction: types.Forward,
+			},
+			{
+				NetworkIdentifier: &types.NetworkIdentifier{
+					Blockchain: "hello",
+					Network:    "world",
+				},
+				TransactionIdentifier: &types.TransactionIdentifier{
+					Hash: "blah",
+				},
+				Direction: types.Forward,
+			},
+		},
+	}
+
 	var tests = map[string]struct {
 		block        *types.Block
 		genesisIndex int64
@@ -907,6 +960,15 @@ func TestBlock(t *testing.T) {
 				Transactions:          []*types.Transaction{invalidRelatedTransaction},
 			},
 			err: ErrInvalidDirection,
+		},
+		"duplicate related transaction": {
+			block: &types.Block{
+				BlockIdentifier:       validBlockIdentifier,
+				ParentBlockIdentifier: validParentBlockIdentifier,
+				Timestamp:             MinUnixEpoch + 1,
+				Transactions:          []*types.Transaction{duplicateRelatedTransactions},
+			},
+			err: ErrDuplicateRelatedTransaction,
 		},
 	}
 

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -91,7 +91,10 @@ var (
 	ErrBlockIndexPrecedesParentBlockIndex = errors.New(
 		"BlockIdentifier.Index <= ParentBlockIdentifier.Index",
 	)
-	ErrInvalidDirection = errors.New("invalid direction (must be 'forward' or 'backward')")
+	ErrInvalidDirection = errors.New(
+		"invalid direction (must be 'forward' or 'backward')",
+	)
+	ErrDuplicateRelatedTransaction = errors.New("duplicate related transaction")
 
 	BlockErrs = []error{
 		ErrAmountValueMissing,
@@ -127,6 +130,7 @@ var (
 		ErrBlockHashEqualsParentBlockHash,
 		ErrBlockIndexPrecedesParentBlockIndex,
 		ErrInvalidDirection,
+		ErrDuplicateRelatedTransaction,
 	}
 )
 

--- a/storage/errors/errors.go
+++ b/storage/errors/errors.go
@@ -403,6 +403,8 @@ var (
 	ErrNothingToPrune                 = errors.New("nothing to prune")
 	ErrPruningFailed                  = errors.New("pruning failed")
 	ErrCannotPruneTransaction         = errors.New("cannot prune transaction")
+	ErrCannotStoreBackwardRelation    = errors.New("cannot store backward relation")
+	ErrCannotRemoveBackwardRelation   = errors.New("cannot remove backward relation")
 
 	BlockStorageErrs = []error{
 		ErrHeadBlockNotFound,
@@ -438,6 +440,8 @@ var (
 		ErrNothingToPrune,
 		ErrPruningFailed,
 		ErrCannotPruneTransaction,
+		ErrCannotStoreBackwardRelation,
+		ErrCannotRemoveBackwardRelation,
 	}
 )
 

--- a/storage/modules/block_storage.go
+++ b/storage/modules/block_storage.go
@@ -1006,7 +1006,10 @@ func getBackwardRelationKeys(tx *types.Transaction) [][]byte {
 			continue
 		}
 
-		keys = append(keys, getBackwardRelationKey(relatedTx.TransactionIdentifier, tx.TransactionIdentifier))
+		keys = append(
+			keys,
+			getBackwardRelationKey(relatedTx.TransactionIdentifier, tx.TransactionIdentifier),
+		)
 	}
 
 	return keys
@@ -1152,7 +1155,14 @@ func (b *BlockStorage) FindRelatedTransactions(
 		return nil, nil, nil, err
 	}
 
-	for _, child := range children {
+	i := 0
+	for {
+		if i >= len(children) {
+			break
+		}
+		child := children[i]
+		i += 1
+
 		childBlock, childTx, err := b.FindTransaction(ctx, child, db)
 		if err != nil {
 			return nil, nil, nil, err
@@ -1201,7 +1211,7 @@ func (b *BlockStorage) getChildren(
 		func(k []byte, v []byte) error {
 			ss := strings.Split(string(k), "/")
 			txHash := ss[len(ss)-1]
-			txId := &types.TransactionIdentifier{ Hash: txHash }
+			txId := &types.TransactionIdentifier{Hash: txHash}
 			children = append(children, txId)
 			return nil
 		},

--- a/storage/modules/block_storage.go
+++ b/storage/modules/block_storage.go
@@ -1161,7 +1161,7 @@ func (b *BlockStorage) FindRelatedTransactions(
 			break
 		}
 		child := children[i]
-		i += 1
+		i++
 
 		childBlock, childTx, err := b.FindTransaction(ctx, child, db)
 		if err != nil {
@@ -1211,8 +1211,8 @@ func (b *BlockStorage) getChildren(
 		func(k []byte, v []byte) error {
 			ss := strings.Split(string(k), "/")
 			txHash := ss[len(ss)-1]
-			txId := &types.TransactionIdentifier{Hash: txHash}
-			children = append(children, txId)
+			txID := &types.TransactionIdentifier{Hash: txHash}
+			children = append(children, txID)
 			return nil
 		},
 		false,

--- a/storage/modules/block_storage.go
+++ b/storage/modules/block_storage.go
@@ -1216,7 +1216,7 @@ func (b *BlockStorage) FindRelatedTransactions(
 		i++
 
 		// skip duplicates
-		if _, val := seen[childID.Hash]; !val {
+		if _, ok := seen[childID.Hash]; !ok {
 			seen[childID.Hash] = struct{}{}
 		} else {
 			continue

--- a/storage/modules/block_storage.go
+++ b/storage/modules/block_storage.go
@@ -972,7 +972,7 @@ func (b *BlockStorage) storeTransaction(
 	blockIdentifier *types.BlockIdentifier,
 	tx *types.Transaction,
 ) error {
-	err := storeBackwardRelations(ctx, transaction, tx)
+	err := b.storeBackwardRelations(ctx, transaction, tx)
 	if err != nil {
 		return err
 	}
@@ -991,7 +991,7 @@ func (b *BlockStorage) storeTransaction(
 	return storeUniqueKey(ctx, transaction, hashKey, encodedResult, true)
 }
 
-func storeBackwardRelations(
+func (b *BlockStorage) storeBackwardRelations(
 	ctx context.Context,
 	transaction database.Transaction,
 	tx *types.Transaction,
@@ -1005,10 +1005,10 @@ func storeBackwardRelations(
 		return nil
 	}
 
-	return modifyBackwardRelations(ctx, transaction, tx, fn)
+	return b.modifyBackwardRelations(ctx, transaction, tx, fn)
 }
 
-func removeBackwardRelations(
+func (b *BlockStorage) removeBackwardRelations(
 	ctx context.Context,
 	transaction database.Transaction,
 	tx *types.Transaction,
@@ -1022,10 +1022,10 @@ func removeBackwardRelations(
 		return nil
 	}
 
-	return modifyBackwardRelations(ctx, transaction, tx, fn)
+	return b.modifyBackwardRelations(ctx, transaction, tx, fn)
 }
 
-func modifyBackwardRelations(
+func (b *BlockStorage) modifyBackwardRelations(
 	ctx context.Context,
 	transaction database.Transaction,
 	tx *types.Transaction,
@@ -1091,7 +1091,7 @@ func (b *BlockStorage) removeTransaction(
 	blockIdentifier *types.BlockIdentifier,
 	tx *types.Transaction,
 ) error {
-	err := removeBackwardRelations(ctx, transaction, tx)
+	err := b.removeBackwardRelations(ctx, transaction, tx)
 	if err != nil {
 		return err
 	}

--- a/storage/modules/block_storage_test.go
+++ b/storage/modules/block_storage_test.go
@@ -135,7 +135,7 @@ func addRelatedTransaction(
 ) *types.Transaction {
 	relatedTx := &types.RelatedTransaction{
 		NetworkIdentifier: nil,
-		TransactionIdentifier: &types.TransactionIdentifier {
+		TransactionIdentifier: &types.TransactionIdentifier{
 			Hash: hash,
 		},
 		Direction: direction,
@@ -951,8 +951,22 @@ func TestRelatedTransactions(t *testing.T) {
 			},
 			Timestamp: 1,
 			Transactions: []*types.Transaction{
-				addRelatedTransaction(simpleTransactionFactory("parentTx", "addr1", "100", &types.Currency{Symbol: "hello"}), "childTx", types.Forward),
-				simpleTransactionFactory("backwardRelative", "addr2", "100", &types.Currency{Symbol: "hello"}),
+				addRelatedTransaction(
+					simpleTransactionFactory(
+						"parentTx",
+						"addr1",
+						"100",
+						&types.Currency{Symbol: "hello"},
+					),
+					"childTx",
+					types.Forward,
+				),
+				simpleTransactionFactory(
+					"backwardRelative",
+					"addr2",
+					"100",
+					&types.Currency{Symbol: "hello"},
+				),
 			},
 		}
 		err = storage.SeeBlock(ctx, block1)
@@ -971,9 +985,32 @@ func TestRelatedTransactions(t *testing.T) {
 			},
 			Timestamp: 1,
 			Transactions: []*types.Transaction{
-				simpleTransactionFactory("childTx", "addr3", "100", &types.Currency{Symbol: "hello"}),
-				addRelatedTransaction(simpleTransactionFactory("backwardTx", "addr4", "100", &types.Currency{Symbol: "hello"}), "backwardRelative", types.Backward),
-				addRelatedTransaction(simpleTransactionFactory("badForward", "addr5", "100", &types.Currency{Symbol: "hello"}), "invalid", types.Forward),
+				simpleTransactionFactory(
+					"childTx",
+					"addr3",
+					"100",
+					&types.Currency{Symbol: "hello"},
+				),
+				addRelatedTransaction(
+					simpleTransactionFactory(
+						"backwardTx",
+						"addr4",
+						"100",
+						&types.Currency{Symbol: "hello"},
+					),
+					"backwardRelative",
+					types.Backward,
+				),
+				addRelatedTransaction(
+					simpleTransactionFactory(
+						"badForward",
+						"addr5",
+						"100",
+						&types.Currency{Symbol: "hello"},
+					),
+					"invalid",
+					types.Forward,
+				),
 			},
 		}
 		err = storage.SeeBlock(ctx, block2)
@@ -981,17 +1018,29 @@ func TestRelatedTransactions(t *testing.T) {
 		err = storage.AddBlock(ctx, block2)
 		assert.NoError(t, err)
 
-		_, _, related, err := storage.FindRelatedTransactions(ctx, block1.Transactions[0].TransactionIdentifier, storage.db.ReadTransaction(ctx))
+		_, _, related, err := storage.FindRelatedTransactions(
+			ctx,
+			block1.Transactions[0].TransactionIdentifier,
+			storage.db.ReadTransaction(ctx),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, len(related), 1)
 		assert.Equal(t, related[0].Hash, block2.Transactions[0].TransactionIdentifier.Hash)
 
-		_, _, related, err = storage.FindRelatedTransactions(ctx, block1.Transactions[1].TransactionIdentifier, storage.db.ReadTransaction(ctx))
+		_, _, related, err = storage.FindRelatedTransactions(
+			ctx,
+			block1.Transactions[1].TransactionIdentifier,
+			storage.db.ReadTransaction(ctx),
+		)
 		assert.NoError(t, err)
 		assert.Equal(t, len(related), 1)
 		assert.Equal(t, related[0].Hash, block2.Transactions[1].TransactionIdentifier.Hash)
 
-		blockId, tx, related, err := storage.FindRelatedTransactions(ctx, block2.Transactions[2].TransactionIdentifier, storage.db.ReadTransaction(ctx))
+		blockId, tx, related, err := storage.FindRelatedTransactions(
+			ctx,
+			block2.Transactions[2].TransactionIdentifier,
+			storage.db.ReadTransaction(ctx),
+		)
 		assert.NoError(t, err)
 		assert.Nil(t, blockId)
 		assert.Nil(t, tx)

--- a/storage/modules/block_storage_test.go
+++ b/storage/modules/block_storage_test.go
@@ -1036,13 +1036,13 @@ func TestRelatedTransactions(t *testing.T) {
 		assert.Equal(t, len(related), 1)
 		assert.Equal(t, related[0].Hash, block2.Transactions[1].TransactionIdentifier.Hash)
 
-		blockId, tx, related, err := storage.FindRelatedTransactions(
+		blockID, tx, related, err := storage.FindRelatedTransactions(
 			ctx,
 			block2.Transactions[2].TransactionIdentifier,
 			storage.db.ReadTransaction(ctx),
 		)
 		assert.NoError(t, err)
-		assert.Nil(t, blockId)
+		assert.Nil(t, blockID)
 		assert.Nil(t, tx)
 		assert.Empty(t, related)
 	})

--- a/storage/modules/block_storage_test.go
+++ b/storage/modules/block_storage_test.go
@@ -1025,7 +1025,11 @@ func TestRelatedTransactions(t *testing.T) {
 		)
 		assert.NoError(t, err)
 		assert.Equal(t, len(related), 1)
-		assert.Equal(t, related[0].Hash, block2.Transactions[0].TransactionIdentifier.Hash)
+		assert.Equal(
+			t,
+			related[0].TransactionIdentifier.Hash,
+			block2.Transactions[0].TransactionIdentifier.Hash,
+		)
 
 		_, _, related, err = storage.FindRelatedTransactions(
 			ctx,
@@ -1034,7 +1038,11 @@ func TestRelatedTransactions(t *testing.T) {
 		)
 		assert.NoError(t, err)
 		assert.Equal(t, len(related), 1)
-		assert.Equal(t, related[0].Hash, block2.Transactions[1].TransactionIdentifier.Hash)
+		assert.Equal(
+			t,
+			related[0].TransactionIdentifier.Hash,
+			block2.Transactions[1].TransactionIdentifier.Hash,
+		)
 
 		blockID, tx, related, err := storage.FindRelatedTransactions(
 			ctx,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
This change adds the FindRelatedTransactions function to block storage, which will allow for related transaction processing in the future. This change also adds a duplicate check for related transactions to the asserter.

### Solution
By checking all forward and backward relations, FindRelatedTransactions finds the highest block that must be confirmed to confirm a given transaction.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
