### PR TITLE
[tablesize]change the default to 2GB

### DIFF
--- a/storage/database/badger_database.go
+++ b/storage/database/badger_database.go
@@ -65,8 +65,8 @@ const (
 	// PerformanceLogValueSize is 256 MB.
 	PerformanceLogValueSize = 256 << 20
 
-	// AllInMemoryTableSize is 3072 MB.
-	AllInMemoryTableSize = 3072 << 20
+	// AllInMemoryTableSize is 2048 MB.
+	AllInMemoryTableSize = 2048 << 20
 
 	// PerformanceLogValueSize is 512 MB.
 	AllInMemoryLogValueSize = 512 << 20


### PR DESCRIPTION
Fixes # .

### Motivation
previously, tablesize is 3GB, reduce the number could make the memory usage smaller
in AWS environment, the check speed is faster and memory usgae is much higher than local env

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
