### PR TITLE
fix(server): avoid superfluous response.WriteHeader call in EncodeJSONResponse

### DIFF
--- a/server/routers.go
+++ b/server/routers.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 
@@ -80,9 +81,13 @@ func NewRouter(routers ...Router) http.Handler {
 // optional status code
 func EncodeJSONResponse(i interface{}, status int, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(status)
 
-	if err := json.NewEncoder(w).Encode(i); err != nil {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(i); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
+
+	w.WriteHeader(status)
+	w.Write(buf.Bytes())
 }

--- a/server/routers_test.go
+++ b/server/routers_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type badJSON struct{}
+
+func (badJSON) MarshalJSON() ([]byte, error) {
+	return nil, assert.AnError
+}
+
+func TestEncodeJSONResponse_Success(t *testing.T) {
+	rec := httptest.NewRecorder()
+	EncodeJSONResponse(map[string]string{"hello": "world"}, http.StatusOK, rec)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json; charset=UTF-8", rec.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{"hello":"world"}`, rec.Body.String())
+}
+
+func TestEncodeJSONResponse_CustomStatus(t *testing.T) {
+	rec := httptest.NewRecorder()
+	EncodeJSONResponse(map[string]string{"hello": "world"}, http.StatusCreated, rec)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.JSONEq(t, `{"hello":"world"}`, rec.Body.String())
+}
+
+func TestEncodeJSONResponse_EncodeError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	EncodeJSONResponse(badJSON{}, http.StatusOK, rec)
+
+	// When encoding fails we should return 500, not the caller-provided status,
+	// and we must not trigger a superfluous WriteHeader call.
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), assert.AnError.Error())
+}


### PR DESCRIPTION
Fixes #407

EncodeJSONResponse was calling w.WriteHeader(status) before json.NewEncoder(w).Encode(i). If encoding failed after partially writing to the response, http.Error would attempt a second WriteHeader, producing the "http: superfluous response.WriteHeader call" log message seen in high-concurrency environments.

The fix encodes to a bytes.Buffer first, writes the header only on success, and returns a clean 500 when encoding fails.

Changes:
- Encode JSON to an intermediate buffer before writing headers
- Add unit tests for success, custom status, and encode-error cases
