### PR TITLE
Fix: Use amount of 0 for currencies not listed

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -305,19 +305,17 @@ func UnmarshalMap(metadata map[string]interface{}, output interface{}) error {
 func ExtractAmount(
 	balances []*Amount,
 	currency *Currency,
-) (*Amount, error) {
+) *Amount {
 	for _, b := range balances {
 		if Hash(b.Currency) != Hash(currency) {
 			continue
 		}
 
-		return b, nil
+		return b
 	}
 
-	return nil, fmt.Errorf(
-		"account balance response does not contain currency %s",
-		PrettyPrintStruct(currency),
-	)
+	// return a 0 amount if currency isn't found in balances
+	return &Amount{Value: "0", Currency: currency}
 }
 
 // String returns a pointer to the

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -17,7 +17,6 @@ package types
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -621,27 +620,21 @@ func TestExtractAmount(t *testing.T) {
 	)
 
 	t.Run("Non-existent currency", func(t *testing.T) {
-		result, err := ExtractAmount(balances, badCurr)
-		assert.Nil(t, result)
-		assert.EqualError(
+		result := ExtractAmount(balances, badCurr)
+		assert.Equal(
 			t,
-			err,
-			fmt.Errorf(
-				"account balance response does not contain currency %s",
-				PrettyPrintStruct(badCurr),
-			).Error(),
+			result.Value,
+			"0",
 		)
 	})
 
 	t.Run("Simple account", func(t *testing.T) {
-		result, err := ExtractAmount(balances, currency1)
+		result := ExtractAmount(balances, currency1)
 		assert.Equal(t, amount1, result)
-		assert.NoError(t, err)
 	})
 
 	t.Run("SubAccount", func(t *testing.T) {
-		result, err := ExtractAmount(balances, currency2)
+		result := ExtractAmount(balances, currency2)
 		assert.Equal(t, amount2, result)
-		assert.NoError(t, err)
 	})
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -429,18 +429,7 @@ func CurrencyBalance(
 		return nil, nil, fetchErr.Err
 	}
 
-	liveAmount, err := types.ExtractAmount(liveBalances, currency)
-	if err != nil {
-		formattedError := fmt.Errorf(
-			"%w: could not get %s currency balance for %s",
-			err,
-			types.PrettyPrintStruct(currency),
-			types.PrettyPrintStruct(account),
-		)
-
-		return nil, nil, formattedError
-	}
-
+	liveAmount := types.ExtractAmount(liveBalances, currency)
 	return liveAmount, liveBlock, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/coinbase/rosetta-cli/issues/230

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
When using rosetta with cosmos-sdk based blockchains with coins minted after Genesis rosetta-cli tests error because of missing account balances. 

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
To solve this issue, instead of returning an error when searching for a balance for a currency that doesn't have a value return a 0 amount.  This means that if rosetta looks for the amount of a currency at a block height before it has been minted it will simply return a 0 amount.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
