### PR TITLE
make types a go module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLINES_CMD=golines
 GOVERALLS_INSTALL=go install github.com/mattn/goveralls@latest
 GOVERALLS_CMD=goveralls
 GOLINT_CMD=go run golang.org/x/lint/golint
-GO_PACKAGES=./asserter/... ./fetcher/... ./types/... ./client/... ./server/... \
+GO_PACKAGES=./asserter/... ./fetcher/... ./client/... ./server/... \
 	./parser/... ./syncer/... ./reconciler/... ./keys/... \
 	./statefulsyncer/... ./storage/... ./utils/... ./constructor/... ./errors/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ GOLINT_CMD=go run golang.org/x/lint/golint
 GO_PACKAGES=./asserter/... ./fetcher/... ./client/... ./server/... \
 	./parser/... ./syncer/... ./reconciler/... ./keys/... \
 	./statefulsyncer/... ./storage/... ./utils/... ./constructor/... ./errors/...
+
+GO_MOD_PACKAGES=./types/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
+GO_MOD_FOLDERS=$(shell echo ${GO_MOD_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
 TEST_SCRIPT=go test ${GO_PACKAGES}
 LINT_SETTINGS=golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam
 
@@ -43,6 +46,7 @@ fix-imports:
 
 check-comments:
 	${GOLINT_CMD} -set_exit_status ${GO_FOLDERS} .
+	${GOLINT_CMD} -set_exit_status ${GO_MOD_FOLDERS} .
 
 lint-examples:
 	cd examples; \
@@ -79,6 +83,7 @@ check-license:
 shorten-lines:
 	${GOLINES_INSTALL}
 	${GOLINES_CMD} -w --shorten-comments ${GO_FOLDERS} examples
+	${GOLINES_CMD} -w --shorten-comments ${GO_MOD_FOLDERS}
 
 shellcheck:
 	shellcheck codegen.sh

--- a/codegen.sh
+++ b/codegen.sh
@@ -210,6 +210,10 @@ do
   rm "types/${type}.go" && cp "templates/${type}.txt" "types/${type}.go";
 done
 
+cp "templates/go.mod.types" "types/go.mod"
+cd types && go get ./...
+cd ..
+
 # Format client generated code
 FORMAT_GEN="gofmt -w /local/types; gofmt -w /local/client; gofmt -w /local/server"
 GOLANG_VERSION=1.18

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/coinbase/rosetta-sdk-go
 
 go 1.18
 
+require github.com/coinbase/rosetta-sdk-go/types v0.0.0
+
+replace github.com/coinbase/rosetta-sdk-go/types => ./types
+
 require (
 	github.com/DataDog/zstd v1.5.2
 	github.com/Zilliqa/gozilliqa-sdk v1.2.1-0.20201201074141-dd0ecada1be6
@@ -13,7 +17,6 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/gorilla/mux v1.8.0
 	github.com/lucasjones/reggen v0.0.0-20180717132126-cdb49ff09d77
-	github.com/mitchellh/mapstructure v1.4.3
 	github.com/neilotoole/errgroup v0.1.6
 	github.com/segmentio/fasthash v1.0.3
 	github.com/stretchr/testify v1.7.2
@@ -38,6 +41,7 @@ require (
 	github.com/klauspost/compress v1.12.3 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
-github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/neilotoole/errgroup v0.1.6 h1:PODGqPXdT5BC/zCYIMoTrwV+ujKcW+gBXM6Ye9Ve3R8=
 github.com/neilotoole/errgroup v0.1.6/go.mod h1:Q2nLGf+594h0CLBs/Mbg6qOr7GtqDK7C2S41udRnToE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/templates/go.mod.types
+++ b/templates/go.mod.types
@@ -1,0 +1,3 @@
+module github.com/coinbase/rosetta-sdk-go/types
+
+go 1.18

--- a/types/go.mod
+++ b/types/go.mod
@@ -1,0 +1,5 @@
+module github.com/coinbase/rosetta-sdk-go/types
+
+go 1.18
+
+require github.com/mitchellh/mapstructure v1.5.0

--- a/types/go.sum
+++ b/types/go.sum
@@ -1,0 +1,2 @@
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=


### PR DESCRIPTION
Fixes #460  .

### Motivation
`rosetta-sdk-go` dependency graph is quite big and all of them are not useful for rosetta development.  This makes it hard to use `rosetta-sdk-go`

### Solution
Make `types` as go submodule so that people can just import `types` independent of `rosetta-sdk-go`

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
