### PR TITLE
Make block identifier asserter function comply with Rosetta spec

### DIFF
--- a/asserter/block.go
+++ b/asserter/block.go
@@ -286,15 +286,15 @@ func PartialBlockIdentifier(blockIdentifier *types.PartialBlockIdentifier) error
 		return ErrPartialBlockIdentifierIsNil
 	}
 
-	if blockIdentifier.Hash != nil && *blockIdentifier.Hash != "" {
-		return nil
+	if blockIdentifier.Hash != nil && *blockIdentifier.Hash == "" {
+		return ErrPartialBlockIdentifierHashIsEmpty
 	}
 
-	if blockIdentifier.Index != nil && *blockIdentifier.Index >= 0 {
-		return nil
+	if blockIdentifier.Index != nil && *blockIdentifier.Index < 0 {
+		return ErrPartialBlockIdentifierIndexIsNegative
 	}
 
-	return ErrPartialBlockIdentifierFieldsNotSet
+	return nil
 }
 
 // TransactionIdentifier returns an error if a

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -83,15 +83,19 @@ var (
 	ErrBlockIdentifierIndexIsNeg             = errors.New("BlockIdentifier.Index is negative")
 	ErrPartialBlockIdentifierIsNil           = errors.New("PartialBlockIdentifier is nil")
 	ErrPartialBlockIdentifierHashIsEmpty     = errors.New("PartialBlockIdentifier hash is empty")
-	ErrPartialBlockIdentifierIndexIsNegative = errors.New("PartialBlockIdentifier index is negative")
-	ErrTxIdentifierIsNil                     = errors.New("TransactionIdentifier is nil")
-	ErrTxIdentifierHashMissing               = errors.New("TransactionIdentifier.Hash is missing")
-	ErrNoOperationsForConstruction           = errors.New("operations cannot be empty for construction")
-	ErrTxIsNil                               = errors.New("Transaction is nil")
-	ErrTimestampBeforeMin                    = errors.New("timestamp is before 01/01/2000")
-	ErrTimestampAfterMax                     = errors.New("timestamp is after 01/01/2040")
-	ErrBlockIsNil                            = errors.New("Block is nil")
-	ErrBlockHashEqualsParentBlockHash        = errors.New(
+	ErrPartialBlockIdentifierIndexIsNegative = errors.New(
+		"PartialBlockIdentifier index is negative",
+	)
+	ErrTxIdentifierIsNil           = errors.New("TransactionIdentifier is nil")
+	ErrTxIdentifierHashMissing     = errors.New("TransactionIdentifier.Hash is missing")
+	ErrNoOperationsForConstruction = errors.New(
+		"operations cannot be empty for construction",
+	)
+	ErrTxIsNil                        = errors.New("Transaction is nil")
+	ErrTimestampBeforeMin             = errors.New("timestamp is before 01/01/2000")
+	ErrTimestampAfterMax              = errors.New("timestamp is after 01/01/2040")
+	ErrBlockIsNil                     = errors.New("Block is nil")
+	ErrBlockHashEqualsParentBlockHash = errors.New(
 		"BlockIdentifier.Hash == ParentBlockIdentifier.Hash",
 	)
 	ErrBlockIndexPrecedesParentBlockIndex = errors.New(

--- a/asserter/errors.go
+++ b/asserter/errors.go
@@ -78,21 +78,20 @@ var (
 	ErrRelatedOperationInFeeNotAllowed = errors.New(
 		"fee operation shouldn't have related_operations",
 	)
-	ErrBlockIdentifierIsNil               = errors.New("BlockIdentifier is nil")
-	ErrBlockIdentifierHashMissing         = errors.New("BlockIdentifier.Hash is missing")
-	ErrBlockIdentifierIndexIsNeg          = errors.New("BlockIdentifier.Index is negative")
-	ErrPartialBlockIdentifierIsNil        = errors.New("PartialBlockIdentifier is nil")
-	ErrPartialBlockIdentifierFieldsNotSet = errors.New(
-		"neither PartialBlockIdentifier.Hash nor PartialBlockIdentifier.Index is set",
-	)
-	ErrTxIdentifierIsNil              = errors.New("TransactionIdentifier is nil")
-	ErrTxIdentifierHashMissing        = errors.New("TransactionIdentifier.Hash is missing")
-	ErrNoOperationsForConstruction    = errors.New("operations cannot be empty for construction")
-	ErrTxIsNil                        = errors.New("Transaction is nil")
-	ErrTimestampBeforeMin             = errors.New("timestamp is before 01/01/2000")
-	ErrTimestampAfterMax              = errors.New("timestamp is after 01/01/2040")
-	ErrBlockIsNil                     = errors.New("Block is nil")
-	ErrBlockHashEqualsParentBlockHash = errors.New(
+	ErrBlockIdentifierIsNil                  = errors.New("BlockIdentifier is nil")
+	ErrBlockIdentifierHashMissing            = errors.New("BlockIdentifier.Hash is missing")
+	ErrBlockIdentifierIndexIsNeg             = errors.New("BlockIdentifier.Index is negative")
+	ErrPartialBlockIdentifierIsNil           = errors.New("PartialBlockIdentifier is nil")
+	ErrPartialBlockIdentifierHashIsEmpty     = errors.New("PartialBlockIdentifier hash is empty")
+	ErrPartialBlockIdentifierIndexIsNegative = errors.New("PartialBlockIdentifier index is negative")
+	ErrTxIdentifierIsNil                     = errors.New("TransactionIdentifier is nil")
+	ErrTxIdentifierHashMissing               = errors.New("TransactionIdentifier.Hash is missing")
+	ErrNoOperationsForConstruction           = errors.New("operations cannot be empty for construction")
+	ErrTxIsNil                               = errors.New("Transaction is nil")
+	ErrTimestampBeforeMin                    = errors.New("timestamp is before 01/01/2000")
+	ErrTimestampAfterMax                     = errors.New("timestamp is after 01/01/2040")
+	ErrBlockIsNil                            = errors.New("Block is nil")
+	ErrBlockHashEqualsParentBlockHash        = errors.New(
 		"BlockIdentifier.Hash == ParentBlockIdentifier.Hash",
 	)
 	ErrBlockIndexPrecedesParentBlockIndex = errors.New(
@@ -132,7 +131,8 @@ var (
 		ErrBlockIdentifierHashMissing,
 		ErrBlockIdentifierIndexIsNeg,
 		ErrPartialBlockIdentifierIsNil,
-		ErrPartialBlockIdentifierFieldsNotSet,
+		ErrPartialBlockIdentifierHashIsEmpty,
+		ErrPartialBlockIdentifierIndexIsNegative,
 		ErrTxIdentifierIsNil,
 		ErrTxIdentifierHashMissing,
 		ErrNoOperationsForConstruction,

--- a/asserter/server_test.go
+++ b/asserter/server_test.go
@@ -57,6 +57,9 @@ var (
 
 	emptyBlockIdentifier = &types.BlockIdentifier{}
 
+	invalidBlockIdentifierHash  string = ""
+	invalidBlockIdentifierIndex int64  = -1
+
 	validTransactionIdentifier = &types.TransactionIdentifier{
 		Hash: "tx1",
 	}
@@ -427,14 +430,27 @@ func TestAccountBalanceRequest(t *testing.T) {
 			allowHistorical: true,
 			err:             nil,
 		},
-		"invalid historical request": {
+		"invalid historical request when block identifier hash is invalid": {
 			request: &types.AccountBalanceRequest{
 				NetworkIdentifier: validNetworkIdentifier,
 				AccountIdentifier: validAccountIdentifier,
-				BlockIdentifier:   &types.PartialBlockIdentifier{},
+				BlockIdentifier: &types.PartialBlockIdentifier{
+					Hash: &invalidBlockIdentifierHash,
+				},
 			},
 			allowHistorical: true,
-			err:             ErrPartialBlockIdentifierFieldsNotSet,
+			err:             ErrPartialBlockIdentifierHashIsEmpty,
+		},
+		"invalid historical request when block identifier index is invalid": {
+			request: &types.AccountBalanceRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				AccountIdentifier: validAccountIdentifier,
+				BlockIdentifier: &types.PartialBlockIdentifier{
+					Index: &invalidBlockIdentifierIndex,
+				},
+			},
+			allowHistorical: true,
+			err:             ErrPartialBlockIdentifierIndexIsNegative,
 		},
 		"valid historical request when not enabled": {
 			request: &types.AccountBalanceRequest{
@@ -522,12 +538,23 @@ func TestBlockRequest(t *testing.T) {
 			},
 			err: ErrPartialBlockIdentifierIsNil,
 		},
-		"invalid PartialBlockIdentifier request": {
+		"invalid block request when block identifier hash is invalid": {
 			request: &types.BlockRequest{
 				NetworkIdentifier: validNetworkIdentifier,
-				BlockIdentifier:   &types.PartialBlockIdentifier{},
+				BlockIdentifier: &types.PartialBlockIdentifier{
+					Hash: &invalidBlockIdentifierHash,
+				},
 			},
-			err: ErrPartialBlockIdentifierFieldsNotSet,
+			err: ErrPartialBlockIdentifierHashIsEmpty,
+		},
+		"invalid block request when block identifier index is invalid": {
+			request: &types.BlockRequest{
+				NetworkIdentifier: validNetworkIdentifier,
+				BlockIdentifier: &types.PartialBlockIdentifier{
+					Index: &invalidBlockIdentifierIndex,
+				},
+			},
+			err: ErrPartialBlockIdentifierIndexIsNegative,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Jingfu Wang <jingfu.wang@coinbase.com>

Make block identifier asserter function comply with Rosetta spec

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
