### PR TITLE
Do not override the provided HTTP client in the fetcher

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -116,8 +116,7 @@ func New(
 			DefaultUserAgent,
 			defaultHTTPClient,
 		)
-		client := client.NewAPIClient(clientCfg)
-		f.rosettaClient = client
+		f.rosettaClient = client.NewAPIClient(clientCfg)
 	}
 
 	if f.insecureTLS {

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
+	"github.com/coinbase/rosetta-sdk-go/client"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
@@ -194,4 +195,22 @@ func TestInitializeAsserter(t *testing.T) {
 			assert.True(checkError(err, test.expectedError))
 		})
 	}
+}
+
+func TestNewWithHTTPCLient(t *testing.T) {
+	// Callers can pass an http.Client to
+	// the fetcher via WithClient.
+	// Ensure that the fetcher does not
+	// override it.
+	httpClient := &http.Client{}
+	apiClient := client.NewAPIClient(
+		client.NewConfiguration(
+			"https://serveraddress",
+			DefaultUserAgent,
+			httpClient,
+		),
+	)
+	fetcher := New("https://serveraddress", WithClient(apiClient))
+	var assert = assert.New(t)
+	assert.Same(httpClient, fetcher.rosettaClient.GetConfig().HTTPClient)
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

When creating a fetcher instance, we always override the `Transport` of the `http.Client` present inside the `APIClient` object. This leads to unexpected behavior when callers provide their own `http.Client` via the `WithClient` option.


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

This change makes it so that we do not override the Transport when it is already provided . Note we still update the Transport's `TLSClientConfig` field when `insecureTLS` is set to true.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
