### PR TITLE
Fix the issue of high RAM usage and long runtime for huge bootstrap_balances.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
     <img width="90%" alt="Rosetta" src="https://www.rosetta-api.org/img/rosetta_header.png">
   </a>
 </p>
+
 <h3 align="center">
    Rosetta SDK
 </h3>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
     <img width="90%" alt="Rosetta" src="https://www.rosetta-api.org/img/rosetta_header.png">
   </a>
 </p>
-
 <h3 align="center">
    Rosetta SDK
 </h3>

--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -18,12 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/neilotoole/errgroup"
 	"log"
 	"math/big"
 	"runtime"
 	"sync"
-
-	"github.com/neilotoole/errgroup"
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/parser"
@@ -1097,7 +1096,17 @@ func (b *BalanceStorage) BootstrapBalances(
 	dbTransaction := b.db.Transaction(ctx)
 	defer dbTransaction.Discard(ctx)
 
-	for _, balance := range balances {
+	for i, balance := range balances {
+		// Commit transaction batch by batch rather than commit at one time.
+		// This helps reduce memory usage and improve running time when bootstrap_balances.json
+		// contains huge number of accounts.
+		if i % utils.MaxEntrySizePerTxn == 0 {
+			if err := dbTransaction.Commit(ctx); err != nil {
+				return err
+			}
+			dbTransaction = b.db.Transaction(ctx)
+		}
+
 		// Ensure change.Difference is valid
 		amountValue, ok := new(big.Int).SetString(balance.Value, 10)
 		if !ok {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -63,6 +63,12 @@ const (
 	// to consider when estimating time to tip if the provided
 	// estimate is 0.
 	minBlocksPerSecond = 0.0001
+
+	// MaxEntrySizePerTxn is the maximum number of entries
+	// in one transaction object. This is used for bootstrap
+	// balances process to avoid TxnTooBig error when memory_limit_disabled=false
+	// as well as reduce the running time.
+	MaxEntrySizePerTxn = 600
 )
 
 var (


### PR DESCRIPTION
Fix the issue of high RAM usage and long runtime for huge bootstrap_balances.json file.

### Motivation
User reported 2 issues when running bootstrap_balances.json (101K accounts) for IOTA:
1) When `memory_limit_disable=false`, bootstrap process will stop at 35Kth accounts because of transaction storage limit.
2) After enabling memory_limit_disable, the running time of bootstrap process takes ~8h40m which is too long.

This ticket aims to resolve both issues so that:
1) Reduce the memory usage for bootstrap process to make it complete successfully.
2) Reduce the time of running bootstrap process for huge data set.

Links to the issues:
https://github.com/coinbase/rosetta-cli/issues/259 
https://github.com/coinbase/rosetta-cli/issues/260 

### Investigation
In general, bootstrap balances consists of 3 steps: 
1) Load and parse bootstrap_balances.json.
2) Store the records (account & currency & amount) in transaction object as a slice of entries.
3) Commit the transaction by writing all entries in LSM and vLog.

I've experimented in 32G RAM machine by bootstrapping different number of accounts and computed the duration of step 2) and 3). The result is as follows:
```
# acct            write entry            commit txn
10115             2m42s                  98.2ms
5059              33s                    48.4ms
2529              6s                     21ms
1264              1s                     9.5ms
632               340ms                  5.4ms
316               117ms                  2.2ms 
```

When running bootstrap scripts with 101K accounts, the process stopped at 35K records with %6.4 memory usage, which is ~2G.

### Solution
Based on investigation, the solution is to split the huge number of accounts into different batches. Each batch contains 600 records. We commit each batch before reading the next batch. By reducing the number of accounts committed in each transaction, we can achieve a better memory usage (101K records used %4 of total RAM which is ~1.3G) and much better running time (~60s for 101K records).
<img width="575" alt="Screen Shot 2021-12-14 at 1 56 13 PM" src="https://user-images.githubusercontent.com/93357037/146081449-9f0d32ed-424f-4ef2-925b-670de36dfbda.png">
