### PR TITLE
add missing fields in fetcher for construction preprocess

### DIFF
--- a/fetcher/construction.go
+++ b/fetcher/construction.go
@@ -269,6 +269,8 @@ func (f *Fetcher) ConstructionPreprocess(
 	network *types.NetworkIdentifier,
 	operations []*types.Operation,
 	metadata map[string]interface{},
+	maxFee []*types.Amount,
+	suggestedFeeMultiplier *float64,
 ) (map[string]interface{}, []*types.AccountIdentifier, *Error) {
 	if err := f.connectionSemaphore.Acquire(ctx, semaphoreRequestWeight); err != nil {
 		return nil, nil, &Error{
@@ -279,9 +281,11 @@ func (f *Fetcher) ConstructionPreprocess(
 
 	response, clientErr, err := f.rosettaClient.ConstructionAPI.ConstructionPreprocess(ctx,
 		&types.ConstructionPreprocessRequest{
-			NetworkIdentifier: network,
-			Operations:        operations,
-			Metadata:          metadata,
+			NetworkIdentifier:      network,
+			Operations:             operations,
+			Metadata:               metadata,
+			MaxFee:                 maxFee,
+			SuggestedFeeMultiplier: suggestedFeeMultiplier,
 		},
 	)
 


### PR DESCRIPTION
Fixes # .



### Motivation
Current Fetcher doesn't have 2 fields which are optionally used in the `ConstructionPreprocess` call

### Solution
- Add maxFee
- Add suggested_fee_multiplier

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
