### PR TITLE
fix: prevent superfluous response.WriteHeader call in EncodeJSONResponse

### DIFF
--- a/server/routers.go
+++ b/server/routers.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 
@@ -79,10 +80,14 @@ func NewRouter(routers ...Router) http.Handler {
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an
 // optional status code
 func EncodeJSONResponse(i interface{}, status int, w http.ResponseWriter) {
+	// Encode to buffer first to avoid superfluous WriteHeader call on error
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(i); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(status)
-
-	if err := json.NewEncoder(w).Encode(i); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	w.Write(buf.Bytes())
 }


### PR DESCRIPTION
## Description

Fixes #407

The EncodeJSONResponse function was calling w.WriteHeader(status) before encoding the JSON response. If json.NewEncoder(w).Encode(i) failed, it would call http.Error() which internally calls WriteHeader again, causing the "http: superfluous response.WriteHeader call" error when running rosetta-cli check:data with high concurrency.

## Changes

- Encode JSON to a buffer first
- Only write the header if encoding succeeds  
- Use http.Error() only on encoding failure (before any header is written)

This follows the Go HTTP best practice of validating content before writing headers to avoid the superfluous WriteHeader error described in [Go Forum](https://forum.golangbridge.org/t/http-superfluous-response-writeheader-call/24326/3).

## Testing

The fix ensures that:
1. On successful JSON encoding: Content-Type header is set, status is written, and JSON body is written
2. On encoding failure: http.Error() handles the response with proper error message and 500 status

No duplicate WriteHeader calls can occur with this fix.