### PR TITLE
fix error wrap

### DIFF
--- a/fetcher/errors.go
+++ b/fetcher/errors.go
@@ -55,7 +55,7 @@ func (f *Fetcher) RequestFailedError(
 	}
 
 	return &Error{
-		Err:       fmt.Errorf("%w: %s %s", ErrRequestFailed, message, err.Error()),
+		Err:       fmt.Errorf("%w: %s %s", ErrRequestFailed, message, err),
 		ClientErr: rosettaErr,
 		Retry: ((rosettaErr != nil && rosettaErr.Retriable) || transientError(err) || f.forceRetry) &&
 			!errors.Is(err, context.Canceled),

--- a/server/routers.go
+++ b/server/routers.go
@@ -49,10 +49,8 @@ type Router interface {
 func CorsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set(
-			"Access-Control-Allow-Headers",
-			"Origin, X-Requested-With, Content-Type, Accept",
-		)
+		w.Header().
+			Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST,OPTIONS")
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The current `RequestFailedError` function will return a new error which is not the same type as the initial error. 
### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
pass the error into `fmt.Errorf` instead of `err.Error()`
