### PR TITLE
Improve logging when unable to lookup balance > min

### DIFF
--- a/constructor/worker/worker.go
+++ b/constructor/worker/worker.go
@@ -470,8 +470,12 @@ func (w *Worker) checkAccountBalance(
 	}
 
 	if bigIntDiff.Sign() < 0 {
-		log.Printf("checkAccountBalance: Account (%s) has balance (%s), less than the minimum balance (%s)",
-			account.Address, amount.Value, input.MinimumBalance.Value)
+		log.Printf(
+			"checkAccountBalance: Account (%s) has balance (%s), less than the minimum balance (%s)",
+			account.Address,
+			amount.Value,
+			input.MinimumBalance.Value,
+		)
 		return "", nil
 	}
 


### PR DESCRIPTION
### Motivation
During `rosetta-cli check:construction`, when accounts does not have enough fund, or minimal required balance is set too high in `ros` config, it is hard to debug and diagnose. 

### Solution
Add extra debug logging when we are unable to lookup for amounts > min.
