### PR TITLE
fix: use correct keypair variable in TestJob_ComplicatedTransfer

### DIFF
--- a/constructor/worker/worker_test.go
+++ b/constructor/worker/worker_test.go
@@ -1011,7 +1011,7 @@ func TestJob_ComplicatedTransfer(t *testing.T) {
 			},
 			{
 				Type:  job.SaveAccount,
-				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key.public_key}}}`,
+				Input: `{"account_identifier": {{account.account_identifier}}, "keypair": {{key}}}`,
 			},
 			{
 				Type:  job.PrintMessage,


### PR DESCRIPTION
Fixes #451

The `SaveAccount` action in `TestJob_ComplicatedTransfer` was incorrectly passing `{{key.public_key}}` to the `keypair` field. Since `keypair` expects a `KeyPair` but `key.public_key` is a `PublicKey`, this caused silent unmarshalling failure.

Change to `{{key}}` since the `GenerateKey` action stores a `KeyPair` at that output path.