### PR TITLE
Improve parsing logic for `set_variable` action types

### DIFF
--- a/constructor/dsl/dsl_test.go
+++ b/constructor/dsl/dsl_test.go
@@ -330,6 +330,37 @@ func TestParse(t *testing.T) {
 			file:        "blah_blah.txt",
 			expectedErr: ErrIncorrectExtension,
 		},
+		"action: valid type": {
+			file: "action_valid.ros",
+			expectedWorkflows: []*job.Workflow{
+				{
+					Name:        string(job.CreateAccount),
+					Concurrency: job.ReservedWorkflowConcurrency,
+					Scenarios: []*job.Scenario{
+						{
+							Name: "create",
+							Actions: []*job.Action{
+								{
+									Type:       job.SetVariable,
+									Input:      `{"network":"chrysalis-devnet", "blockchain":"iota"}`,
+									OutputPath: "network",
+								},
+								{
+									Type:       job.GenerateKey,
+									Input:      `{"curve_type": "edwards25519"}`,
+									OutputPath: "key",
+								},
+								{
+									Type:       job.Derive,
+									Input:      `{"network_identifier": {{network}},"public_key": {{key.public_key}}}`,
+									OutputPath: "account",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/constructor/dsl/parser.go
+++ b/constructor/dsl/parser.go
@@ -17,6 +17,7 @@ package dsl
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -147,6 +148,10 @@ func parseActionType(line string) (job.ActionType, string, string, error) {
 		divide:   job.Division,
 	} {
 		tokens = strings.SplitN(remaining, symbol, split2)
+
+		if json.Valid([]byte(strings.TrimSuffix(remaining, ";"))) {
+			break
+		}
 		if len(tokens) == split2 {
 			if len(mathOperation) == 0 {
 				return "", "", "", ErrInvalidMathSymbol

--- a/constructor/dsl/testdata/action_valid.ros
+++ b/constructor/dsl/testdata/action_valid.ros
@@ -1,0 +1,10 @@
+create_account(1){
+  create{
+    network = {"network":"chrysalis-devnet", "blockchain":"iota"};
+    key = generate_key({"curve_type": "edwards25519"});
+    account = derive({
+      "network_identifier": {{network}},
+      "public_key": {{key.public_key}}
+    });
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/coinbase/rosetta-cli/issues/248

### Motivation
To improve the parsing logic for `set_variable` action types

### Solution
Before splitting the string to determine if the remaining line contains an arithmetic operator, we first check to see if the remaining line (sans `;` suffix) is valid JSON

### Open questions
Is there any possibility of arithmetic and JSON in the same line?
