### PR TITLE
Skip reconciliation when interesting account is missing

### DIFF
--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -56,6 +56,17 @@ const (
 	// to process (so the index we are querying at may be
 	// ahead of the nodes tip).
 	TipFailure = "TIP_FAILURE"
+
+	// AccountMissing is returned when looking up computed
+	// balance fails because the account does not exist in
+	// balance storage.
+	// This can happen when interesting accounts
+	// are specified. We try to reconcile balances for
+	// each of these accounts at each block height.
+	// But, until we encounter a block with an interesting account
+	// in it, there is no entry for it in balance storage.
+	// So, we can not reconcile.
+	AccountMissing = "ACCOUNT_MISSING"
 )
 
 const (

--- a/storage/errors/errors.go
+++ b/storage/errors/errors.go
@@ -324,7 +324,7 @@ var (
 
 	// ErrAccountMissing is returned when a fetched
 	// account does not exist.
-	ErrAccountMissing = errors.New("block nil")
+	ErrAccountMissing = errors.New("account missing")
 
 	// ErrInvalidChangeValue is returned when the change value
 	// cannot be parsed.


### PR DESCRIPTION
<!-- Fixes # . -->

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

1. There is a bug in our reconciliation logic around missing accounts. When an interesting account is configured, the reconciler may stop with an error like below:

`Error: unable to get computed balance for &{Address:0000000001 SubAccount:<nil>, Metadata:map[]}: &{Symbol: ICP Decimals:8 Metadata:map[]}: block nil`

The reconciler reconciles interesting accounts at every block height. But, there is no entry for an account in balance storage until it is encountered in a block. So, when the reconciler tries to reconcile an interesting account, it hasn't encountered yet, it stops with an account missing error (`ErrAccountMissing`).

2. The error message for `ErrAccountMissing` incorrectly says "block nil". 

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

1. Updated the reconciliation logic to skip reconciliation for missing accounts.
2. Fixed error message.

<!-- ### Open questions -->
<!--
(optional) Any open questions or feedback on design desired?
-->
