### PR TITLE
Fix: Correct SaveAccount input to use full KeyPair object

### DIFF
--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1011,7 +1011,7 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 			},
 			{
 				Type:  job.SaveAccount,
-				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 			},
 			{
 				Type:  job.PrintMessage,


### PR DESCRIPTION
## Description

Fixes #451

The test `TestJob_ComplicatedTransfer` had an incorrect input on line 1014. It was using `{{key.public_key}}` for the keypair field, but `SaveAccountInput` expects a full `KeyPair` object with `hex_bytes` and `curve_type` fields, not just a public key.

## Bug Impact

This bug caused silent unmarshalling failure where the keypair field would end up with empty values, potentially masking real issues in account saving logic.

## Changes

- Changed `{{key.public_key}}` to `{{key}}` in the SaveAccount input
- This ensures the full KeyPair object is passed, matching the expected schema

## Testing

This is a test file fix - the test itself validates the change when run.

## Related

- Issue #451: Silent test failure bug in TestJob_ComplicatedTransfer