### PR TITLE
Check related ops

### DIFF
--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -40,6 +40,7 @@ type Asserter struct {
 	callMethods             map[string]struct{}
 	mempoolCoins            bool
 	validations             *Validations
+	relatedOpsEnabled       bool
 }
 
 // Validations is used to define stricter validations
@@ -78,6 +79,7 @@ func NewServer(
 	callMethods []string,
 	mempoolCoins bool,
 	validationFilePath string,
+	relatedOpsEnabled bool,
 ) (*Asserter, error) {
 	if err := OperationTypes(supportedOperationTypes); err != nil {
 		return nil, err
@@ -112,6 +114,7 @@ func NewServer(
 		callMethods:             callMap,
 		mempoolCoins:            mempoolCoins,
 		validations:             validationConfig,
+		relatedOpsEnabled:       relatedOpsEnabled,
 	}, nil
 }
 

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -318,10 +318,7 @@ func (a *Asserter) Operations(
 			}
 		}
 
-		// Ensure all operations have related_operations implemented or none of them do.
-		// If we have multiple outputs (paymentCount > 2),
-		// throw an error if related operations key is not implemented.
-		// We need a way to enforce DAG structure among operations.
+		// Check if related operations key exists
 		if len(op.RelatedOperations) != 0 {
 			relatedOpsExists = true
 		}
@@ -351,7 +348,10 @@ func (a *Asserter) Operations(
 			relatedIndexes = append(relatedIndexes, relatedOp.Index)
 		}
 	}
-	fmt.Println(a.relatedOpsEnabled)
+
+	// If related operations is not supported in asserter,
+	// Only print warning if related operations keys does not exist
+	// Otherwise throw error
 	if !relatedOpsExists && !a.relatedOpsEnabled {
 		fmt.Println("Related Operations key is not implemented. " +
 			"This is fine as long as there is a distinction between sends and receives and no multiple outputs")

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -297,6 +297,8 @@ func (a *Asserter) Operations(
 	feeTotal := big.NewInt(0)
 	paymentCount := 0
 	feeCount := 0
+	opsLen := len(operations)
+	relatedOpsExists := false
 	for i, op := range operations {
 		// Ensure operations are sorted
 		if err := a.Operation(op, int64(i), construction); err != nil {
@@ -314,6 +316,20 @@ func (a *Asserter) Operations(
 				val, _ := new(big.Int).SetString(op.Amount.Value, 10)
 				feeTotal.Add(feeTotal, val)
 				feeCount++
+			}
+		}
+
+		// Ensure all operations have related_operations implemented or none of them do.
+		// If we have multiple outputs (opsLen > 2),
+		// throw an error if related operations key is not implemented.
+		// We need a way to enforce DAG structure among operations.
+		if i != 0 {
+			if len(op.RelatedOperations) == 0 {
+				if relatedOpsExists || opsLen > 2 {
+					return ErrRelatedOperationMissing
+				}
+			} else {
+				relatedOpsExists = true
 			}
 		}
 
@@ -341,6 +357,9 @@ func (a *Asserter) Operations(
 			}
 			relatedIndexes = append(relatedIndexes, relatedOp.Index)
 		}
+	}
+	if !relatedOpsExists {
+		fmt.Println("Related Operations key is not implemented. This is fine as long as there is a distinction between sends and receives")
 	}
 
 	// only account based validation

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -1371,6 +1371,7 @@ func TestBlock(t *testing.T) {
 			)
 			assert.NotNil(t, asserter)
 			assert.NoError(t, err)
+			asserter.relatedOpsEnabled =  true
 
 			err = asserter.Block(test.block)
 			if test.err != nil {

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -319,11 +319,6 @@ func TestOperationsValidations(t *testing.T) {
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
 					},
-					RelatedOperations: []*types.OperationIdentifier{
-						{
-							Index: int64(0),
-						},
-					},
 					Type:    "PAYMENT",
 					Status:  types.String("SUCCESS"),
 					Account: validAccount,
@@ -332,11 +327,6 @@ func TestOperationsValidations(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(2),
-					},
-					RelatedOperations: []*types.OperationIdentifier{
-						{
-							Index: int64(0),
-						},
 					},
 					Type:    "FEE",
 					Status:  types.String("SUCCESS"),
@@ -363,11 +353,6 @@ func TestOperationsValidations(t *testing.T) {
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
 					},
-					RelatedOperations: []*types.OperationIdentifier{
-						{
-							Index: int64(0),
-						},
-					},
 					Type:    "PAYMENT",
 					Status:  types.String("SUCCESS"),
 					Account: validAccount,
@@ -392,11 +377,6 @@ func TestOperationsValidations(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
-					},
-					RelatedOperations: []*types.OperationIdentifier{
-						{
-							Index: int64(0),
-						},
 					},
 					Type:    "FEE",
 					Status:  types.String("SUCCESS"),
@@ -423,11 +403,6 @@ func TestOperationsValidations(t *testing.T) {
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
 					},
-					RelatedOperations: []*types.OperationIdentifier{
-						{
-							Index: int64(0),
-						},
-					},
 					Type:    "PAYMENT",
 					Status:  types.String("SUCCESS"),
 					Account: validAccount,
@@ -442,11 +417,6 @@ func TestOperationsValidations(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(2),
-					},
-					RelatedOperations: []*types.OperationIdentifier{
-						{
-							Index: int64(0),
-						},
 					},
 					Type:    "FEE",
 					Status:  types.String("SUCCESS"),
@@ -473,11 +443,6 @@ func TestOperationsValidations(t *testing.T) {
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
 					},
-					RelatedOperations: []*types.OperationIdentifier{
-						{
-							Index: int64(0),
-						},
-					},
 					Type:    "PAYMENT",
 					Status:  types.String("SUCCESS"),
 					Account: validAccount,
@@ -492,11 +457,6 @@ func TestOperationsValidations(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(2),
-					},
-					RelatedOperations: []*types.OperationIdentifier{
-						{
-							Index: int64(0),
-						},
 					},
 					Type:    "FEE",
 					Status:  types.String("SUCCESS"),

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -319,6 +319,11 @@ func TestOperationsValidations(t *testing.T) {
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
 					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: int64(0),
+						},
+					},
 					Type:    "PAYMENT",
 					Status:  types.String("SUCCESS"),
 					Account: validAccount,
@@ -327,6 +332,11 @@ func TestOperationsValidations(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(2),
+					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: int64(0),
+						},
 					},
 					Type:    "FEE",
 					Status:  types.String("SUCCESS"),
