### PR TITLE
fix(constructor): use KeyPair instead of PublicKey in test

### DIFF
--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1011,7 +1011,7 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 			},
 			{
 				Type:  job.SaveAccount,
-				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 			},
 			{
 				Type:  job.PrintMessage,


### PR DESCRIPTION
## Description

The test `TestJob_ComplicatedTransfer` was passing `{{key.public_key}}` (a `PublicKey`) to the `keypair` field, which expects a `KeyPair`. This caused the `KeyPair` to silently unmarshal with empty `private_key` and nil `public_key`, because the JSON fields didn't match the expected struct.

## Changes

- Changed `{{key.public_key}}` to `{{key}}` in the `SaveAccount` action input, since ``key`` (from the `GenerateKey` action) is already a `KeyPair`.

## Bug Details

After `populate_input`, the action input became:
```json
{"account_identifier": {"address":"test"}, "keypair": {"hex_bytes":"...", "curve_type":"secp256k1"}}
```

But `KeyPair` expects:
```json
{"public_key": {"hex_bytes":"...", "curve_type":"..."}, "private_key": "..."}
```

So unmarshalling silently produced an empty `KeyPair` with no error.

Fixes #451