### PR TITLE
Bootstrap file memory issues

### DIFF
--- a/storage/modules/balance_storage.go
+++ b/storage/modules/balance_storage.go
@@ -1101,7 +1101,7 @@ func (b *BalanceStorage) BootstrapBalances(
 		// Commit transaction batch by batch rather than commit at one time.
 		// This helps reduce memory usage and improve running time when bootstrap_balances.json
 		// contains huge number of accounts.
-		if i%utils.MaxEntrySizePerTxn == 0 {
+		if i != 0 && i%utils.MaxEntrySizePerTxn == 0 {
 			if err := dbTransaction.Commit(ctx); err != nil {
 				return err
 			}

--- a/storage/modules/balance_storage_test.go
+++ b/storage/modules/balance_storage_test.go
@@ -1020,6 +1020,14 @@ func TestBootstrapBalances(t *testing.T) {
 		account = &types.AccountIdentifier{
 			Address: "hello",
 		}
+
+		account2 = &types.AccountIdentifier{
+			Address: "hello world",
+		}
+
+		account3 = &types.AccountIdentifier{
+			Address: "hello world new",
+		}
 	)
 
 	ctx := context.Background()
@@ -1064,6 +1072,16 @@ func TestBootstrapBalances(t *testing.T) {
 			Value:    amount.Value,
 			Currency: amount.Currency,
 		},
+		{
+			Account:  account2,
+			Value:    amount.Value,
+			Currency: amount.Currency,
+		},
+		{
+			Account:  account3,
+			Value:    amount.Value,
+			Currency: amount.Currency,
+		},
 	}, "", " ")
 	assert.NoError(t, err)
 
@@ -1083,7 +1101,7 @@ func TestBootstrapBalances(t *testing.T) {
 
 	storage.Initialize(mockHelper, mockHandler)
 	t.Run("Set balance successfully", func(t *testing.T) {
-		mockHandler.On("AccountsSeen", ctx, mock.Anything, 1).Return(nil).Once()
+		mockHandler.On("AccountsSeen", ctx, mock.Anything, 1).Return(nil).Times(3)
 		err = storage.BootstrapBalances(
 			ctx,
 			bootstrapBalancesFile,
@@ -1099,6 +1117,26 @@ func TestBootstrapBalances(t *testing.T) {
 		)
 
 		assert.Equal(t, amount, retrievedAmount)
+		assert.NoError(t, err)
+
+		retrievedAmount2, err := storage.GetOrSetBalance(
+			ctx,
+			account2,
+			amount.Currency,
+			genesisBlockIdentifier,
+		)
+
+		assert.Equal(t, amount, retrievedAmount2)
+		assert.NoError(t, err)
+
+		retrievedAmount3, err := storage.GetOrSetBalance(
+			ctx,
+			account3,
+			amount.Currency,
+			genesisBlockIdentifier,
+		)
+
+		assert.Equal(t, amount, retrievedAmount3)
 		assert.NoError(t, err)
 
 		// Attempt to update balance

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -63,6 +63,12 @@ const (
 	// to consider when estimating time to tip if the provided
 	// estimate is 0.
 	minBlocksPerSecond = 0.0001
+
+	// MaxEntrySizePerTxn is the maximum number of entries
+	// in one transaction object. This is used for bootstrap
+	// balances process to avoid TxnTooBig error when memory_limit_disabled=false
+	// as well as reduce the running time.
+	MaxEntrySizePerTxn = 600
 )
 
 var (


### PR DESCRIPTION
Fixes .
https://github.com/coinbase/rosetta-cli/issues/259 
https://github.com/coinbase/rosetta-cli/issues/260 

### Motivation
For motivation please refer #365 

### Solution
We commit transaction for bootstrap balances in chunks of 600 accounts.

### Open questions
I tested it locally with `MaxEntrySizePerTxn` to be lower/same than number of account and it worked. I still have not found a clean way to unit test that since that value comes from a const.
