### PR TITLE
add sub account optional flag

### DIFF
--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -105,7 +105,11 @@ type MetadataDescription struct {
 
 // AccountDescription is used to describe a *types.AccountIdentifier.
 type AccountDescription struct {
-	Exists                 bool
+	Exists bool
+
+	// SubAccountOptional If this is true then SubAccountExists, SubAccountAddress,
+	// SubAccountMetadataKeys matching is ignored
+	SubAccountOptional     bool
 	SubAccountExists       bool
 	SubAccountAddress      string
 	SubAccountMetadataKeys []*MetadataDescription
@@ -210,6 +214,10 @@ func accountMatch(req *AccountDescription, account *types.AccountIdentifier) err
 			return ErrAccountMatchAccountMissing
 		}
 
+		return nil
+	}
+
+	if req.SubAccountOptional {
 		return nil
 	}
 

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2022 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -251,7 +251,10 @@ func accountMatch(req *AccountDescription, account *types.AccountIdentifier) err
 	return nil
 }
 
-func verifySubAccountAddress(subAccountAddress string, subAccount *types.SubAccountIdentifier) error {
+func verifySubAccountAddress(
+	subAccountAddress string,
+	subAccount *types.SubAccountIdentifier,
+) error {
 	if len(subAccountAddress) > 0 && subAccount.Address != subAccountAddress {
 		return fmt.Errorf(
 			"%w: expected %s but got %s",

--- a/parser/match_operations.go
+++ b/parser/match_operations.go
@@ -251,6 +251,8 @@ func accountMatch(req *AccountDescription, account *types.AccountIdentifier) err
 	return nil
 }
 
+// verifySubAccountAddress verifies the sub-account address if
+// sub-account is present.
 func verifySubAccountAddress(
 	subAccountAddress string,
 	subAccount *types.SubAccountIdentifier,

--- a/parser/match_operations_test.go
+++ b/parser/match_operations_test.go
@@ -1408,22 +1408,19 @@ func TestMatchOperations(t *testing.T) {
 			matches: nil,
 			err:     true,
 		},
-		"nil amount ops (sub account optional - when sub-account exist)": {
+		"sub account optional - when sub-account exist": {
 			operations: []*types.Operation{
 				{
 					Account: &types.AccountIdentifier{
 						Address: "addr1",
 						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub 3",
+							Address: "sub 2",
 						},
 					},
 				},
 				{
 					Account: &types.AccountIdentifier{
 						Address: "addr2",
-						SubAccount: &types.SubAccountIdentifier{
-							Address: "sub 2",
-						},
 					},
 				},
 			},
@@ -1453,19 +1450,6 @@ func TestMatchOperations(t *testing.T) {
 						{
 							Account: &types.AccountIdentifier{
 								Address: "addr1",
-								SubAccount: &types.SubAccountIdentifier{
-									Address: "sub 3",
-								},
-							},
-						},
-					},
-					Amounts: []*big.Int{nil},
-				},
-				{
-					Operations: []*types.Operation{
-						{
-							Account: &types.AccountIdentifier{
-								Address: "addr2",
 								SubAccount: &types.SubAccountIdentifier{
 									Address: "sub 2",
 								},
@@ -1474,14 +1458,27 @@ func TestMatchOperations(t *testing.T) {
 					},
 					Amounts: []*big.Int{nil},
 				},
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+							},
+						},
+					},
+					Amounts: []*big.Int{nil},
+				},
 			},
 			err: false,
 		},
-		"nil amount ops (sub account optional - when sub-account doesn't exist)": {
+		"sub account optional - when sub-account address is different": {
 			operations: []*types.Operation{
 				{
 					Account: &types.AccountIdentifier{
 						Address: "addr1",
+						SubAccount: &types.SubAccountIdentifier{
+							Address: "sub 2",
+						},
 					},
 				},
 				{
@@ -1497,7 +1494,7 @@ func TestMatchOperations(t *testing.T) {
 							Exists:             true,
 							SubAccountOptional: true,
 							SubAccountExists:   true,
-							SubAccountAddress:  "sub 2",
+							SubAccountAddress:  "sub 3",
 						},
 					},
 					{
@@ -1510,29 +1507,8 @@ func TestMatchOperations(t *testing.T) {
 					},
 				},
 			},
-			matches: []*Match{
-				{
-					Operations: []*types.Operation{
-						{
-							Account: &types.AccountIdentifier{
-								Address: "addr1",
-							},
-						},
-					},
-					Amounts: []*big.Int{nil},
-				},
-				{
-					Operations: []*types.Operation{
-						{
-							Account: &types.AccountIdentifier{
-								Address: "addr2",
-							},
-						},
-					},
-					Amounts: []*big.Int{nil},
-				},
-			},
-			err: false,
+			matches: nil,
+			err:     true,
 		},
 		"nil descriptions": {
 			operations: []*types.Operation{

--- a/parser/match_operations_test.go
+++ b/parser/match_operations_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Coinbase, Inc.
+// Copyright 2022 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/match_operations_test.go
+++ b/parser/match_operations_test.go
@@ -1408,6 +1408,132 @@ func TestMatchOperations(t *testing.T) {
 			matches: nil,
 			err:     true,
 		},
+		"nil amount ops (sub account optional - when sub-account exist)": {
+			operations: []*types.Operation{
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr1",
+						SubAccount: &types.SubAccountIdentifier{
+							Address: "sub 3",
+						},
+					},
+				},
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr2",
+						SubAccount: &types.SubAccountIdentifier{
+							Address: "sub 2",
+						},
+					},
+				},
+			},
+			descriptions: &Descriptions{
+				OperationDescriptions: []*OperationDescription{
+					{
+						Account: &AccountDescription{
+							Exists:             true,
+							SubAccountOptional: true,
+							SubAccountExists:   true,
+							SubAccountAddress:  "sub 2",
+						},
+					},
+					{
+						Account: &AccountDescription{
+							Exists:             true,
+							SubAccountOptional: true,
+							SubAccountExists:   true,
+							SubAccountAddress:  "sub 1",
+						},
+					},
+				},
+			},
+			matches: []*Match{
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub 3",
+								},
+							},
+						},
+					},
+					Amounts: []*big.Int{nil},
+				},
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+								SubAccount: &types.SubAccountIdentifier{
+									Address: "sub 2",
+								},
+							},
+						},
+					},
+					Amounts: []*big.Int{nil},
+				},
+			},
+			err: false,
+		},
+		"nil amount ops (sub account optional - when sub-account doesn't exist)": {
+			operations: []*types.Operation{
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr1",
+					},
+				},
+				{
+					Account: &types.AccountIdentifier{
+						Address: "addr2",
+					},
+				},
+			},
+			descriptions: &Descriptions{
+				OperationDescriptions: []*OperationDescription{
+					{
+						Account: &AccountDescription{
+							Exists:             true,
+							SubAccountOptional: true,
+							SubAccountExists:   true,
+							SubAccountAddress:  "sub 2",
+						},
+					},
+					{
+						Account: &AccountDescription{
+							Exists:             true,
+							SubAccountOptional: true,
+							SubAccountExists:   true,
+							SubAccountAddress:  "sub 1",
+						},
+					},
+				},
+			},
+			matches: []*Match{
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr1",
+							},
+						},
+					},
+					Amounts: []*big.Int{nil},
+				},
+				{
+					Operations: []*types.Operation{
+						{
+							Account: &types.AccountIdentifier{
+								Address: "addr2",
+							},
+						},
+					},
+					Amounts: []*big.Int{nil},
+				},
+			},
+			err: false,
+		},
 		"nil descriptions": {
 			operations: []*types.Operation{
 				{


### PR DESCRIPTION
Fixes #403  .

### Motivation
In some rosetta implementation `sub account` field is optional. This means we can't predict if it will be there or not. The current matcher logic requires it to be either required or not required. 

### Solution
Added a flag called `SubAccountOptional` which if set to `true` will ignore the subaccount matching and if false, behaves exactly as before

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
