### PR TITLE
Fix nil pointer dereference when initializing fetcher with timeout

### DIFF
--- a/fetcher/configuration.go
+++ b/fetcher/configuration.go
@@ -73,7 +73,7 @@ func WithInsecureTLS() Option {
 // WithTimeout overrides the default HTTP timeout.
 func WithTimeout(timeout time.Duration) Option {
 	return func(f *Fetcher) {
-		f.rosettaClient.GetConfig().HTTPClient.Timeout = timeout
+		f.httpTimeout = timeout
 	}
 }
 

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -74,6 +74,7 @@ type Fetcher struct {
 	retryElapsedTime time.Duration
 	insecureTLS      bool
 	forceRetry       bool
+	httpTimeout      time.Duration
 
 	// connectionSemaphore is used to limit the
 	// number of concurrent requests we make.
@@ -89,6 +90,7 @@ func New(
 		maxConnections:   DefaultMaxConnections,
 		maxRetries:       DefaultRetries,
 		retryElapsedTime: DefaultElapsedTime,
+		httpTimeout:      DefaultHTTPTimeout,
 	}
 
 	// Override defaults with any provided options
@@ -106,7 +108,7 @@ func New(
 		defaultTransport.MaxIdleConns = f.maxConnections
 		defaultTransport.MaxIdleConnsPerHost = DefaultMaxConnections
 		defaultHTTPClient := &http.Client{
-			Timeout:   DefaultHTTPTimeout,
+			Timeout:   f.httpTimeout,
 			Transport: defaultTransport,
 		}
 

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -221,15 +221,16 @@ func TestNewWithTimeout(t *testing.T) {
 	fetcher := New("https://serveraddress")
 	assert.Equal(DefaultHTTPTimeout, fetcher.rosettaClient.GetConfig().HTTPClient.Timeout)
 
-	var customTimeout = 6*time.Minute
+	var customTimeout = 6 * time.Minute
 	fetcher2 := New("https://serveraddress", WithTimeout(customTimeout))
 	assert.Equal(customTimeout, fetcher2.rosettaClient.GetConfig().HTTPClient.Timeout)
 
-	// If we pass in a http timeout value when initializing the fetcher, and also pass in an existing client,
+	// If we pass in a http timeout value when initializing the fetcher, and also pass in an
+	// existing client,
 	// we will simply respect the timeout on the existing client and not override it.
-	var existingClientTimeout = 3*time.Minute
+	var existingClientTimeout = 3 * time.Minute
 	httpClient := &http.Client{
-		Timeout : existingClientTimeout,
+		Timeout: existingClientTimeout,
 	}
 	apiClient := client.NewAPIClient(
 		client.NewConfiguration(


### PR DESCRIPTION
Fixes nil pointer dereference when initializing fetcher with timeout (PROTO-2135).

### Motivation
Currently when we initialize the fetcher, the rosetta client might not exist yet https://github.com/coinbase/rosetta-sdk-go/blob/master/fetcher/fetcher.go#L96. However when we initialize the fetcher with the timeout option, it tries to dereference the rosetta client which could result in nil pointer dereference panic https://github.com/coinbase/rosetta-sdk-go/blob/master/fetcher/configuration.go#L76.

The issue could be reproduced by pulling the latest rosetta-sdk-go and rosetta-cli, and running utils:asserter-configuration on rosetta-cli.

### Solution
Instead of setting timeout on the rosetta client directly during fetcher initialization, store it as a field on the fetcher and set it on the rosetta client later when creating the client. In case a rosetta client is also passed in for fetcher initialization, we just use the timeout on that existing client and not override it.
