### PR TITLE
249

### DIFF
--- a/utils/priority_mutex.go
+++ b/utils/priority_mutex.go
@@ -39,12 +39,17 @@ type PriorityMutex struct {
 // priority mutex. When priority is true, a lock
 // will be granted before other low priority callers.
 func (m *PriorityMutex) Lock(priority bool) {
+	c := m.lockInternal(priority)
+	m.wait(c)
+}
+
+func (m *PriorityMutex) lockInternal(priority bool) <-chan struct{} {
 	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
 	if !m.lock {
 		m.lock = true
-		m.mutex.Unlock()
-		return
+		return nil
 	}
 
 	c := make(chan struct{})
@@ -54,8 +59,13 @@ func (m *PriorityMutex) Lock(priority bool) {
 		m.low = append(m.low, c)
 	}
 
-	m.mutex.Unlock()
-	<-c
+	return c
+}
+
+func (m *PriorityMutex) wait(c <-chan struct{}) {
+	if c != nil {
+		<-c
+	}
 }
 
 // Unlock selects the next highest priority lock

--- a/utils/priority_mutex.go
+++ b/utils/priority_mutex.go
@@ -40,7 +40,9 @@ type PriorityMutex struct {
 // will be granted before other low priority callers.
 func (m *PriorityMutex) Lock(priority bool) {
 	c := m.lockInternal(priority)
-	m.wait(c)
+	if c != nil {
+		<-c
+	}
 }
 
 func (m *PriorityMutex) lockInternal(priority bool) <-chan struct{} {
@@ -60,12 +62,6 @@ func (m *PriorityMutex) lockInternal(priority bool) <-chan struct{} {
 	}
 
 	return c
-}
-
-func (m *PriorityMutex) wait(c <-chan struct{}) {
-	if c != nil {
-		<-c
-	}
 }
 
 // Unlock selects the next highest priority lock

--- a/utils/priority_mutex_test.go
+++ b/utils/priority_mutex_test.go
@@ -85,7 +85,7 @@ func TestPriorityMutex(t *testing.T) {
 	assert.Len(t, l.low, 50)
 
 	l.Unlock()
-	assert.NoError(t, g.Wait()) // Wait for all goroutines to ask for lock
+	assert.NoError(t, g.Wait())
 
 	// Check results array to ensure all of the high priority items processed first,
 	// followed by all of the low priority items.

--- a/utils/priority_mutex_test.go
+++ b/utils/priority_mutex_test.go
@@ -16,10 +16,11 @@ package utils
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/sync/errgroup"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
 )
 
 // A wrapper around the PriorityMutex being tested to properly assert invariants without the

--- a/utils/priority_mutex_test.go
+++ b/utils/priority_mutex_test.go
@@ -16,17 +16,40 @@ package utils
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
+	"sync"
+	"testing"
 )
+
+// A wrapper around the PriorityMutex being tested to properly assert invariants without the
+// possibility of race conditions. The `lockWg` completes after the low/high queue is appended to
+// but before the blocking `wait` call so we can assert invariants on the size of the queue.
+type wrappedPriorityMutex struct {
+	*PriorityMutex
+	lockWg sync.WaitGroup
+}
+
+func newWrappedPriorityMutex(numLockCalls int) *wrappedPriorityMutex {
+	w := &wrappedPriorityMutex{PriorityMutex: new(PriorityMutex)}
+	w.lockWg.Add(numLockCalls)
+	return w
+}
+
+func (w *wrappedPriorityMutex) Lock(priority bool) {
+	c := w.PriorityMutex.lockInternal(priority)
+	w.lockWg.Done()
+	w.wait(c)
+}
+
+func (w *wrappedPriorityMutex) Wait() {
+	w.lockWg.Wait()
+}
 
 func TestPriorityMutex(t *testing.T) {
 	arr := []bool{}
 	expected := make([]bool, 60)
-	l := new(PriorityMutex)
+	l := newWrappedPriorityMutex(61)
 	g, _ := errgroup.WithContext(context.Background())
 
 	// Lock while adding all locks
@@ -55,14 +78,14 @@ func TestPriorityMutex(t *testing.T) {
 	}
 
 	// Wait for all goroutines to ask for lock
-	time.Sleep(1 * time.Second)
+	l.Wait()
 
 	// Ensure number of expected locks is correct
 	assert.Len(t, l.high, 10)
 	assert.Len(t, l.low, 50)
 
 	l.Unlock()
-	assert.NoError(t, g.Wait())
+	assert.NoError(t, g.Wait()) // Wait for all goroutines to ask for lock
 
 	// Check results array to ensure all of the high priority items processed first,
 	// followed by all of the low priority items.

--- a/utils/priority_mutex_test.go
+++ b/utils/priority_mutex_test.go
@@ -39,8 +39,10 @@ func newWrappedPriorityMutex(numLockCalls int) *wrappedPriorityMutex {
 
 func (w *wrappedPriorityMutex) Lock(priority bool) {
 	c := w.PriorityMutex.lockInternal(priority)
-	w.lockWg.Done()
-	w.wait(c)
+	if c != nil {
+		w.lockWg.Done()
+		<-c
+	}
 }
 
 func (w *wrappedPriorityMutex) Wait() {
@@ -50,7 +52,7 @@ func (w *wrappedPriorityMutex) Wait() {
 func TestPriorityMutex(t *testing.T) {
 	arr := []bool{}
 	expected := make([]bool, 60)
-	l := newWrappedPriorityMutex(61)
+	l := newWrappedPriorityMutex(60)
 	g, _ := errgroup.WithContext(context.Background())
 
 	// Lock while adding all locks


### PR DESCRIPTION
Fixes #249  .

### Solution
Don't rely on `time.Sleep` since there are no formal guarantees
Instead use a WaitGroup-based wrapper so we can properly assert that all goroutines
have asked for lock
