### PR TITLE
update retry logic

### DIFF
--- a/fetcher/account.go
+++ b/fetcher/account.go
@@ -117,6 +117,7 @@ func (f *Fetcher) AccountBalanceRetry(
 		color.Cyan(msg)
 		if err := tryAgain(
 			msg,
+			f.forceRetry,
 			backoffRetries,
 			err,
 		); err != nil {
@@ -219,6 +220,7 @@ func (f *Fetcher) AccountCoinsRetry(
 		color.Cyan(msg)
 		if err := tryAgain(
 			msg,
+			f.forceRetry,
 			backoffRetries,
 			err,
 		); err != nil {

--- a/fetcher/block.go
+++ b/fetcher/block.go
@@ -115,7 +115,7 @@ func (f *Fetcher) fetchChannelTransactions(
 
 			txFetchErr := fmt.Sprintf("transaction %s", types.PrintStruct(transactionIdentifier))
 			color.Red("%s%s", txFetchErr, f.metaData)
-			if err := tryAgain(txFetchErr, backoffRetries, fetchErr); err != nil {
+			if err := tryAgain(txFetchErr, f.forceRetry, backoffRetries, fetchErr); err != nil {
 				return err
 			}
 		}
@@ -332,7 +332,7 @@ func (f *Fetcher) BlockRetry(
 
 		blockFetchErr := fmt.Sprintf("block %s", types.PrintStruct(blockIdentifier))
 		color.Red("%s%s", blockFetchErr, f.metaData)
-		if err := tryAgain(blockFetchErr, backoffRetries, err); err != nil {
+		if err := tryAgain(blockFetchErr, f.forceRetry, backoffRetries, err); err != nil {
 			return nil, err
 		}
 	}

--- a/fetcher/call.go
+++ b/fetcher/call.go
@@ -92,6 +92,7 @@ func (f *Fetcher) CallRetry(
 
 		if err := tryAgain(
 			fmt.Sprintf("/call %s:%s", method, types.PrintStruct(parameters)),
+			f.forceRetry,
 			backoffRetries,
 			err,
 		); err != nil {

--- a/fetcher/events.go
+++ b/fetcher/events.go
@@ -103,6 +103,7 @@ func (f *Fetcher) EventsBlocksRetry(
 
 		if err := tryAgain(
 			fmt.Sprintf("/events/blocks %+v %+v", offset, limit),
+			f.forceRetry,
 			backoffRetries,
 			err,
 		); err != nil {

--- a/fetcher/network.go
+++ b/fetcher/network.go
@@ -95,6 +95,7 @@ func (f *Fetcher) NetworkStatusRetry(
 
 		if err := tryAgain(
 			fmt.Sprintf("network status %s", types.PrintStruct(network)),
+			f.forceRetry,
 			backoffRetries,
 			err,
 		); err != nil {
@@ -171,7 +172,7 @@ func (f *Fetcher) NetworkListRetry(
 			return nil, fetcherErr
 		}
 
-		if err := tryAgain("NetworkList", backoffRetries, err); err != nil {
+		if err := tryAgain("NetworkList", f.forceRetry, backoffRetries, err); err != nil {
 			return nil, err
 		}
 	}
@@ -251,6 +252,7 @@ func (f *Fetcher) NetworkOptionsRetry(
 
 		if err := tryAgain(
 			fmt.Sprintf("network options %s", types.PrintStruct(network)),
+			f.forceRetry,
 			backoffRetries,
 			err,
 		); err != nil {

--- a/fetcher/search.go
+++ b/fetcher/search.go
@@ -91,6 +91,7 @@ func (f *Fetcher) SearchTransactionsRetry(
 
 		if err := tryAgain(
 			fmt.Sprintf("/search/transactions %s", types.PrintStruct(request)),
+			f.forceRetry,
 			backoffRetries,
 			err,
 		); err != nil {

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -81,8 +81,8 @@ func transientError(err error) bool {
 
 // tryAgain handles a backoff and prints error messages depending
 // on the fetchMsg.
-func tryAgain(fetchMsg string, thisBackoff *Backoff, err *Error) *Error {
-	if !err.Retry {
+func tryAgain(fetchMsg string, forceRetry bool, thisBackoff *Backoff, err *Error) *Error {
+	if !err.Retry && !forceRetry {
 		return err
 	}
 


### PR DESCRIPTION
Fixes # .

We met this problem in most of recent validation by using internal tools:
Many errors's use default logic which is not retriable, however, due to network problems we saw many timeout should be retriable(we found this in /block, /account/balance, and /network/options)

This pr adds the `force_retry` to the `tryagain` function which solves it

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

do not merge it or change to ready for review at this moment 

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
