### PR TITLE
Pallas signer stake delegation

### DIFF
--- a/keys/errors.go
+++ b/keys/errors.go
@@ -44,7 +44,7 @@ var (
 	)
 	ErrVerifyFailed = errors.New("verify: verify returned false")
 
-	ErrPaymentNotFound = errors.New("payment not found in signingPayload")
+	ErrEmptyTransaction = errors.New("payment or stakeDelegation field not found in signingPayload")
 )
 
 // Err takes an error as an argument and returns

--- a/keys/signer_pallas.go
+++ b/keys/signer_pallas.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/coinbase/kryptology/pkg/signatures/schnorr/mina"
@@ -192,7 +193,7 @@ func constructTransaction(p *PayloadFields) (*mina.Transaction, error) {
 		return nil, fmt.Errorf("failed to parse uint for nonce: %w", err)
 	}
 
-	validUntil := uint64(0)
+	validUntil := uint64(math.MaxUint64)
 	if p.ValidUntil != nil {
 		validUntil, err = strconv.ParseUint(*p.ValidUntil, 10, 32)
 		if err != nil {

--- a/keys/signer_pallas_test.go
+++ b/keys/signer_pallas_test.go
@@ -78,7 +78,7 @@ func (s *ts) TestParseSigningPayload() {
 		validUntil                = "78"
 		memo                      = "memo"
 		signingPayloadWithPayment = SigningPayload{
-			Payment: &PayloadFields{
+			Payment: &PayloadFieldsPayment{
 				To:         toAddress,
 				From:       fromAddress,
 				Fee:        "12",
@@ -88,9 +88,9 @@ func (s *ts) TestParseSigningPayload() {
 				Memo:       &memo,
 			},
 		}
-		signingPayloadWithNoPayment                           = SigningPayload{}
+		signingPayloadWithNoPaymentOrDelegation                           = SigningPayload{}
 		signingPayloadWithPaymentAndNullValidUntilAndNullMemo = SigningPayload{
-			Payment: &PayloadFields{
+			Payment: &PayloadFieldsPayment{
 				To:         toAddress,
 				From:       fromAddress,
 				Fee:        "12",
@@ -101,7 +101,7 @@ func (s *ts) TestParseSigningPayload() {
 			},
 		}
 		signingPayloadWithPaymentAndInvalidFromPublicKey = SigningPayload{
-			Payment: &PayloadFields{
+			Payment: &PayloadFieldsPayment{
 				To:         toAddress,
 				From:       "InvalidFrom",
 				Fee:        "12",
@@ -111,7 +111,7 @@ func (s *ts) TestParseSigningPayload() {
 			},
 		}
 		signingPayloadWithPaymentAndInvalidToPublicKey = SigningPayload{
-			Payment: &PayloadFields{
+			Payment: &PayloadFieldsPayment{
 				To:         "InvalidTo",
 				From:       fromAddress,
 				Fee:        "12",
@@ -154,7 +154,7 @@ func (s *ts) TestParseSigningPayload() {
 		s.Require().Equal(expectedTransactionBinary, transactionBinary)
 	})
 
-	s.Run("failed to parse when payment exists with null valid_until and memo", func() {
+	s.Run("successful to parse when payment exists with null valid_until and memo", func() {
 		payloadBinary, _ := json.Marshal(signingPayloadWithPaymentAndNullValidUntilAndNullMemo)
 		payload := &types.SigningPayload{
 			AccountIdentifier: &types.AccountIdentifier{Address: "test"},
@@ -172,7 +172,7 @@ func (s *ts) TestParseSigningPayload() {
 			FeeToken:   1,
 			FeePayerPk: fromPublicKey,
 			Nonce:      56,
-			ValidUntil: 0,
+			ValidUntil: 4294967295,
 			Memo:       "",
 			Tag:        [3]bool{false, false, false},
 			SourcePk:   fromPublicKey,
@@ -188,7 +188,7 @@ func (s *ts) TestParseSigningPayload() {
 	})
 
 	s.Run("failed to parse when payment or stake delegation does not exist", func() {
-		payloadBinary, _ := json.Marshal(signingPayloadWithNoPayment)
+		payloadBinary, _ := json.Marshal(signingPayloadWithNoPaymentOrDelegation)
 		payload := &types.SigningPayload{
 			AccountIdentifier: &types.AccountIdentifier{Address: "test"},
 			Bytes:             payloadBinary,


### PR DESCRIPTION
### Motivation
The following PR updates the pallas signer used for mina.
- It adds support for stake delegation transactions, in order to test the mina rosetta implementation.
- It fixes the default value for the `validUntil` field of payment transaction (from `0` to `max_uint32`).

This was tested by running the construction tests on the mina rosetta server with both payment and delegation transactions.


### Solution
#### Delegation transactions
The `Transaction` type could already handle various types of transaction and distinguish between them using the `Tag` field.
`{false, false, false}` is the first case (payments) and `{false,false,true}` the second one (stake delegation).
However the parsing step in `signer_pallas.go` could only handle `Payment` transaction so far so I added the `StakeDelelegation` case.

#### The valid_until field

If the `valid_until` field is not specified in the preprocess step, the rosetta server uses the greatest `uint32` as a default value. The pallas signer of `rosetta-sdk-go` was defaulting to zero when building the signing payload which resulted in an `invalid signature` error. The greatest `uint32` is now used in both cases.