@@ -353,6 +363,11 @@ func TestOperationsValidations(t *testing.T) {
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
 					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: int64(0),
+						},
+					},
 					Type:    "PAYMENT",
 					Status:  types.String("SUCCESS"),
 					Account: validAccount,
@@ -377,6 +392,11 @@ func TestOperationsValidations(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
+					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: int64(0),
+						},
 					},
 					Type:    "FEE",
 					Status:  types.String("SUCCESS"),
@@ -403,6 +423,11 @@ func TestOperationsValidations(t *testing.T) {
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
 					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: int64(0),
+						},
+					},
 					Type:    "PAYMENT",
 					Status:  types.String("SUCCESS"),
 					Account: validAccount,
@@ -417,6 +442,11 @@ func TestOperationsValidations(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(2),
+					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: int64(0),
+						},
 					},
 					Type:    "FEE",
 					Status:  types.String("SUCCESS"),
@@ -443,6 +473,11 @@ func TestOperationsValidations(t *testing.T) {
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(1),
 					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: int64(0),
+						},
+					},
 					Type:    "PAYMENT",
 					Status:  types.String("SUCCESS"),
 					Account: validAccount,
@@ -457,6 +492,11 @@ func TestOperationsValidations(t *testing.T) {
 				{
 					OperationIdentifier: &types.OperationIdentifier{
 						Index: int64(2),
+					},
+					RelatedOperations: []*types.OperationIdentifier{
+						{
+							Index: int64(0),
+						},
 					},
 					Type:    "FEE",
 					Status:  types.String("SUCCESS"),
@@ -948,6 +988,44 @@ func TestBlock(t *testing.T) {
 			},
 		},
 	}
