### PR TITLE
fix: use {{key}} instead of {{key.public_key}} in SaveAccount test inputs

### DIFF
--- a/constructor/coordinator/coordinator_test.go
+++ b/constructor/coordinator/coordinator_test.go
@@ -145,7 +145,7 @@ func TestProcess(t *testing.T) {
 						},
 						{
 							Type:  job.SaveAccount,
-							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 						},
 					},
 				},
@@ -1601,7 +1601,7 @@ func TestReturnFunds_NoBalance(t *testing.T) {
 						},
 						{
 							Type:  job.SaveAccount,
-							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 						},
 					},
 				},
@@ -1831,7 +1831,7 @@ func TestReturnFunds_NoWorkflow(t *testing.T) {
 						},
 						{
 							Type:  job.SaveAccount,
-							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 						},
 					},
 				},
@@ -1938,7 +1938,7 @@ func TestReturnFunds(t *testing.T) {
 						},
 						{
 							Type:  job.SaveAccount,
-							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+							Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 						},
 					},
 				},

--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1011,7 +1011,7 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 			},
 			{
 				Type:  job.SaveAccount,
-				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 			},
 			{
 				Type:  job.PrintMessage,


### PR DESCRIPTION
Fixes #451

## Problem
The `SaveAccount` test inputs in `coordinator_test.go` and `worker_test.go` were incorrectly referencing `{{key.public_key}}` for the `keypair` field. However, `SaveAccountInput.KeyPair` is of type `*keys.KeyPair`, not `*types.PublicKey`.

## Fix
Changed `{{key.public_key}}` to `{{key}}` in all affected test inputs to pass the full keypair object, consistent with how `dsl_test.go` already handles this correctly.