### PR TITLE
ROSE-230: Use integer to compare amount sign

### DIFF
--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -67,11 +67,11 @@ func (s AmountSign) Match(amount *types.Amount) bool {
 		return true
 	}
 
-	if s == PositiveOrZeroAmountSign && (numeric.Sign() == 1 || amount.Value == "0") {
+	if s == PositiveOrZeroAmountSign && (numeric.Sign() == 1 || len(numeric.Bits()) == 0) {
 		return true
 	}
 
-	if s == NegativeOrZeroAmountSign && (numeric.Sign() == -1 || amount.Value == "0") {
+	if s == NegativeOrZeroAmountSign && (numeric.Sign() == -1 || len(numeric.Bits()) == 0) {
 		return true
 	}
 


### PR DESCRIPTION
### Motivation
https://jira.coinbase-corp.com/browse/ROSE-230

### Solution
Currently we use amount.Value == "0" to check if an amount matches zero. This caused an issue in ChainIO as we may have "-0" as input. To resolve the issue, we need to convert string to integer and then compare.