+	relatedMissingTransaction := &types.Transaction{
+		TransactionIdentifier: &types.TransactionIdentifier{
+			Hash: "blah",
+		},
+		Operations: []*types.Operation{
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(0),
+				},
+				Type:    "PAYMENT",
+				Status:  types.String("SUCCESS"),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(1),
+				},
+				RelatedOperations: []*types.OperationIdentifier{
+				},
+				Type:    "PAYMENT",
+				Status:  types.String("SUCCESS"),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(2),
+				},
+				RelatedOperations: []*types.OperationIdentifier{
+				},
+				Type:    "PAYMENT",
+				Status:  types.String("SUCCESS"),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+		},
+	}
 	invalidRelatedTransaction := &types.Transaction{
 		TransactionIdentifier: &types.TransactionIdentifier{
 			Hash: "blah",
@@ -1131,6 +1209,15 @@ func TestBlock(t *testing.T) {
 				Transactions:          []*types.Transaction{relatedDuplicateTransaction},
 			},
 			err: ErrRelatedOperationIndexDuplicate,
+		},
+		"missing related transaction operations": {
+			block: &types.Block{
+				BlockIdentifier:       validBlockIdentifier,
+				ParentBlockIdentifier: validParentBlockIdentifier,
+				Timestamp:             MinUnixEpoch + 1,
+				Transactions:          []*types.Transaction{relatedMissingTransaction},
+			},
+			err: ErrRelatedOperationMissing,
 		},
 		"nil block": {
 			block: nil,

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -71,6 +71,7 @@ var (
 		"related operation has index greater than operation",
 	)
 	ErrRelatedOperationIndexDuplicate     = errors.New("found duplicate related operation index")
+	ErrRelatedOperationMissing 			  = errors.New("related operations key is missing")
 	ErrBlockIdentifierIsNil               = errors.New("BlockIdentifier is nil")
 	ErrBlockIdentifierHashMissing         = errors.New("BlockIdentifier.Hash is missing")
 	ErrBlockIdentifierIndexIsNeg          = errors.New("BlockIdentifier.Index is negative")

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -260,7 +260,6 @@ func CallMethods(methods []string) error {
 	if err := StringArray("Allow.CallMethods", methods); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/asserter/network.go
+++ b/asserter/network.go
@@ -260,6 +260,7 @@ func CallMethods(methods []string) error {
 	if err := StringArray("Allow.CallMethods", methods); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/asserter/server_test.go
+++ b/asserter/server_test.go
@@ -203,6 +203,7 @@ var (
 		[]string{"eth_call"},
 		false,
 		"",
+		true,
 	)
 )
 
@@ -214,6 +215,7 @@ func TestNewWithOptions(t *testing.T) {
 		historicalBalanceLookup bool
 		supportedNetworks       []*types.NetworkIdentifier
 		callMethods             []string
+		relatedOpsEnabled       bool
 
 		err error
 	}{
@@ -222,17 +224,20 @@ func TestNewWithOptions(t *testing.T) {
 			historicalBalanceLookup: true,
 			supportedNetworks:       []*types.NetworkIdentifier{validNetworkIdentifier},
 			callMethods:             []string{"eth_call"},
+			relatedOpsEnabled:       true,
 		},
 		"no call methods": {
 			supportedOperationTypes: []string{"PAYMENT"},
 			historicalBalanceLookup: true,
 			supportedNetworks:       []*types.NetworkIdentifier{validNetworkIdentifier},
+			relatedOpsEnabled:       true,
 		},
 		"duplicate operation types": {
 			supportedOperationTypes: []string{"PAYMENT", "PAYMENT"},
 			historicalBalanceLookup: true,
 			supportedNetworks:       []*types.NetworkIdentifier{validNetworkIdentifier},
 			callMethods:             []string{"eth_call"},
+			relatedOpsEnabled:       true,
 			err: errors.New(
 				"Allow.OperationTypes contains a duplicate PAYMENT",
 			),
@@ -242,6 +247,7 @@ func TestNewWithOptions(t *testing.T) {
 			historicalBalanceLookup: true,
 			supportedNetworks:       []*types.NetworkIdentifier{validNetworkIdentifier},
 			callMethods:             []string{"eth_call"},
+			relatedOpsEnabled:       true,
 			err:                     errors.New("Allow.OperationTypes has an empty string"),
 		},
 		"duplicate network identifier": {
@@ -252,6 +258,7 @@ func TestNewWithOptions(t *testing.T) {
 				validNetworkIdentifier,
 			},
 			callMethods: []string{"eth_call"},
+			relatedOpsEnabled:       true,
 			err:         ErrSupportedNetworksDuplicate,
 		},
 		"nil network identifier": {
@@ -259,12 +266,14 @@ func TestNewWithOptions(t *testing.T) {
 			historicalBalanceLookup: true,
 			supportedNetworks:       []*types.NetworkIdentifier{validNetworkIdentifier, nil},
 			callMethods:             []string{"eth_call"},
+			relatedOpsEnabled:       true,
 			err:                     ErrNetworkIdentifierIsNil,
 		},
 		"no supported networks": {
 			supportedOperationTypes: []string{"PAYMENT"},
 			historicalBalanceLookup: true,
 			callMethods:             []string{"eth_call"},
+			relatedOpsEnabled:       true,
 			err:                     ErrNoSupportedNetworks,
 		},
 	}
@@ -277,6 +286,7 @@ func TestNewWithOptions(t *testing.T) {
 				test.callMethods,
 				false,
 				"",
+				test.relatedOpsEnabled,
 			)
 			if test.err == nil {
 				assert.NotNil(t, thisA)
@@ -438,6 +448,7 @@ func TestAccountBalanceRequest(t *testing.T) {
 				nil,
 				false,
 				"",
+				true,
 			)
 			assert.NotNil(t, asserter)
 			assert.NoError(t, err)
@@ -1456,6 +1467,7 @@ func TestAccountCoinsRequest(t *testing.T) {
 				nil,
 				test.allowMempool,
 				"",
+				true,
 			)
 			assert.NotNil(t, asserter)
 			assert.NoError(t, err)

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -65,6 +65,7 @@ func main() {
 		nil,
 		false,
 		"",
+		true,
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/types/allow.go
+++ b/types/allow.go
@@ -52,7 +52,6 @@ type Allow struct {
 	// contents of the mempool should populate this field as true. If false, requests to
 	// `/account/coins` that set `include_mempool` as true will be automatically rejected.
 	MempoolCoins bool `json:"mempool_coins"`
-	// If related operations is enabled and supported by an asset, we will throw an error if we find this key
-	// missing in a transaction. Otherwise, we will not throw an error.
+	// Any Rosetta implementation that supports related operations should set this to true.
 	RelatedOpsEnabled bool `json:"related_ops_enabled"`
 }

--- a/types/allow.go
+++ b/types/allow.go
@@ -52,4 +52,7 @@ type Allow struct {
 	// contents of the mempool should populate this field as true. If false, requests to
 	// `/account/coins` that set `include_mempool` as true will be automatically rejected.
 	MempoolCoins bool `json:"mempool_coins"`
+	// If related operations is enabled and supported by an asset, we will throw an error if we find this key
+	// missing in a transaction. Otherwise, we will not throw an error.
+	RelatedOpsEnabled bool `json:"related_ops_enabled"`
 }


### PR DESCRIPTION
Fixes # .


### Motivation
<!--
-->
Currently we don't flag an asset if it doesn't have related operations implemented. Implementing related operations is optional, we only need it to be implemented if we have multiple outputs or we don't distinguish between sends/receives. In that case, ChainIO will break because it uses related operations to enforce a DAG structure on the operations.

### Solution
<!--
-->
Make related operations support configurable. If a related_operations_enabled is set to true in asserter file, then throw error if related operations key doesn't exist. Otherwise, just print warning.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->