### PR TITLE
Fix PROTO-1835

### DIFF
--- a/parser/balance_changes.go
+++ b/parser/balance_changes.go
@@ -36,7 +36,7 @@ type BalanceChange struct {
 // checks indiciating it should be considered a balance change.
 type ExemptOperation func(*types.Operation) bool
 
-var blockNilError = errors.New("block is nil")
+var errBlockNil = errors.New("block is nil")
 
 // skipOperation returns a boolean indicating whether
 // an operation should be processed. An operation will
@@ -81,7 +81,7 @@ func (p *Parser) BalanceChanges(
 	blockRemoved bool,
 ) ([]*BalanceChange, error) {
 	if block == nil {
-		return nil, blockNilError
+		return nil, errBlockNil
 	}
 
 	balanceChanges := map[string]*BalanceChange{}

--- a/parser/balance_changes.go
+++ b/parser/balance_changes.go
@@ -16,6 +16,7 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
@@ -34,6 +35,8 @@ type BalanceChange struct {
 // if the operation should be skipped eventhough it passes other
 // checks indiciating it should be considered a balance change.
 type ExemptOperation func(*types.Operation) bool
+
+var blockNilError = errors.New("block is nil")
 
 // skipOperation returns a boolean indicating whether
 // an operation should be processed. An operation will
@@ -73,10 +76,14 @@ func (p *Parser) skipOperation(op *types.Operation) (bool, error) {
 // orphaned, the opposite of each balance change is
 // returned.
 func (p *Parser) BalanceChanges(
-	ctx context.Context,
+	_ context.Context,
 	block *types.Block,
 	blockRemoved bool,
 ) ([]*BalanceChange, error) {
+	if block == nil {
+		return nil, blockNilError
+	}
+
 	balanceChanges := map[string]*BalanceChange{}
 	for _, tx := range block.Transactions {
 		for _, op := range tx.Operations {

--- a/parser/balance_changes_test.go
+++ b/parser/balance_changes_test.go
@@ -257,7 +257,7 @@ func TestBalanceChanges(t *testing.T) {
 			// block not specified, so default to nil, which is what we're testing
 			// changes not specified, so default to nil, which is what's expected
 			allowedStatus: defaultStatus,
-			err: blockNilError,
+			err:           errBlockNil,
 		},
 	}
 

--- a/parser/balance_changes_test.go
+++ b/parser/balance_changes_test.go
@@ -253,6 +253,12 @@ func TestBalanceChanges(t *testing.T) {
 			allowedStatus: defaultStatus,
 			err:           nil,
 		},
+		"nil block": {
+			// block not specified, so default to nil, which is what we're testing
+			// changes not specified, so default to nil, which is what's expected
+			allowedStatus: defaultStatus,
+			err: blockNilError,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Fixes PROTO-1835

### Motivation
A Coinbase dev reported a panic when using Rosetta CLI to view a nonexistent block

### Solution
I think the appropriate change is in rosetta-sdk-go. There is a public method that takes in a pointer to a block. If the caller passes a nil block, the method will panic. Instead, check for a nil block and return an explicit error.