### PR TITLE
Related ops checks

### DIFF
--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -46,11 +46,11 @@ type Asserter struct {
 // on the transaction. Fore more details please refer to
 // https://github.com/coinbase/rosetta-sdk-go/tree/master/asserter#readme
 type Validations struct {
-	Enabled    bool                 `json:"enabled"`
-	RelatedOps bool                 `json:"related_ops"`
-	ChainType  ChainType            `json:"chain_type"`
-	Payment    *ValidationOperation `json:"payment"`
-	Fee        *ValidationOperation `json:"fee"`
+	Enabled          bool                 `json:"enabled"`
+	RelatedOpsExists bool                 `json:"related_ops_exists"`
+	ChainType        ChainType            `json:"chain_type"`
+	Payment          *ValidationOperation `json:"payment"`
+	Fee              *ValidationOperation `json:"fee"`
 }
 
 type ValidationOperation struct {

--- a/asserter/asserter.go
+++ b/asserter/asserter.go
@@ -46,10 +46,11 @@ type Asserter struct {
 // on the transaction. Fore more details please refer to
 // https://github.com/coinbase/rosetta-sdk-go/tree/master/asserter#readme
 type Validations struct {
-	Enabled   bool                 `json:"enabled"`
-	ChainType ChainType            `json:"chain_type"`
-	Payment   *ValidationOperation `json:"payment"`
-	Fee       *ValidationOperation `json:"fee"`
+	Enabled    bool                 `json:"enabled"`
+	RelatedOps bool                 `json:"related_ops"`
+	ChainType  ChainType            `json:"chain_type"`
+	Payment    *ValidationOperation `json:"payment"`
+	Fee        *ValidationOperation `json:"fee"`
 }
 
 type ValidationOperation struct {

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -318,16 +318,12 @@ func (a *Asserter) Operations(
 			}
 		}
 
-		// Check if related operations key exists in this transaction
-		if len(op.RelatedOperations) != 0 {
-			relatedOpsExists = true
-		}
-
 		// Ensure an operation's related_operations are only
 		// operations with an index less than the operation
 		// and that there are no duplicates.
 		relatedIndexes := []int64{}
 		for _, relatedOp := range op.RelatedOperations {
+			relatedOpsExists = true
 			if relatedOp.Index >= op.OperationIdentifier.Index {
 				return fmt.Errorf(
 					"%w: related operation index %d >= operation index %d",

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -351,7 +351,7 @@ func (a *Asserter) Operations(
 	// throw an error if relatedOps is not implemented and relatedOps is supported
 	// otherwise print a warning
 	if !relatedOpsExists {
-		if a.validations.Enabled && a.validations.RelatedOps {
+		if a.validations.Enabled && a.validations.RelatedOpsExists {
 			return ErrRelatedOperationMissing
 		} else {
 			fmt.Println("Related Operations key is not implemented. " +

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -348,10 +348,16 @@ func (a *Asserter) Operations(
 			relatedIndexes = append(relatedIndexes, relatedOp.Index)
 		}
 	}
-	//Throw a warning if relatedOps is not implemented
+	// throw an error if relatedOps is not implemented and relatedOps is supported
+	// otherwise print a warning
 	if !relatedOpsExists {
-		fmt.Println("Related Operations key is not implemented. " +
-			"This is fine as long as there is a distinction between sends and receives and no multiple outputs")
+		if a.validations.Enabled && a.validations.RelatedOps {
+			return ErrRelatedOperationMissing
+		} else {
+			fmt.Println("Related Operations key is not implemented. " +
+				"This is fine as long as there is a distinction between " +
+				"sends and receives and no multiple outputs")
+		}
 	}
 
 	// only account based validation

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -353,11 +353,10 @@ func (a *Asserter) Operations(
 	if !relatedOpsExists {
 		if a.validations.Enabled && a.validations.RelatedOpsExists {
 			return ErrRelatedOperationMissing
-		} else {
-			fmt.Println("Related Operations key is not implemented. " +
-				"This is fine as long as there is a distinction between " +
-				"sends and receives and no multiple outputs")
 		}
+		fmt.Println("Related Operations key is not implemented. " +
+			"This is fine as long as there is a distinction between " +
+			"sends and receives and no multiple outputs")
 	}
 
 	// only account based validation

--- a/asserter/block.go
+++ b/asserter/block.go
@@ -297,6 +297,7 @@ func (a *Asserter) Operations(
 	feeTotal := big.NewInt(0)
 	paymentCount := 0
 	feeCount := 0
+	relatedOpsExists := false
 	for i, op := range operations {
 		// Ensure operations are sorted
 		if err := a.Operation(op, int64(i), construction); err != nil {
@@ -315,6 +316,11 @@ func (a *Asserter) Operations(
 				feeTotal.Add(feeTotal, val)
 				feeCount++
 			}
+		}
+
+		// Check if related operations key exists in this transaction
+		if len(op.RelatedOperations) != 0 {
+			relatedOpsExists = true
 		}
 
 		// Ensure an operation's related_operations are only
@@ -341,6 +347,11 @@ func (a *Asserter) Operations(
 			}
 			relatedIndexes = append(relatedIndexes, relatedOp.Index)
 		}
+	}
+	//Throw a warning if relatedOps is not implemented
+	if !relatedOpsExists {
+		fmt.Println("Related Operations key is not implemented. " +
+			"This is fine as long as there is a distinction between sends and receives and no multiple outputs")
 	}
 
 	// only account based validation

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -1176,7 +1176,7 @@ func TestBlock(t *testing.T) {
 				Timestamp:             MinUnixEpoch + 1,
 				Transactions:          []*types.Transaction{relatedMissingTransaction},
 			},
-			err: ErrRelatedOperationMissing,
+			err:                ErrRelatedOperationMissing,
 			validationFilePath: "data/validation_balanced_related_ops.json",
 		},
 		"nil block": {

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -966,23 +966,21 @@ func TestBlock(t *testing.T) {
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: int64(1),
 				},
-				RelatedOperations: []*types.OperationIdentifier{
-				},
-				Type:    "PAYMENT",
-				Status:  types.String("SUCCESS"),
-				Account: validAccount,
-				Amount:  validAmount,
+				RelatedOperations: []*types.OperationIdentifier{},
+				Type:              "PAYMENT",
+				Status:            types.String("SUCCESS"),
+				Account:           validAccount,
+				Amount:            validAmount,
 			},
 			{
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: int64(2),
 				},
-				RelatedOperations: []*types.OperationIdentifier{
-				},
-				Type:    "PAYMENT",
-				Status:  types.String("SUCCESS"),
-				Account: validAccount,
-				Amount:  validAmount,
+				RelatedOperations: []*types.OperationIdentifier{},
+				Type:              "PAYMENT",
+				Status:            types.String("SUCCESS"),
+				Account:           validAccount,
+				Amount:            validAmount,
 			},
 		},
 	}
@@ -1082,11 +1080,11 @@ func TestBlock(t *testing.T) {
 	}
 
 	var tests = map[string]struct {
-		block        *types.Block
+		block              *types.Block
 		validationFilePath string
-		genesisIndex int64
-		startIndex   *int64
-		err          error
+		genesisIndex       int64
+		startIndex         *int64
+		err                error
 	}{
 		"valid block": {
 			block: &types.Block{

--- a/asserter/block_test.go
+++ b/asserter/block_test.go
@@ -948,6 +948,44 @@ func TestBlock(t *testing.T) {
 			},
 		},
 	}
+	relatedMissingTransaction := &types.Transaction{
+		TransactionIdentifier: &types.TransactionIdentifier{
+			Hash: "blah",
+		},
+		Operations: []*types.Operation{
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(0),
+				},
+				Type:    "PAYMENT",
+				Status:  types.String("SUCCESS"),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(1),
+				},
+				RelatedOperations: []*types.OperationIdentifier{
+				},
+				Type:    "PAYMENT",
+				Status:  types.String("SUCCESS"),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+			{
+				OperationIdentifier: &types.OperationIdentifier{
+					Index: int64(2),
+				},
+				RelatedOperations: []*types.OperationIdentifier{
+				},
+				Type:    "PAYMENT",
+				Status:  types.String("SUCCESS"),
+				Account: validAccount,
+				Amount:  validAmount,
+			},
+		},
+	}
 	invalidRelatedTransaction := &types.Transaction{
 		TransactionIdentifier: &types.TransactionIdentifier{
 			Hash: "blah",
@@ -1045,6 +1083,7 @@ func TestBlock(t *testing.T) {
 
 	var tests = map[string]struct {
 		block        *types.Block
+		validationFilePath string
 		genesisIndex int64
 		startIndex   *int64
 		err          error
@@ -1131,6 +1170,16 @@ func TestBlock(t *testing.T) {
 				Transactions:          []*types.Transaction{relatedDuplicateTransaction},
 			},
 			err: ErrRelatedOperationIndexDuplicate,
+		},
+		"missing related transaction operations": {
+			block: &types.Block{
+				BlockIdentifier:       validBlockIdentifier,
+				ParentBlockIdentifier: validParentBlockIdentifier,
+				Timestamp:             MinUnixEpoch + 1,
+				Transactions:          []*types.Transaction{relatedMissingTransaction},
+			},
+			err: ErrRelatedOperationMissing,
+			validationFilePath: "data/validation_balanced_related_ops.json",
 		},
 		"nil block": {
 			block: nil,
@@ -1280,7 +1329,7 @@ func TestBlock(t *testing.T) {
 						TimestampStartIndex: test.startIndex,
 					},
 				},
-				"",
+				test.validationFilePath,
 			)
 			assert.NotNil(t, asserter)
 			assert.NoError(t, err)

--- a/asserter/data/validation_balanced_related_ops.json
+++ b/asserter/data/validation_balanced_related_ops.json
@@ -1,12 +1,12 @@
 {
   "enabled": true,
-  "related_ops": false,
+  "related_ops": true,
   "chain_type": "account",
   "payment": {
     "name": "PAYMENT",
     "operation": {
       "count": 2,
-      "should_balance": false
+      "should_balance": true
     }
   },
   "fee": {

--- a/asserter/data/validation_balanced_related_ops.json
+++ b/asserter/data/validation_balanced_related_ops.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "related_ops": true,
+  "related_ops_exists": true,
   "chain_type": "account",
   "payment": {
     "name": "PAYMENT",

--- a/asserter/data/validation_fee_and_payment_balanced.json
+++ b/asserter/data/validation_fee_and_payment_balanced.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "related_ops": false,
+  "related_ops_exists": false,
   "chain_type": "account",
   "payment": {
     "name": "PAYMENT",

--- a/asserter/data/validation_fee_and_payment_balanced.json
+++ b/asserter/data/validation_fee_and_payment_balanced.json
@@ -1,5 +1,6 @@
 {
   "enabled": true,
+  "related_ops": false,
   "chain_type": "account",
   "payment": {
     "name": "PAYMENT",

--- a/asserter/data/validation_fee_and_payment_unbalanced.json
+++ b/asserter/data/validation_fee_and_payment_unbalanced.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "related_ops": false,
+  "related_ops_exists": false,
   "chain_type": "account",
   "payment": {
     "name": "PAYMENT",

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -71,7 +71,7 @@ var (
 		"related operation has index greater than operation",
 	)
 	ErrRelatedOperationIndexDuplicate     = errors.New("found duplicate related operation index")
-	ErrRelatedOperationMissing 			  = errors.New("related operations key is missing")
+	ErrRelatedOperationMissing            = errors.New("related operations key is missing")
 	ErrBlockIdentifierIsNil               = errors.New("BlockIdentifier is nil")
 	ErrBlockIdentifierHashMissing         = errors.New("BlockIdentifier.Hash is missing")
 	ErrBlockIdentifierIndexIsNeg          = errors.New("BlockIdentifier.Index is negative")
@@ -120,6 +120,7 @@ var (
 		ErrOperationStatusNotEmptyForConstruction,
 		ErrRelatedOperationIndexOutOfOrder,
 		ErrRelatedOperationIndexDuplicate,
+		ErrRelatedOperationMissing,
 		ErrBlockIdentifierIsNil,
 		ErrBlockIdentifierHashMissing,
 		ErrBlockIdentifierIndexIsNeg,

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -71,6 +71,7 @@ var (
 		"related operation has index greater than operation",
 	)
 	ErrRelatedOperationIndexDuplicate     = errors.New("found duplicate related operation index")
+	ErrRelatedOperationMissing 			  = errors.New("related operations key is missing")
 	ErrBlockIdentifierIsNil               = errors.New("BlockIdentifier is nil")
 	ErrBlockIdentifierHashMissing         = errors.New("BlockIdentifier.Hash is missing")
 	ErrBlockIdentifierIndexIsNeg          = errors.New("BlockIdentifier.Index is negative")


### PR DESCRIPTION
Fixes # .


### Motivation
<!--
-->
Currently we don't flag an asset if it doesn't have related operations implemented. Implementing related operations is optional, we only need it to be implemented if we have multiple outputs or we don't distinguish between sends/receives. In that case, ChainIO will break because it uses related operations to enforce a DAG structure on the operations.

### Solution
<!--
-->
Make related operations support configurable. If a related_operations_enabled is set to true in validator file, then throw error if related operations key doesn't exist. Otherwise, just print warning.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->