### PR TITLE
fix: correct SaveAccount input in TestJob_ComplicatedTransfer

### DIFF
--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1011,7 +1011,7 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 			},
 			{
 				Type:  job.SaveAccount,
-				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 			},
 			{
 				Type:  job.PrintMessage,


### PR DESCRIPTION
## Description

Fixes #451

The test `TestJob_ComplicatedTransfer` was incorrectly passing `{{key.public_key}}` (a `*types.PublicKey`) where `{{key}}` (a `*keys.KeyPair`) was expected by `SaveAccountInput`.

### The Bug

`SaveAccountInput` expects:
```go
type SaveAccountInput struct {
    AccountIdentifier *types.AccountIdentifier `json:"account_identifier"`
    KeyPair           *keys.KeyPair            `json:"keypair"`
}
```

But the test was providing only the public key:
```go
Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
```

This caused silent JSON unmarshalling failures where the KeyPair field was populated with empty values instead of the actual key data, as described in #451.

### The Fix

Changed `{{key.public_key}}` to `{{key}}` to pass the full KeyPair that `GenerateKey` stored in the variable.

### Verification

This is a one-line test fix that corrects the input data to match the expected type. The test was previously silently failing - now it will properly validate the SaveAccount functionality.

## Type of Change
- [x] Bug fix (test correction)

## Testing
- The existing test `TestJob_ComplicatedTransfer` will now properly validate SaveAccount behavior instead of silently failing during JSON unmarshalling.