### PR TITLE
Add hooks to allow overriding Helper field in Syncer

### DIFF
--- a/statefulsyncer/configuration.go
+++ b/statefulsyncer/configuration.go
@@ -16,6 +16,8 @@ package statefulsyncer
 
 import (
 	"time"
+
+	"github.com/coinbase/rosetta-sdk-go/syncer"
 )
 
 // Option is used to overwrite default values in
@@ -64,5 +66,11 @@ func WithPruneSleepTime(sleepTime int) Option {
 func WithSeenConcurrency(concurrency int64) Option {
 	return func(s *StatefulSyncer) {
 		s.seenSemaphoreSize = concurrency
+	}
+}
+
+func WithExtraSyncerOpts(os ...syncer.Option) Option {
+	return func(s *StatefulSyncer) {
+		s.extraSyncerOpts = os
 	}
 }

--- a/statefulsyncer/stateful_syncer.go
+++ b/statefulsyncer/stateful_syncer.go
@@ -72,6 +72,8 @@ type StatefulSyncer struct {
 	// BlockSeen occur concurrently.
 	seenSemaphore     *semaphore.Weighted
 	seenSemaphoreSize int64
+
+	extraSyncerOpts []syncer.Option
 }
 
 // Logger is used by the statefulsyncer to
@@ -162,10 +164,12 @@ func (s *StatefulSyncer) Sync(ctx context.Context, startIndex int64, endIndex in
 		s,
 		s,
 		s.cancel,
-		syncer.WithPastBlocks(pastBlocks),
-		syncer.WithCacheSize(s.cacheSize),
-		syncer.WithMaxConcurrency(s.maxConcurrency),
-		syncer.WithAdjustmentWindow(s.adjustmentWindow),
+		append([]syncer.Option{
+			syncer.WithPastBlocks(pastBlocks),
+			syncer.WithCacheSize(s.cacheSize),
+			syncer.WithMaxConcurrency(s.maxConcurrency),
+			syncer.WithAdjustmentWindow(s.adjustmentWindow),
+		}, s.extraSyncerOpts...)...,
 	)
 
 	return syncer.Sync(ctx, startIndex, endIndex)

--- a/syncer/configuration.go
+++ b/syncer/configuration.go
@@ -65,3 +65,9 @@ func WithAdjustmentWindow(adjustmentWindow int64) Option {
 		s.adjustmentWindow = adjustmentWindow
 	}
 }
+
+func WithCustomHelper(h func(Helper) Helper) Option {
+	return func(s *Syncer) {
+		s.helper = h(s.helper)
+	}
+}


### PR DESCRIPTION
Fixes #422.

### Motivation

For `rosetta-cli check:data` to do accounting correctly on the Concordium blockchain, it needs to rewrite account addresses into the same "normalized" alias.

### Solution

Add (stateful)syncer options for overriding `syncer.Option`s passed to `syncer.New` from outside the `statefulsyncer.New`.

Our internal fork of `rosetta-cli` is able to utilize this in https://github.com/Concordium/rosetta-cli/pull/1/files.

### Open questions

There might be better ways to solve the underlying problem than patching block results, but I haven't been able to find one that works as reliably. So even if this is a bit brute-force'ish it's good enough for me.