### PR TITLE
chore(types): rename SCHNORR_BIP340 to SchnorrBip340 for PascalCase consistency

### DIFF
--- a/client/api_account.go
+++ b/client/api_account.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_block.go
+++ b/client/api_block.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_call.go
+++ b/client/api_call.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_construction.go
+++ b/client/api_construction.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_events.go
+++ b/client/api_events.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_mempool.go
+++ b/client/api_mempool.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_network.go
+++ b/client/api_network.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/api_search.go
+++ b/client/api_search.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/configuration.go
+++ b/client/configuration.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client/response.go
+++ b/client/response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/codegen.sh
+++ b/codegen.sh
@@ -134,6 +134,7 @@ sed "${SED_IFLAG[@]}" 's/ECDSA_RECOVERY/EcdsaRecovery/g' client/* server/*
 sed "${SED_IFLAG[@]}" 's/ECDSA/Ecdsa/g' client/* server/*
 sed "${SED_IFLAG[@]}" 's/ED25519/Ed25519/g' client/* server/*
 sed "${SED_IFLAG[@]}" 's/SCHNORR_1/Schnorr1/g' client/* server/*
+sed "${SED_IFLAG[@]}" 's/SCHNORR_BIP340/SchnorrBip340/g' client/* server/*
 sed "${SED_IFLAG[@]}" 's/SCHNORR_POSEIDON/SchnorrPoseidon/g' client/* server/*
 sed "${SED_IFLAG[@]}" 's/PALLAS/Pallas/g' client/* server/*
 sed "${SED_IFLAG[@]}" 's/CREATED/CoinCreated/g' client/* server/*

--- a/server/api.go
+++ b/server/api.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_account.go
+++ b/server/api_account.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_block.go
+++ b/server/api_block.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_call.go
+++ b/server/api_call.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_construction.go
+++ b/server/api_construction.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_events.go
+++ b/server/api_events.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_mempool.go
+++ b/server/api_mempool.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_network.go
+++ b/server/api_network.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/api_search.go
+++ b/server/api_search.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/logger.go
+++ b/server/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/server/routers.go
+++ b/server/routers.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_balance_request.go
+++ b/types/account_balance_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_balance_response.go
+++ b/types/account_balance_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_balance_with_sub_account.go
+++ b/types/account_balance_with_sub_account.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_coins_request.go
+++ b/types/account_coins_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_coins_response.go
+++ b/types/account_coins_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/account_identifier.go
+++ b/types/account_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/all_account_balances_request.go
+++ b/types/all_account_balances_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/all_account_balances_response.go
+++ b/types/all_account_balances_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/allow.go
+++ b/types/allow.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/amount.go
+++ b/types/amount.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/balance_exemption.go
+++ b/types/balance_exemption.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block.go
+++ b/types/block.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_event.go
+++ b/types/block_event.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_event_type.go
+++ b/types/block_event_type.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_identifier.go
+++ b/types/block_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_request.go
+++ b/types/block_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_response.go
+++ b/types/block_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_transaction.go
+++ b/types/block_transaction.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_transaction_request.go
+++ b/types/block_transaction_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/block_transaction_response.go
+++ b/types/block_transaction_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/call_request.go
+++ b/types/call_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/call_response.go
+++ b/types/call_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/case.go
+++ b/types/case.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/coin.go
+++ b/types/coin.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/coin_action.go
+++ b/types/coin_action.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/coin_change.go
+++ b/types/coin_change.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/coin_identifier.go
+++ b/types/coin_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_combine_request.go
+++ b/types/construction_combine_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_combine_response.go
+++ b/types/construction_combine_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_derive_request.go
+++ b/types/construction_derive_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_hash_request.go
+++ b/types/construction_hash_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_metadata_request.go
+++ b/types/construction_metadata_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_metadata_response.go
+++ b/types/construction_metadata_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_parse_request.go
+++ b/types/construction_parse_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_payloads_request.go
+++ b/types/construction_payloads_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_payloads_response.go
+++ b/types/construction_payloads_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_preprocess_operations_request.go
+++ b/types/construction_preprocess_operations_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_preprocess_operations_response.go
+++ b/types/construction_preprocess_operations_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_preprocess_request.go
+++ b/types/construction_preprocess_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_preprocess_response.go
+++ b/types/construction_preprocess_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/construction_submit_request.go
+++ b/types/construction_submit_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/currency.go
+++ b/types/currency.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/curve_type.go
+++ b/types/curve_type.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/direction.go
+++ b/types/direction.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/error.go
+++ b/types/error.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/events_blocks_request.go
+++ b/types/events_blocks_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/events_blocks_response.go
+++ b/types/events_blocks_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/exemption_type.go
+++ b/types/exemption_type.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/mempool_response.go
+++ b/types/mempool_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/mempool_transaction_request.go
+++ b/types/mempool_transaction_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/mempool_transaction_response.go
+++ b/types/mempool_transaction_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/metadata_request.go
+++ b/types/metadata_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_identifier.go
+++ b/types/network_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_list_response.go
+++ b/types/network_list_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_options_response.go
+++ b/types/network_options_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_request.go
+++ b/types/network_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/network_status_response.go
+++ b/types/network_status_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/operation.go
+++ b/types/operation.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/operation_identifier.go
+++ b/types/operation_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/operation_status.go
+++ b/types/operation_status.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/operator.go
+++ b/types/operator.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/partial_block_identifier.go
+++ b/types/partial_block_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/peer.go
+++ b/types/peer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/public_key.go
+++ b/types/public_key.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/related_transaction.go
+++ b/types/related_transaction.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/search_transactions_request.go
+++ b/types/search_transactions_request.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/search_transactions_response.go
+++ b/types/search_transactions_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/signature.go
+++ b/types/signature.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/signature_type.go
+++ b/types/signature_type.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/signature_type.go
+++ b/types/signature_type.go
@@ -35,6 +35,6 @@ const (
 	EcdsaRecovery   SignatureType = "ecdsa_recovery"
 	Ed25519         SignatureType = "ed25519"
 	Schnorr1        SignatureType = "schnorr_1"
-	SCHNORR_BIP340  SignatureType = "schnorr_bip340"
+	SchnorrBip340   SignatureType = "schnorr_bip340"
 	SchnorrPoseidon SignatureType = "schnorr_poseidon"
 )

--- a/types/sub_account_identifier.go
+++ b/types/sub_account_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/sub_network_identifier.go
+++ b/types/sub_network_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/sync_status.go
+++ b/types/sync_status.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/transaction_identifier.go
+++ b/types/transaction_identifier.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/transaction_identifier_response.go
+++ b/types/transaction_identifier_response.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/types.go
+++ b/types/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/types/version.go
+++ b/types/version.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Coinbase, Inc.
+// Copyright 2026 Coinbase, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes # .

### Motivation

All `SignatureType` constants in `types/signature_type.go` follow PascalCase
(`Ecdsa`, `EcdsaRecovery`, `Ed25519`, `Schnorr1`, `SchnorrPoseidon`) but
`SCHNORR_BIP340` was left in SCREAMING_SNAKE_CASE because `codegen.sh` had no
`sed` rule to rename it after generation. This PR adds that rule so the
generated output is consistent with every other constant in the file.

### Note on file count

101 of the 103 changed files are mechanical copyright-year updates (`2025 → 2026`) across `types/`, `client/`, and `server/`. These are **auto-generated** files — `make check-gen` runs `addlicense` inside Docker and stamps all regenerated files with the current year, so any PR opened in 2026 includes this diff. This is a pre-existing repo-wide issue that will be addressed separately.

**Files worth reviewing:**
- `codegen.sh` (+1 line)
- `types/signature_type.go` (+1 line, -1 line)

### Solution

**`codegen.sh`** — Add one `sed` line in the SignatureType rename block,
alongside the existing `SCHNORR_1` and `SCHNORR_POSEIDON` rules:

```bash
sed "${SED_IFLAG[@]}" 's/SCHNORR_BIP340/SchnorrBip340/g' client/* server/*
```

This runs on `client/*` before model files are moved to `types/`, so
`types/signature_type.go` automatically gets `SchnorrBip340` after the move.

**`types/signature_type.go`** — Rename the constant to match what `codegen.sh`
now produces. The wire value `"schnorr_bip340"` is unchanged — this is a Go
identifier rename only and has no protocol impact.

**At merge time**, a `types/v1.7.2` tag will be created to publish the updated
types module. Callers pinned to `v1.7.1` will need to:
1. Bump to `types v1.7.2` in their `go.mod`
2. Replace `types.SCHNORR_BIP340` → `types.SchnorrBip340`

### Open questions

None.